### PR TITLE
Provide error message and reset upload progress on file upload failures #855

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -48,6 +48,8 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
     $scope.addCommentModal = {};
 
+    $scope.errorMessage = "";
+
     SubmissionRepo.findSubmissionById($routeParams.id).then(function(submission) {
 
         $scope.submission = submission;
@@ -196,11 +198,22 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         resetFileData();
 
         $scope.queueUpload = function (files) {
+            $scope.errorMessage = "";
             $scope.addFileData.files = files;
         };
 
         $scope.removeFiles = function () {
+            $scope.errorMessage = "";
             delete $scope.addFileData.files;
+        };
+
+        var uploadFailed = function(fieldValue, reason) {
+            $scope.errorMessage = "Upload Failed" + (reason ? ": " + reason : "") + ".";
+            $scope.addFileData.uploading = false;
+            fieldValue.uploading = false;
+            fieldValue.fileInfo.uploaded = false;
+            fieldValue.setIsValid(false);
+            fieldValue.refresh();
         };
 
         $scope.submitAddFile = function () {
@@ -232,39 +245,64 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             fieldValue.file = $scope.addFileData.files[0];
 
             FileUploadService.uploadFile($scope.submission, fieldValue).then(function (response) {
+                if (response.data.meta.status === 'SUCCESS') {
+                    var fieldProfile = $scope.submission.getFieldProfileByPredicate(fieldValue.fieldPredicate);
 
-                var fieldProfile = $scope.submission.getFieldProfileByPredicate(fieldValue.fieldPredicate);
+                    if ($scope.addFileData.addFileSelection === 'replace' && $scope.hasPrimaryDocument()) {
+                        FileUploadService.archiveFile($scope.submission, $scope.submission.primaryDocumentFieldValue);
+                    }
 
-                if ($scope.addFileData.addFileSelection === 'replace' && $scope.hasPrimaryDocument()) {
-                    FileUploadService.archiveFile($scope.submission, $scope.submission.primaryDocumentFieldValue);
+                    fieldValue.value = response.data.meta.message;
+
+                    $scope.submission.saveFieldValue(fieldValue, fieldProfile).then(function (response) {
+                        var apiRes = angular.fromJson(response.body);
+                        if (apiRes.meta.status === "INVALID") {
+                            if (apiRes.meta.message !== undefined) {
+                                uploadFailed(fieldValue, apiRes.meta.message);
+                            }
+                            else {
+                                uploadFailed(fieldValue, false);
+                            }
+                        } else {
+                            if ($scope.addFileData.sendEmailToRecipient) {
+                                $scope.submission.sendEmail({
+                                    subject: $scope.addFileData.subject,
+                                    message: $scope.addFileData.message,
+                                    recipientEmail: $scope.recipientEmails.join(';'),
+                                    ccRecipientEmail: $scope.ccRecipientEmails.join(';'),
+                                    sendEmailToRecipient: $scope.addFileData.sendEmailToRecipient,
+                                    sendEmailToCCRecipient: $scope.addFileData.sendEmailToCCRecipient
+                                }).then(function () {
+                                    $scope.resetAddFile();
+                                });
+                            } else {
+                                $scope.resetAddFile();
+                            }
+                        }
+                    });
+                }
+                else {
+                    if (response.payload !== undefined && typeof response.payload  == "object" && response.payload.meta.message !== undefined) {
+                        uploadFailed(fieldValue, response.payload.meta.message);
+                    }
+                    else {
+                        uploadFailed(fieldValue, false);
+                    }
                 }
 
-                fieldValue.value = response.data.meta.message;
-
-                $scope.submission.saveFieldValue(fieldValue, fieldProfile).then(function (response) {
-                    var apiRes = angular.fromJson(response.body);
-                    if (apiRes.meta.status === "INVALID") {
-                        fieldValue.refresh();
-                    } else {
-                        if ($scope.addFileData.sendEmailToRecipient) {
-                            $scope.submission.sendEmail({
-                                subject: $scope.addFileData.subject,
-                                message: $scope.addFileData.message,
-                                recipientEmail: $scope.recipientEmails.join(';'),
-                                ccRecipientEmail: $scope.ccRecipientEmails.join(';'),
-                                sendEmailToRecipient: $scope.addFileData.sendEmailToRecipient,
-                                sendEmailToCCRecipient: $scope.addFileData.sendEmailToCCRecipient
-                            }).then(function () {
-                                $scope.resetAddFile();
-                            });
-                        } else {
-                            $scope.resetAddFile();
-                        }
-                    }
-                });
-
             }, function (response) {
-                console.log('Error status: ' + response.status);
+                var reason = false;
+                var status = response.meta.status;
+                if (response.payload !== undefined && typeof response.payload  == "object" && response.payload.meta.message !== undefined) {
+                    reason = response.payload.meta.message;
+                    status = response.payload.meta.status;
+                }
+                else if (response.status !== undefined) {
+                    status = response.status;
+                }
+
+                console.log('Error status: ' + status);
+                uploadFailed(fieldValue, reason);
             }, function (progress) {
                 $scope.addFileData.progress = progress;
             });
@@ -276,6 +314,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         };
 
         $scope.resetAddFile = function () {
+            $scope.errorMessage = "";
             resetFileData();
             $scope.closeModal();
         };
@@ -285,52 +324,52 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             if ($scope.addFileData.addFileSelection == 'replace') {
                 if ($scope.addFileData.sendEmailToRecipient) {
                     if ($scope.addFileData.sendEmailToCCRecipient) {
-                        disable = $scope.addFileData.files === undefined || 
-                                  $scope.addFileData.uploading || 
-                                  $scope.recipientEmails.length === 0 || 
-                                  $scope.ccRecipientEmails.length === 0 || 
-                                  $scope.addFileData.subject === undefined || 
-                                  $scope.addFileData.subject === "" || 
+                        disable = $scope.addFileData.files === undefined ||
+                                  $scope.addFileData.uploading ||
+                                  $scope.recipientEmails.length === 0 ||
+                                  $scope.ccRecipientEmails.length === 0 ||
+                                  $scope.addFileData.subject === undefined ||
+                                  $scope.addFileData.subject === "" ||
                                   $scope.addFileData.message === undefined ||
                                   $scope.addFileData.message === "";
                     } else {
-                        disable = $scope.addFileData.files === undefined || 
-                                  $scope.addFileData.uploading || 
-                                  $scope.recipientEmails.length === 0 || 
-                                  $scope.addFileData.subject === undefined || 
-                                  $scope.addFileData.subject === "" || 
+                        disable = $scope.addFileData.files === undefined ||
+                                  $scope.addFileData.uploading ||
+                                  $scope.recipientEmails.length === 0 ||
+                                  $scope.addFileData.subject === undefined ||
+                                  $scope.addFileData.subject === "" ||
                                   $scope.addFileData.message === undefined ||
                                   $scope.addFileData.message === "";
                     }
                 } else {
-                    disable = $scope.addFileData.files === undefined || 
+                    disable = $scope.addFileData.files === undefined ||
                               $scope.addFileData.uploading;
                 }
             } else {
                 if ($scope.addFileData.sendEmailToRecipient) {
                     if ($scope.addFileData.sendEmailToCCRecipient) {
-                        disable = $scope.addFileData.files === undefined || 
-                                  $scope.addFileData.fieldPredicate == undefined || 
-                                  $scope.addFileData.uploading || 
-                                  $scope.recipientEmails.length === 0 || 
-                                  $scope.ccRecipientEmails.length === 0 || 
-                                  $scope.addFileData.subject === undefined || 
-                                  $scope.addFileData.subject === "" || 
+                        disable = $scope.addFileData.files === undefined ||
+                                  $scope.addFileData.fieldPredicate == undefined ||
+                                  $scope.addFileData.uploading ||
+                                  $scope.recipientEmails.length === 0 ||
+                                  $scope.ccRecipientEmails.length === 0 ||
+                                  $scope.addFileData.subject === undefined ||
+                                  $scope.addFileData.subject === "" ||
                                   $scope.addFileData.message === undefined ||
                                   $scope.addFileData.message === "";
                     } else {
-                        disable = $scope.addFileData.files === undefined || 
-                                  $scope.addFileData.fieldPredicate == undefined || 
-                                  $scope.addFileData.uploading || 
-                                  $scope.recipientEmails.length === 0 || 
-                                  $scope.addFileData.subject === undefined || 
-                                  $scope.addFileData.subject === "" || 
+                        disable = $scope.addFileData.files === undefined ||
+                                  $scope.addFileData.fieldPredicate == undefined ||
+                                  $scope.addFileData.uploading ||
+                                  $scope.recipientEmails.length === 0 ||
+                                  $scope.addFileData.subject === undefined ||
+                                  $scope.addFileData.subject === "" ||
                                   $scope.addFileData.message === undefined ||
                                   $scope.addFileData.message === "";
                     }
                 } else {
-                    disable = $scope.addFileData.files === undefined || 
-                              $scope.addFileData.fieldPredicate == undefined || 
+                    disable = $scope.addFileData.files === undefined ||
+                              $scope.addFileData.fieldPredicate == undefined ||
                               $scope.addFileData.uploading;
                 }
             }
@@ -362,6 +401,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
                 $scope.getFile($scope.submission.primaryDocumentFieldValue);
             },
             "uploadNewFile": function () {
+                $scope.errorMessage = "";
                 $scope.openModal('#addFileModal');
             },
             "gotoAllFiles": function () {

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -211,8 +211,10 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             $scope.errorMessage = "Upload Failed" + (reason ? ": " + reason : "") + ".";
             $scope.addFileData.uploading = false;
             fieldValue.uploading = false;
-            fieldValue.fileInfo.uploaded = false;
             fieldValue.setIsValid(false);
+            if (fieldValue.fileInfo !== undefined && fieldValue.fileInfo.uploaded === true) {
+                delete fieldValue.fileInfo.uploaded;
+            }
             fieldValue.refresh();
         };
 

--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -175,31 +175,62 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, FieldValu
                 });
             };
 
