### PR TITLE
Added None to the activeDocument sidebar if there is no primary document

### DIFF
--- a/src/main/webapp/WEB-INF/app/views/sideboxes/activeDocument.html
+++ b/src/main/webapp/WEB-INF/app/views/sideboxes/activeDocument.html
@@ -7,6 +7,9 @@
 		<div><span>{{box.getPrimaryDocumentFileName()}}</span></div>
 		<div><a href ng-click="box.downloadPrimaryDocument()">Download</a></div>
 	</div>
+	<div class="col-sm-12 primary-file-title" ng-if="!box.hasPrimaryDocument()">
+		<div><span>None</span></div>
+	</div>
 	<div class="clearfix"></div>
 	
 	<sideboxsub>FILE OPTIONS</sideboxsub>


### PR DESCRIPTION
The activeDocument sidebar now displays "None" if there is not a primary document.