### PR TITLE
"Last event" column does not work in List View

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -5,8 +5,10 @@ import static javax.persistence.FetchType.EAGER;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -438,6 +440,21 @@ public class Submission extends ValidatingBaseEntity {
      */
     public void removeActionLog(ActionLog actionLog) {
         getActionLogs().remove(actionLog);
+    }
+
+    /**
+     *
+     */
+    @JsonView(ApiView.Partial.class)
+    public String getLastEvent() {
+        Optional<ActionLog> actionLog = getActionLogs().stream().max(Comparator.comparing(al -> al.getActionDate()));
+        String lastEvent = null;
+
+        if (actionLog.isPresent()) {
+            lastEvent = actionLog.get().getEntry();
+        }
+
+        return lastEvent;
     }
 
     /**

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -628,6 +628,22 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     break;
 
+                case "lastEvent":
+                    // @formatter:off
+
+                    sqlJoinsBuilder.append("\nLEFT JOIN")
+                                   .append("\n   (SELECT al.id, al.action_date, al.entry, al.action_logs_id")
+                                   .append("\n   FROM action_log al")
+                                   .append("\n   WHERE (al.action_logs_id = id)")
+                                   .append("\n   ORDER BY al.action_date DESC")
+                                   .append("\n   LIMIT 1) als")
+                                   .append("\n   ON action_logs_id = s.submission_status_id");
+                    // @formatter:on
+
+                    // @todo finish sqlWheresBuilder.
+
+                    break;
+
                 default:
                     logger.info("No value path given for submissionListColumn " + submissionListColumn.getTitle());
                 }

--- a/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
+++ b/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
@@ -127,7 +127,7 @@
   {
     "title": "Last event",
     "sort": "NONE",
-    "valuePath": [],
+    "valuePath": ["lastEvent"],
     "status": null,
     "inputType": {
       "name": "INPUT_TEXT"


### PR DESCRIPTION
Resolves #918.

Added a synthetic getter with a partial view annotation to retrieve only the last action event.

SubmissionRepoImpl craftDynamicSubmissionQuery() is not fully implemented.
There may be another issue in craftDynamicSubmissionQuery() which involves this implementation.
Finish implementation after review of the potential issue in craftDynamicSubmissionQuery().