+            var uploadFailed = function(fieldValue, reason) {
+                fieldValue.uploading = false;
+                fieldValue.fileInfo.uploaded = false;
+                fieldValue.setIsValid(false);
+                $scope.errorMessage = "Upload Failed" + (reason ? ": " + reason : "") + ".";
+                $scope.cancelUpload();
+            };
+
             var upload = function (fieldValue) {
                 return $q(function (resolve) {
                     FileUploadService.uploadFile($scope.submission, fieldValue).then(function (response) {
-                        if ($scope.hasFile(fieldValue)) {
-                            $scope.submission.removeFile(fieldValue);
-                        }
-                        fieldValue.value = response.data.meta.message;
-                        fieldValue.fileInfo.uploaded = true;
-                        $scope.submission.saveFieldValue(fieldValue, $scope.profile).then(function (response) {
-                            var apiRes = angular.fromJson(response.body);
-                            if(apiRes.meta.status === 'SUCCESS') {
-                                var newFieldValue = apiRes.payload.FieldValue;
-                                if(newFieldValue.fieldPredicate.value === "_doctype_primary") {
-                                    $scope.submission.fetchDocumentTypeFileInfo();
-                                }
-                                fieldValue.uploading = false;
-                                resolve(true);
-                            } else {
-                                resolve(false);
+                        if (response.data.meta.status === 'SUCCESS') {
+                            if ($scope.hasFile(fieldValue)) {
+                                $scope.submission.removeFile(fieldValue);
                             }
-                        });
+                            fieldValue.value = response.data.meta.message;
+                            fieldValue.fileInfo.uploaded = true;
+                            $scope.submission.saveFieldValue(fieldValue, $scope.profile).then(function (response) {
+                                var apiRes = angular.fromJson(response.body);
+                                if (apiRes.meta.status === 'SUCCESS') {
+                                    var newFieldValue = apiRes.payload.FieldValue;
+                                    if(newFieldValue.fieldPredicate.value === "_doctype_primary") {
+                                        $scope.submission.fetchDocumentTypeFileInfo();
+                                    }
+                                    fieldValue.uploading = false;
+                                    resolve(true);
+                                } else {
+                                    if (apiRes.meta.message !== undefined) {
+                                        uploadFailed(fieldValue, apiRes.meta.message);
+                                    }
+                                    resolve(false);
+                                }
+                            });
+                        }
+                        else {
+                            if (response.payload !== undefined && typeof response.payload  == "object" && response.payload.meta.message !== undefined) {
+                                uploadFailed(fieldValue, response.payload.meta.message);
+                            }
+                            else {
+                                uploadFailed(fieldValue, false);
+                            }
+                            resolve(false);
+                        }
                     }, function (response) {
-                        console.log('Error status: ' + response.status);
-                        $scope.errorMessage = response.data.meta.message;
-                        $scope.cancelUpload();
+                        var reason = false;
+                        var status = response.meta.status;
+                        if (response.payload !== undefined && typeof response.payload  == "object" && response.payload.meta.message !== undefined) {
+                            reason = response.payload.meta.message;
+                            status = response.payload.meta.status;
+                        }
+                        else if (response.status !== undefined) {
+                            status = response.status;
+                        }
+
+                        console.log('Error status: ' + status);
+                        uploadFailed(fieldValue, reason);
                     }, function (progress) {
                         $scope.progress = progress;
                         fieldValue.progress = progress;

--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -177,8 +177,10 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, FieldValu
 
             var uploadFailed = function(fieldValue, reason) {
                 fieldValue.uploading = false;
-                fieldValue.fileInfo.uploaded = false;
                 fieldValue.setIsValid(false);
+                if (fieldValue.fileInfo !== undefined && fieldValue.fileInfo.uploaded === true) {
+                    delete fieldValue.fileInfo.uploaded;
+                }
                 $scope.errorMessage = "Upload Failed" + (reason ? ": " + reason : "") + ".";
                 $scope.cancelUpload();
             };

--- a/src/main/webapp/app/views/inputtype/input-file.html
+++ b/src/main/webapp/app/views/inputtype/input-file.html
@@ -18,6 +18,7 @@
         <span ng-if="hasFile(fieldValue)" class="file-upload-icon glyphicon glyphicon-trash text-danger select-toggle" ng-click="openModal('#confirmDeleteFileModal' + getUriHash(fieldValue))"></span>
       </div>
     </div>
+
     <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
     <div class="file-info" ng-if="hasFile(fieldValue) || previewing">
       <p class="file-name">{{fieldValue.fileInfo.name}}</p>
@@ -45,6 +46,7 @@
       <dropzone file-model="files" text="Choose file here or drag and drop to upload" allow-multiple="true" patterns="{{getPattern()}}" drop-method="queueUpload(files)"></dropzone>
     </div>
   </div>
+  <div ng-if="!fieldValue.uploading && errorMessage" class="file-info text-danger">{{errorMessage}}</div>
   <div class="col-md-7 col-sm-12 file-preview-container" ng-if="previewing || hasFiles">
     <table class="table table-condensed table-hover multiple-file-upload-table">
       <thead>

--- a/src/main/webapp/app/views/modals/view/addFileModal.html
+++ b/src/main/webapp/app/views/modals/view/addFileModal.html
@@ -19,6 +19,7 @@
 
         <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="pdf" drop-method="queueUpload(files)"></dropzone>
 
+        <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
         <div ng-if="addFileData.files">
           <button ng-if="!addFileData.uploading" class="btn btn-default pull-right" ng-click="removeFiles()">Remove</button>
           <label>Name:</label>
@@ -95,6 +96,7 @@
 
       <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="*" drop-method="queueUpload(files)"></dropzone>
 
+      <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
       <div ng-if="addFileData.files">
         <button ng-if="!addFileData.uploading" class="btn btn-default pull-right" ng-click="removeFiles()">Remove</button>
         <label>Name:</label>


### PR DESCRIPTION
There is already error messaging in place, but it is not implemented in every place.
Implement the errorMessage to be displayed in all of the file upload areas.

The error results from file upload failures is inconsistently structured.
Sometimes the errors are a string of HTML, other times the errors are objects.
This only parses the objects with known structures.

In all error cases, even if there is no parsed error message, an upload failure message is presented.

closes #855