### PR TITLE
Update vireo.xml to fix mis-matched person/submitter tags

### DIFF
--- a/conf/formats/vireo.xml
+++ b/conf/formats/vireo.xml
@@ -293,7 +293,7 @@
 		        #{if attachment.getPerson().getRole() != null} 
 		        <role>${ attachment.getPerson().getRole().name()?.escapeXml()?.raw() }</role>
 		        #{/if} 
-		    </submitter>
+		    </person>
 		    #{/if} 
         </attachment>
         #{/list} 


### PR DESCRIPTION
Fixed mis-matched person/submitter tag in attachment block.

Should fix #116 
