### PR TITLE
June sprint #897 assigned to unassigned

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -204,10 +204,20 @@ public class SubmissionListController {
     public ApiResponse removeFilterCriterion(@WeaverUser User user, @PathVariable String namedSearchFilterName, @RequestBody FilterCriterion filterCriterion) {
         NamedSearchFilterGroup activeFilter = user.getActiveFilter();
 
+        String filterValue = null;
         for (NamedSearchFilter namedSearchFilter : activeFilter.getNamedSearchFilters()) {
             if (namedSearchFilter.getName().equals(namedSearchFilterName)) {
                 for (FilterCriterion fc : namedSearchFilter.getFilters()) {
-                    if (fc.getValue().equals(filterCriterion.getValue()) && fc.getGloss().equals(filterCriterion.getGloss())) {
+                    filterValue = fc.getValue();
+                    if (filterValue == null) {
+                        if (filterCriterion.getValue() == null && fc.getGloss().equals(filterCriterion.getGloss())) {
+                            namedSearchFilter.removeFilter(fc);
+                            if (namedSearchFilter.getFilters().size() == 0) {
+                                activeFilter.removeNamedSearchFilter(namedSearchFilter);
+                            }
+                            break;
+                        }
+                    } else if (filterValue.equals(filterCriterion.getValue()) && fc.getGloss().equals(filterCriterion.getGloss())) {
                         namedSearchFilter.removeFilter(fc);
                         if (namedSearchFilter.getFilters().size() == 0) {
                             activeFilter.removeNamedSearchFilter(namedSearchFilter);

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -585,7 +585,10 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
-                        if (submissionListColumn.getExactMatch()) {
+                        if (filterString == null) {
+                            sqlWheresBuilder.append(" a").append(".email IS NULL").append(" OR");
+                        }
+                        else if (submissionListColumn.getExactMatch()) {
                             sqlWheresBuilder.append(" a").append(".email = '").append(filterString).append("' OR");
                         } else {
                             sqlWheresBuilder.append(" LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%' OR");

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -575,7 +575,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         };
 
         SidebarService.addBoxes([{
-                "title": "Now filtering By:",
+                "title": "Now Filtering By:",
                 "viewUrl": "views/sideboxes/nowfiltering.html",
                 "activeFilters": $scope.activeFilters,
                 "removeFilterValue": $scope.removeFilterValue


### PR DESCRIPTION
Resolves #897.
Resolves #879.

The issue is simply that a `WHERE IS NULL` check should be performed when unassigned.
The _furtherFilterByAssigneTo.html_ file is already passing `NULL` (until the solution provided by @cstarcher  here:  #880).

My approach is to utilize NULL as passed, which resolves both said issues.
My approach in conflict with #880.

An alternative approach to what I present here could be to depend on #880 as written, and then handle the case of where _"unassigned"_ is passed then perform a `WHERE IS NULL` check. The likelihood of somebody's name being _"unassigned"_ is close to 0, but I tend to prefer avoiding such situations altogether (however rare).

Feedback and discussion is desired.