### PR TITLE
Controlled Vocabulary editing always resets table

### DIFF
--- a/src/main/webapp/app/controllers/settings/controlledVocabularyRepoController.js
+++ b/src/main/webapp/app/controllers/settings/controlledVocabularyRepoController.js
@@ -385,7 +385,7 @@ vireo.controller("ControlledVocabularyRepoController", function ($controller, $q
             $scope.modalData = {
                 language: $scope.languages[0]
             };
-        }
+        };
 
         $scope.resetControlledVocabulary = function (closeModal) {
             $scope.refreshControlledVocabulary();


### PR DESCRIPTION
Resolves #913.

There are 3 major observations leading to the referenced bug:
1) The $scope.resetControlledVocabulary always deletes and recreates the Controlled Vocabulary (and is called multiple times per request).
2) reloadTable() always deletes and creates a new table, losing all sorting and pagination.
3) Closing a model always calls $scope.resetControlledVocabulary().

In the case of observation 1:
  - Provide and instead use $scope.refreshControlledVocabulary() that conditionally preserves the existing Controlled Vocabulary.
  - Maintain $scope.resetControlledVocabulary() to prevent breakage of external calls (maintain compatibility).
  - Prevent redundant calls by never calling reset when the ApiResponseAction is set to CHANGE.
    - This is notable because each ApiResponseAction seems to be immediately followed by a CHANGE ApiResponseAction.
  - The selected Controlled Vocabulary must be loaded from the regenerated Vocabulary list to preserve state changes.
    - This allows for silently updating state information for the currently selected Controlled Vocabulary, such as the position.

In the case of observation 2:
  - Add a preseveState argument to reloadTable() to preserve the current sorting and pagination.
  - Alter $scope.setSelectedCv to pass the preserveState variable while maintaining external call compatibility.

In the case of observation 3:
  - The $scope.resetControlledVocabulary() is re-written to call $scope.refreshControlledVocabulary().