### PR TITLE
Sprint32 #1001 tooltip render html

### DIFF
--- a/src/main/resources/organization/SYSTEM_Organization_Definition.json
+++ b/src/main/resources/organization/SYSTEM_Organization_Definition.json
@@ -184,6 +184,7 @@
           "optional":true,
           "usage":"",
           "help":"Enter your ORCID author identifier. If you do not have an ORCID iD, get one at <a href='https://orcid.org/register' target='_blank'>orcid.org</a>.",
+          "htmlTooltip":true,
           "fieldGlosses":[
             {
               "value":"ORCID",

--- a/src/main/webapp/app/directives/tooltipDirective.js
+++ b/src/main/webapp/app/directives/tooltipDirective.js
@@ -1,62 +1,62 @@
 vireo.directive('tooltip', function ($timeout, $compile) {
 
-	return {
-		template: '<span class="tooltip-handle" ng-mousemove="positionTip($event)" ng-mouseover="showTip()" ng-mouseout="hideTip()" ng-click="toggleVisible()" ng-transclude></span>',
-		replace: true,
-		transclude: true,
-		restrict: 'A',
-		scope:true,
-		link: function($scope, elem, attr) {
-			
-			var tipTemplate = 	'<div class="tooltip-wrapper">'+
-									'<div ng-style="tipStyles" class="tip" ng-class="{\'tip-visible\': tipVisible, \'hidden\': hidden}">'+
-										'<div class="tip-point"></div>' +
-										'<div class="tip-message">{{::tip}}</div>' +
-									'</div>' +
-								'</div>';
-			
-			angular.element("body").append($compile(tipTemplate)($scope));
+    return {
+        template: '<span class="tooltip-handle" ng-mousemove="positionTip($event)" ng-mouseover="showTip()" ng-mouseout="hideTip()" ng-click="toggleVisible()" ng-transclude></span>',
+        replace: true,
+        transclude: true,
+        restrict: 'A',
+        scope:true,
+        link: function($scope, elem, attr) {
+            var htmlTooltip = attr.htmltooltip !== undefined;
 
-			$scope.tip = attr.tooltip;
+            var tipTemplate = '<div class="tooltip-wrapper">' +
+                                  '<div ng-style="tipStyles" class="tip" ng-class="{\'tip-visible\': tipVisible, \'hidden\': hidden}">' +
+                                      '<div class="tip-point"></div>' +
+                                      (htmlTooltip ? '<div class="tip-message">' + attr.tooltip + '</div>' : '<div class="tip-message">{{::tip}}</div>') +
+                                  '</div>' +
+                              '</div>';
 
-			$scope.tipVisible = false;
-			$scope.hidden = true;
-			$scope.showTimer = {};
-			$scope.tipStyles = {};
+            angular.element("body").append($compile(tipTemplate)($scope));
 
-			$scope.showTip = function() {
-				$scope.hidden = false;
-				$scope.showTimer = $timeout(function() {
-					$scope.tipVisible = true;
-				}, 500);
-			};
+            $scope.tip = attr.tooltip;
 
-			$scope.hideTip = function() {
-				$timeout.cancel($scope.showTimer);
-				$scope.tipVisible = false;
+            $scope.tipVisible = false;
+            $scope.hidden = true;
+            $scope.showTimer = {};
+            $scope.tipStyles = {};
 
-				$timeout(function() {
-					$scope.hidden = true;
-				}, 500);
+            $scope.showTip = function() {
+                $scope.hidden = false;
+                $scope.showTimer = $timeout(function() {
+                    $scope.tipVisible = true;
+                }, 500);
+            };
 
-			};
+            $scope.hideTip = function() {
+                $timeout.cancel($scope.showTimer);
+                $scope.tipVisible = false;
 
-			$scope.toggleVisible = function() {
-				$timeout.cancel($scope.showTimer);
-				$scope.tipVisible = $scope.tipVisible ? false : true;
+                $timeout(function() {
+                    $scope.hidden = true;
+                }, 500);
+            };
 
-				if(!$scope.tipVisible) {
-					$timeout(function() {
-						$scope.hidden = $scope.hidden ? false : true;
-					}, 500);
-				} 
+            $scope.toggleVisible = function() {
+                $timeout.cancel($scope.showTimer);
+                $scope.tipVisible = $scope.tipVisible ? false : true;
 
-			};
+                if(!$scope.tipVisible) {
+                    $timeout(function() {
+                        $scope.hidden = $scope.hidden ? false : true;
+                    }, 500);
+                }
 
-			$scope.positionTip = function($event) {
-				$scope.tipStyles.top = $event.clientY + 20;
-				$scope.tipStyles.left = $event.clientX -	25;
-			};
-		}
-	};
+            };
+
+            $scope.positionTip = function($event) {
+                $scope.tipStyles.top = $event.clientY + 20;
+                $scope.tipStyles.left = $event.clientX -    25;
+            };
+        }
+    };
 });

--- a/src/main/webapp/app/resources/styles/sass/app.scss
+++ b/src/main/webapp/app/resources/styles/sass/app.scss
@@ -1405,6 +1405,14 @@ input[type=color]:focus {
   font-size: 0.85em;
 }
 
+.tip .tip-message a,
+.tip .tip-message a:active,
+.tip .tip-message a:focus,
+.tip .tip-message a:hover,
+.tip .tip-message a:visited {
+  color: #f8ff11;
+}
+
 .tip.tip-visible .tip-message {
   z-index: 102 !important;
 }

--- a/src/main/webapp/app/views/inputtype/input-orcid.html
+++ b/src/main/webapp/app/views/inputtype/input-orcid.html
@@ -1,8 +1,8 @@
 <div class="input-group">
-  <input type="text" 
-    class="form-control" 
-    name="{{profile.fieldPredicate.value}}" 
-    ng-required="!profile.optional" 
+  <input type="text"
+    class="form-control"
+    name="{{profile.fieldPredicate.value}}"
+    ng-required="!profile.optional"
     ng-model="fieldValue.value"
     ng-blur="save(fieldValue)"
     ng-disabled="fieldValue.updating"
@@ -10,8 +10,8 @@
     uib-typeahead="word.name as word.name for word in profile.controlledVocabularies[0].dictionary | filter: { name: $viewValue }"
     typeahead-on-select="saveWithCV(fieldValue, $item)"/>
   <span class="input-group-addon">
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" tooltip="{{ profile.help }}"> </span>
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" tooltip="{{ profile.help }}" htmltooltip="{{profile.htmlTooltip}}"> </span>
     <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
-  </span>  
+  </span>
 </div>
 <small class="form-text text-muted">Enter your ORCID author identifier. If you do not have an ORCID iD, get one at <a href="https://orcid.org/register">orcid.org</a>.</small>


### PR DESCRIPTION
Add support for HTML to be stored within the tooltip popup
    
I was unable to prevent `{{ }}` from filtering HTML, even when using the `trusted` filter that utilizes `$sceProvider`.
I was unable to use `ng-bind-html` because it needs to be applied to an attribute and not an entire html tag.
    
This leaves me with the undesirable literal addition of the html.
    
To reduce the potential problems, this is restricted to only definitions that add `"htmlTooltip":true,` to the appropriate Definition property.

closes #1001 