### PR TITLE
fix for errors which do not have an associated jobName

### DIFF
--- a/app/org/tdl/vireo/error/impl/ErrorLogImpl.java
+++ b/app/org/tdl/vireo/error/impl/ErrorLogImpl.java
@@ -90,9 +90,13 @@ public class ErrorLogImpl implements ErrorLog {
 	@Override
 	public ErrorReport logError(Throwable exception, JobMetadata job) {
 
+		String jobName = "unknown";
+		if(null != job) {
+			jobName = job.getName();
+		}
 		String message = String.format(
 				"Background job: %s", 
-				job.getName());
+				jobName);
 
 		return logError(exception, message);
 	}


### PR DESCRIPTION
In some cases, an accurate error message may be hidden by a subsequent one thrown by the ErrorLog implementation itself. In the cases I have noted, this stems from the fact that all errors attempt to make use of the jobName of the job at hand, despite the fact that the job itself may be null. SWORD deposit errors are such a case. In order to remedy, I have set a default jobName which will be replaced by the actual one only if the job is not null. In my experience, this sufficiently addresses the problem with a minimum impact to the surrounding code.

(BTW: resubmitted. now 900% cleaner)
