### PR TITLE
Disable navigation buttons on student submission page during submit #858

### DIFF
--- a/src/main/webapp/app/controllers/submission/studentSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/studentSubmissionController.js
@@ -27,6 +27,10 @@ vireo.controller("StudentSubmissionController", function ($controller, $scope, $
     });
 
     $scope.setActiveStep = function (step, hash) {
+        if ($scope.submitting) {
+            // do not allow changing the active step while submitting to prevent changing field values.
+            return;
+        }
 
         var stepIndex = $scope.submission.submissionWorkflowSteps.indexOf(step);
         var reviewStepNum = $scope.submission.submissionWorkflowSteps.length + 1;

--- a/src/main/webapp/app/views/submission/submission.html
+++ b/src/main/webapp/app/views/submission/submission.html
@@ -12,7 +12,7 @@
       <ul class="nav nav-pills nav-justified">
         <li class="submission-workflow-step-navigation" ng-class="{'active': activeStep.id == workflowStep.id}" ng-repeat="workflowStep in submission.submissionWorkflowSteps">
           <a ng-click="setActiveStep(workflowStep)">
-            <button class="invisible-button wide-button">
+            <button class="invisible-button wide-button" ng-disabled="submitting">
                 <span>{{$index+1}}. {{workflowStep.name}}</span>
                 <span class="glyphicon glyphicon-arrow-right pull-right"></span>
             </button>
@@ -20,7 +20,7 @@
         </li>
         <li class="submission-workflow-step-navigation" ng-class="{'active': activeStep.name === 'review'}" ng-if="studentSubmissionRepoReady">
           <a ng-click="reviewSubmission()">
-            <button class="invisible-button">Confirm & Submit</button>
+            <button class="invisible-button" ng-disabled="submitting">Confirm & Submit</button>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
This issue as requested appears to be solved already.
The submit button locks and the page never redirects to the *Submission Complete* page until after the server returns the response.

However, the described problem of being able to change values during submit still exists but just manifests in a different way.
If the response is delayed and the submit button is locked while waiting, the navigation buttons remain clickable and the user can navigate to other pages to make changes during submit.

I believe this, in effect, is really part of the problem being requested to solve.
Given that the primary issue described appears to already be resolved, this addresses the secondary issue as described above.

closes #858