### PR TITLE
Added route change listener to remove modal bg

### DIFF
--- a/src/main/webapp/WEB-INF/app/config/runTime.js
+++ b/src/main/webapp/WEB-INF/app/config/runTime.js
@@ -1,8 +1,14 @@
-vireo.run(function($route, $rootScope, $location) {
+vireo.run(function($route, $rootScope, $location, ModalService, $timeout) {
 
 	angular.element("body").fadeIn(1000);
 
-	// Add runtime tasks here
+  // Add runtime tasks here
+  
+  $rootScope.$on("$routeChangeStart", function (evt, next, current) {
+      ModalService.closeModal();
+      //this should be incorporated with the clodeModal method in weaver-ui-core
+      angular.element('.modal-backdrop').remove();
+  });
 
 	// Allow the passing of an additional parameter which 
 	// Will allow the path to be changed with out route reload

--- a/src/main/webapp/WEB-INF/app/config/runTime.js
+++ b/src/main/webapp/WEB-INF/app/config/runTime.js
@@ -1,4 +1,4 @@
-vireo.run(function($route, $rootScope, $location, ModalService, $timeout) {
+vireo.run(function($route, $rootScope, $location, ModalService) {
 
 	angular.element("body").fadeIn(1000);
 


### PR DESCRIPTION
This adds a listener to the route change success, in the runtime config, that closes the modal and removes the back drop on each route change.