### PR TITLE
Improve tab selection display of workflow step navigation buttons

### DIFF
--- a/src/main/webapp/app/resources/styles/sass/views/submission/_student-submission.scss
+++ b/src/main/webapp/app/resources/styles/sass/views/submission/_student-submission.scss
@@ -43,8 +43,29 @@
   margin-bottom: 25px;
 }
 
-.submission-workflow-step-navigation a {
+.nav-pills > .submission-workflow-step-navigation > a {
+  display: inline-block;
   width: 95%;
+  padding: 0px;
+  margin: 0px 0px 5px 0px;
+  color: inherit;
+  background-color: inherit;
+}
+
+.nav-pills > .submission-workflow-step-navigation.active > a,
+.nav-pills > .submission-workflow-step-navigation.active > a:focus,
+.nav-pills > .submission-workflow-step-navigation.active > a:hover {
+  color: inherit;
+  background-color: inherit;
+}
+
+.submission-workflow-step-navigation a .invisible-button {
+  display: inline-block;
+  vertical-align: top;
+  position: relative;
+  padding: 10px 15px;
+  border-radius: 4px;
+  width: 100%;
   color: white;
   background: $button_main_color_off;
   background: -moz-linear-gradient linear-gradient(to right, $button_main_color_off, $button_highlight_color_off);
@@ -53,14 +74,19 @@
   background: linear-gradient(to right, $button_main_color_off, $button_highlight_color_off);
 }
 
-.submission-workflow-step-navigation a:hover,
-.submission-workflow-step-navigation.active a {
+.submission-workflow-step-navigation a:hover .invisible-button,
+.submission-workflow-step-navigation a .invisible-button:focus,
+.submission-workflow-step-navigation.active a .invisible-button {
   cursor: pointer;
   background: rgb(31, 58, 71);
   background: -moz-linear-gradient linear-gradient(to right, $button_main_color_on, $button_highlight_color_on);
   background: -webkit-linear-gradient(to right, $button_main_color_on, $button_highlight_color_on);
   background: -ms-linear-gradient(to right, $button_main_color_on, $button_highlight_color_on);
   background: linear-gradient(to right, $button_main_color_on, $button_highlight_color_on);
+}
+
+.submission-workflow-step-navigation a .invisible-button:focus {
+  box-shadow: 0px 0px 2px #115db9;
 }
 
 .field-value-input:not(:last-of-type) {


### PR DESCRIPTION
Move the styling off the `a` tag and onto the `button` tag.
This allows for responding to the appropriate CSS action selectors.

Add a box-shadow to help bring out the selected button across all browsers.

Further resolves #862.