### PR TITLE
Handle case where filterValue may be null when .toString() is used

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -190,7 +190,11 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
 
 
         var addFilter = function (column, gloss) {
-            $scope.activeFilters.addFilter(column.title, $scope.furtherFilterBy[column.title.split(" ").join("")], gloss, column.exactMatch).then(function () {
+            var filterValue = $scope.furtherFilterBy[column.title.split(" ").join("")];
+            if (filterValue !== null) {
+                filterValue = filterValue.toString();
+            }
+            $scope.activeFilters.addFilter(column.title, filterValue, gloss, column.exactMatch).then(function () {
                 $scope.furtherFilterBy[column.title.split(" ").join("")] = "";
                 query();
             });


### PR DESCRIPTION
This fixes the problem on the javascript/client-side because it is the least likely to introduce regressions.

Further resolves #897 and #879.