### PR TITLE
correct thesis schema

### DIFF
--- a/conf/formats/dspace_simple.xml
+++ b/conf/formats/dspace_simple.xml
@@ -210,7 +210,7 @@ ${ attachment.getName() }	bundle:LICENSE
 #{/elseif}
 #{elseif "metadata_thesis.xml".equals(template) }
 <?xml version="1.0" encoding="utf-8"?>
-<dublin_core schema="degree">
+<dublin_core schema="thesis">
     <!-- thesis.degree.name == Degree -->
     #{if sub.getDegree() != null } 
     <dcvalue element="degree" qualifier="name">


### PR DESCRIPTION
For correct registration in DSpace, the thesis schema needs to be correctly identified. Otherwise, DSpace tries to add the metadata as dc.degree.name, etc. This change will fix the problem and make the DSpace simple format consistent with the DSpace METS format.
