### PR TITLE
Reverted changes that were causing the submission to reload

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -573,12 +573,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             "publish": function (state) {
                 $scope.submissionStatusBox.updating = true;
                 state.updating = true;
-                $scope.submission.publish($scope.submissionStatusBox.depositLocation).then(function (response) {
-                    var apiRes = angular.fromJson(response.body);
-                    if(apiRes.meta.status === 'SUCCESS') {
-                        var submission = apiRes.payload.Submission;
-                        angular.extend($scope.submission.submissionStatus, submission.submissionStatus);
-                    }
+                $scope.submission.publish($scope.submissionStatusBox.depositLocation).then(function () {
                     delete state.updating;
                     delete $scope.submissionStatusBox.updating;
                     $scope.submissionStatusBox.resetStatus();

--- a/src/main/webapp/app/controllers/submission/submissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/submissionViewController.js
@@ -103,9 +103,6 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $scope, 
         CustomActionDefinitionRepo.listen(function(apiRes) {
             if(apiRes.meta.status === 'SUCCESS') {
                 StudentSubmissionRepo.remove($scope.submission);
-                StudentSubmissionRepo.fetchSubmissionById($routeParams.submissionId).then(function (submission) {
-                    angular.extend($scope.submission, submission);
-                });
             }
         });
 


### PR DESCRIPTION
Resolves #1067.

This reverted changes made in #828 and #1011 that no longer seem to be needed.

My suspicion is that framework changes caused submission updates to be broadcast where we had been doing it manually in the past, causing multiple reloads.