### PR TITLE
[713] Restore MarcXML21 export

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -552,8 +553,10 @@ public class SubmissionController {
         case "MarcXML21":
         case "DSpaceMETS":
         case "ProQuest":
+            ServletOutputStream sos = response.getOutputStream();
+
             try {
-                ZipOutputStream zos = new ZipOutputStream(response.getOutputStream());
+                ZipOutputStream zos = new ZipOutputStream(sos);
 
                 // TODO: need a more dynamic way to achieve this
                 if (packagerName.equals("ProQuest")) {
@@ -561,30 +564,32 @@ public class SubmissionController {
                 }
 
                 for (Submission submission : submissionRepo.batchDynamicSubmissionQuery(filter, columns)) {
+
+                    StringBuilder contentsText = new StringBuilder();
                     ExportPackage exportPackage = packagerUtility.packageExport(packager, submission);
-
-                    if (exportPackage.isFile()) {
-                        File exportFile = (File) exportPackage.getPayload();
-                        if (packagerName.equals("MarcXML21")) {
-                            zos.putNextEntry(new ZipEntry("MarcXML21/" + exportFile.getName()));
-                        } else {
-                            zos.putNextEntry(new ZipEntry(exportFile.getName()));
+                    if (exportPackage.isMap()) {
+                        for (Map.Entry<String, File> fileEntry : ((Map<String, File>) exportPackage.getPayload()).entrySet()) {
+                            if (packagerName.equals("MarcXML21")) {
+                                zos.putNextEntry(new ZipEntry("MarcXML21/" + fileEntry.getKey()));
+                            } else {
+                                zos.putNextEntry(new ZipEntry(fileEntry.getKey()));
+                            }
+                            contentsText.append("MD " + fileEntry.getKey() + "\n");
+                            zos.write(Files.readAllBytes(fileEntry.getValue().toPath()));
+                            zos.closeEntry();
                         }
-                        zos.write(Files.readAllBytes(exportFile.toPath()));
-                        zos.closeEntry();
                     }
-
                 }
                 zos.close();
 
                 response.setContentType(packager.getMimeType());
                 response.setHeader("Content-Disposition", "inline; filename=" + packagerName + "." + packager.getFileExtension());
             } catch (Exception e) {
+                LOG.info("Error With Export",e);
                 response.setContentType("application/json");
                 ApiResponse apiResponse = new ApiResponse(ERROR, "Something went wrong with the export!");
-                PrintWriter out = response.getWriter();
-                out.print(objectMapper.writeValueAsString(apiResponse));
-                out.close();
+                sos.print(objectMapper.writeValueAsString(apiResponse));
+                sos.close();
             }
             break;
         case "DSpaceSimple":

--- a/src/main/java/org/tdl/vireo/model/export/ZipExportPackage.java
+++ b/src/main/java/org/tdl/vireo/model/export/ZipExportPackage.java
@@ -1,13 +1,17 @@
 package org.tdl.vireo.model.export;
 
 import java.io.File;
+import java.util.Map;
 
 import org.tdl.vireo.model.Submission;
 
 public class ZipExportPackage extends AbstractExportPackage {
 
-    public ZipExportPackage(Submission submission, String format, File file) {
-        super(submission, format, file);
+    public ZipExportPackage(Submission submission, String format, Map<String, File> files) {
+        super(submission, format, files);
     }
 
+    public ZipExportPackage(Submission submission, String format,File file) {
+      super(submission, format, file);
+    }
 }

--- a/src/main/java/org/tdl/vireo/model/packager/MarcXML21Packager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/MarcXML21Packager.java
@@ -1,9 +1,9 @@
 package org.tdl.vireo.model.packager;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.persistence.Entity;
 
@@ -29,27 +29,22 @@ public class MarcXML21Packager extends AbstractPackager<ZipExportPackage> {
     }
 
     @Override
-    public ZipExportPackage packageExport(Submission submission, String manifest) {
+    public ZipExportPackage packageExport(Submission submission, Map<String, String> dsDocs) {
 
-        String packageName = "submission_" + submission.getId().toString();
-        File pkg = null;
-
+        Map<String, File> pkgs = new HashMap<String, File>();
         try {
-            pkg = File.createTempFile(packageName, ".xml");
-
-            FileOutputStream fos = new FileOutputStream(pkg);
-
-            File submissionFile = File.createTempFile(packageName, null);
-            FileUtils.writeStringToFile(submissionFile, manifest, "UTF-8");
-
-            fos.write(Files.readAllBytes(submissionFile.toPath()));
-            submissionFile.delete();
-            fos.close();
-
+            // Add non submitted content
+            for (Map.Entry<String, String> ds_entry : dsDocs.entrySet()) {
+                String docName = ds_entry.getKey();
+                String docContents = ds_entry.getValue();
+                File ff = File.createTempFile(docName, "");
+                FileUtils.writeStringToFile(ff, docContents, "UTF-8");
+                pkgs.put(docName, ff);
+            }
         } catch (IOException ioe) {
             throw new RuntimeException("Unable to generate package", ioe);
         }
 
-        return new ZipExportPackage(submission, "http://www.loc.gov/MARC21/slim", pkg);
+        return new ZipExportPackage(submission, "http://www.loc.gov/MARC21/slim", pkgs);
     }
 }


### PR DESCRIPTION
Resolves #713 

This PR fixes the MarcXML21 export.

But the bug also affects the DSpaceMETS (#1139 ) and ProQuest (#1140 ) exporters.

The exports were failing silently because the UnsupportedFormatterException was being caught but not logged. The Exception is now being written to the log.

The catch block that was swallowing the UFException was also generating its own IllegalStateException because it was calling for a new response outputStream after the try block had  claimed it. The try and catch blocks are now sharing the same outputStream.

The result of this PR is that:
- MarcXML21 exporting works again, but **the resulting zip contents should be reviewed carefully to make sure they are still correct**.
- The DSpaceMets and ProQuest Export no longer fail silently, but still fail. Issues are open for each.
- MarcXML21, DSpaceMets, or ProQuest export failures will no longer trigger a follow on IllegalStateException