### PR TITLE
if field not optional validate on blur

### DIFF
--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -1,4 +1,4 @@
-vireo.directive("field", function ($controller, $filter, $q, $timeout, FieldValue, FileUploadService) {
+vireo.directive("field", function ($controller, $filter, $q, $timeout, FileUploadService) {
     return {
         templateUrl: 'views/directives/fieldProfile.html',
         restrict: 'E',
@@ -38,8 +38,9 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, FieldValu
             $scope.save = function (fieldValue) {
                 // give typeahead select time to save the value
                 $timeout(function () {
+                    console.log($scope.profile);
                     // if the fieldProfileForm is undefined we have changed view, save the field value if not already updating
-                    if (($scope.fieldProfileForm === undefined || $scope.fieldProfileForm.$dirty) && !fieldValue.updating) {
+                    if (($scope.fieldProfileForm === undefined || $scope.fieldProfileForm.$dirty || !$scope.profile.optional) && !fieldValue.updating) {
                         fieldValue.updating = true;
                         return save(fieldValue);
                     }

--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -38,7 +38,6 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, FileUploa
             $scope.save = function (fieldValue) {
                 // give typeahead select time to save the value
                 $timeout(function () {
-                    console.log($scope.profile);
                     // if the fieldProfileForm is undefined we have changed view, save the field value if not already updating
                     if (($scope.fieldProfileForm === undefined || $scope.fieldProfileForm.$dirty || !$scope.profile.optional) && !fieldValue.updating) {
                         fieldValue.updating = true;


### PR DESCRIPTION
Validation occurs on server side during the submission. If a field is modified it attempts to save onblur. Therefor, most cases the validation error would display. In the case of skipping a required was the only case not displaying a validation message when desired. Simple onblur will now attempt to save a required field whether it has been changed or not.

closes #853 