### PR TITLE
Long filenames in uploaded file overflow out of sidebox

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -491,6 +491,8 @@ sidebox ul.sidebox-list {
 
 sidebox ul.sidebox-list li {
   padding: 3px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 sidebox ul.sidebox-list input {


### PR DESCRIPTION
Resolves #958.

Using "overflow-wrap" due to semantic meaning in how it is intended to break.
Using "word-wrap" for legacy/compatibility reasons.

see: https://www.w3.org/TR/css-text-3/#word-break-property
see: https://www.w3.org/TR/css-text-3/#propdef-overflow-wrap