### PR TITLE
Sprint32 #751 file upload use cv

### DIFF
--- a/src/main/webapp/app/controllers/settings/controlledVocabularyRepoController.js
+++ b/src/main/webapp/app/controllers/settings/controlledVocabularyRepoController.js
@@ -27,6 +27,10 @@ vireo.controller("ControlledVocabularyRepoController", function ($controller, $q
 
     $scope.uploadAction = "confirm";
 
+    $scope.uploadModalDataText = "Begin import by dropping csv into drop zone";
+
+    $scope.uploadModalDataPattern = ".csv";
+
     $scope.forms = {};
 
     $scope.newVW = {};

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -203,6 +203,33 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
         resetFileData();
 
+        $scope.getPattern = function (doctype) {
+            var pattern = "*";
+            var fieldPredicate;
+            var i;
+
+            for(i in $scope.fieldPredicates) {
+                if($scope.fieldPredicates[i].value === doctype) {
+                    fieldPredicate = $scope.fieldPredicates[i];
+                    break;
+                }
+            }
+
+            if (fieldPredicate !== undefined) {
+                var fieldProfile = $scope.submission.getFieldProfileByPredicate(fieldPredicate);
+                if (fieldProfile.controlledVocabularies[0] !== undefined) {
+                    var cv = fieldProfile.controlledVocabularies[0];
+                    pattern = "";
+                    for (i in cv.dictionary) {
+                        var word = cv.dictionary[i];
+                        pattern += pattern.length > 0 ? (",." + word.name) : ("." + word.name);
+                    }
+                }
+            }
+
+            return pattern;
+        };
+
         $scope.queueUpload = function (files) {
             $scope.errorMessage = "";
             $scope.addFileData.files = files;

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -50,6 +50,8 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
     $scope.errorMessage = "";
 
+    $scope.dropZoneText = "Drop a file or click arrow";
+
     SubmissionRepo.findSubmissionById($routeParams.id).then(function(submission) {
 
         $scope.submission = submission;

--- a/src/main/webapp/app/directives/dropZoneDirective.js
+++ b/src/main/webapp/app/directives/dropZoneDirective.js
@@ -3,11 +3,11 @@ vireo.directive("dropzone", function ($timeout) {
         templateUrl: 'views/directives/dropZone.html',
         restrict: 'E',
         scope: {
-            'id': '@',
-            'text': '@',
-            'patterns': '@',
-            'maxFiles': '@',
-            'allowMultiple': '@',
+            'id': '=',
+            'text': '=',
+            'patterns': '=',
+            'maxFiles': '=',
+            'allowMultiple': '=',
             'dropMethod': '&',
             'fileModel': '='
         },

--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -23,6 +23,8 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, FileUploa
 
             $scope.errorMessage = "";
 
+            $scope.dropzoneText = "Choose file here or drag and drop to upload";
+
             var save = function (fieldValue) {
                 return $q(function (resolve) {
                     $scope.submission.saveFieldValue(fieldValue, $scope.profile).then(function (res) {

--- a/src/main/webapp/app/views/admin/settings/application/controlledVocabularyManagement.html
+++ b/src/main/webapp/app/views/admin/settings/application/controlledVocabularyManagement.html
@@ -36,8 +36,8 @@
 
 		<div class="col-md-6">
 			<div class="col-md-10 col-md-offset-1">
-				<dropzone file-model="uploadModalData.file" id="{{dropZoneId}}" text="Begin import by dropping csv into drop zone" patterns=".csv" drop-method="beginImport(files)">
-				</dropzone>
+                <dropzone file-model="uploadModalData.file" text="uploadModalDataText" patterns="uploadModalDataPattern" drop-method="beginImport(files)">
+                </dropzone>
 			</div>
 		</div>
 	</div>

--- a/src/main/webapp/app/views/inputtype/input-file.html
+++ b/src/main/webapp/app/views/inputtype/input-file.html
@@ -5,7 +5,7 @@
         <span ng-if="!uploading" class="glyphicon glyphicon-info-sign opaque" tooltip="{{ profile.help }}"></span>
         <span ng-if="uploading" class="glyphicon glyphicon-refresh spinning"></span>
       </span>
-      <dropzone file-model="files" text="Choose file here or drag and drop to upload" allow-multiple="false" patterns="{{getPattern()}}" drop-method="queueUpload(files)"></dropzone>
+      <dropzone file-model="files" text="dropzoneText" allow-multiple="!profile.repeatable" patterns="getPattern()" drop-method="queueUpload(files)"></dropzone>
     </div>
   </div>
   <div class="col-md-7 col-sm-12 file-preview-container">
@@ -43,7 +43,7 @@
         <span ng-if="!uploading" class="glyphicon glyphicon-info-sign opaque" tooltip="{{ profile.help }}"></span>
         <span ng-if="uploading" class="glyphicon glyphicon-refresh spinning"></span>
       </span>
-      <dropzone file-model="files" text="Choose file here or drag and drop to upload" allow-multiple="true" patterns="{{getPattern()}}" drop-method="queueUpload(files)"></dropzone>
+      <dropzone file-model="files" text="dropzoneText" allow-multiple="profile.repeatable" patterns="getPattern()" drop-method="queueUpload(files)"></dropzone>
     </div>
   </div>
   <div ng-if="!fieldValue.uploading && errorMessage" class="file-info text-danger">{{errorMessage}}</div>

--- a/src/main/webapp/app/views/modals/view/addFileModal.html
+++ b/src/main/webapp/app/views/modals/view/addFileModal.html
@@ -17,7 +17,7 @@
 
       <div class="add-file-section" ng-class="{'section-open': addFileData.addFileSelection === 'replace', 'section-closed': addFileData.addFileSelection !== 'replace'}">
 
-        <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="pdf" drop-method="queueUpload(files)"></dropzone>
+        <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="getPattern('_doctype_primary')" drop-method="queueUpload(files)"></dropzone>
 
         <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
         <div ng-if="addFileData.files">
@@ -93,12 +93,12 @@
 
       <div class="form-group">
         <label for="additionalDocumentFileName">New Document Type:</label>
-        <select id="additionalDocumentFileName" class="form-control" ng-model="addFileData.fieldPredicate" ng-options="documentFieldPredicate as getFileType(documentFieldPredicate) for documentFieldPredicate in fieldPredicates | filter:{ documentTypePredicate: true } | filter:{value:'!_doctype_primary'} track by documentFieldPredicate.value">
+        <select id="additionalDocumentFileName" class="form-control" ng-model="addFileData.fieldPredicate" ng-options="documentFieldPredicate as getFileType(documentFieldPredicate) for documentFieldPredicate in fieldPredicates | filter:{ documentTypePredicate: true } | filter:{value:'!_doctype_primary'} track by documentFieldPredicate.value" ng-selected="getPattern(addFileData.fieldPredicate.value)">
           <option value="">Select File Type...</option>
         </select>
       </div>
 
-      <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="*" drop-method="queueUpload(files)"></dropzone>
+      <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" patterns="getPattern(addFileData.fieldPredicate.value)" drop-method="queueUpload(files)"></dropzone>
 
       <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
       <div ng-if="addFileData.files">

--- a/src/main/webapp/app/views/modals/view/addFileModal.html
+++ b/src/main/webapp/app/views/modals/view/addFileModal.html
@@ -17,7 +17,7 @@
 
       <div class="add-file-section" ng-class="{'section-open': addFileData.addFileSelection === 'replace', 'section-closed': addFileData.addFileSelection !== 'replace'}">
 
-        <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" , patterns="getPattern('_doctype_primary')" drop-method="queueUpload(files)"></dropzone>
+        <dropzone ng-if="!addFileData.files" file-model="files" text="dropZoneText" , patterns="getPattern('_doctype_primary')" drop-method="queueUpload(files)"></dropzone>
 
         <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
         <div ng-if="addFileData.files">
@@ -98,7 +98,7 @@
         </select>
       </div>
 
-      <dropzone ng-if="!addFileData.files" file-model="files" text="Drop a file or click arrow" patterns="getPattern(addFileData.fieldPredicate.value)" drop-method="queueUpload(files)"></dropzone>
+      <dropzone ng-if="!addFileData.files" file-model="files" text="dropZoneText" patterns="getPattern(addFileData.fieldPredicate.value)" drop-method="queueUpload(files)"></dropzone>
 
       <div class="file-info text-danger" ng-if="errorMessage">{{errorMessage}}</div>
       <div ng-if="addFileData.files">


### PR DESCRIPTION
Restrict file type based on CV restrictions in the admin submission controller file upload modal
Default or fallback to '*' file types.

Change dropzone scope behavior.
The pattern will never update once the select list changes because of the scope properties for 'patterns'.
By changing the scope, the pattern can be dynamically updated.

There are additional problems related to this the resolved issue:
1. #1009
2. #1010

closes #751 