### PR TITLE
Feb sprint configuration repo patch

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -676,7 +676,6 @@ public class SubmissionController {
 
                     StringBuilder contentsText = new StringBuilder();
 
-					submission.setConfigurationRepo(configurationRepo);
                     ExportPackage exportPackage = packagerUtility.packageExport(packager, submission);
 
                     if (exportPackage.isMap()) {
@@ -726,7 +725,7 @@ public class SubmissionController {
                     zos.closeEntry();
 
                     zos.closeEntry();
-                    submission.setConfigurationRepo(null);
+                    
                 }
                 zos.close();
 

--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -127,9 +127,6 @@ public class Submission extends ValidatingBaseEntity {
     @Column(nullable = true)
     private String depositURL;
 
-	@Transient
-    private static ConfigurationRepo configurationRepo;
-
     public Submission() {
         setModelValidator(new SubmissionValidator());
         setFieldValues(new HashSet<FieldValue>());
@@ -159,20 +156,6 @@ public class Submission extends ValidatingBaseEntity {
         this(submitter, organization);
         setSubmissionStatus(submissionStatus);
     }
-
-    /**
-     * @return the configurationRepo 
-    */
-    public ConfigurationRepo getConfigurationRepo() {
-        return configurationRepo;
-	}
-
-    /**
-     * @param configurationRepo
-    */
-	public void setConfigurationRepo(ConfigurationRepo configurationRepo){
-		this.configurationRepo = configurationRepo;
-	}
 
     /**
      * @return the submitter

--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -567,12 +567,8 @@ public class SubmissionHelperUtility {
     // NOTE: these come from the settings service
 
 
-    public String getGrantor() {
-        String grantor = null;
-        if(submission.getConfigurationRepo()!=null){
-            grantor = submission.getConfigurationRepo().getValueByName("grantor");
-        }
-        return grantor != null ? grantor : "";
+    public String getGrantor() {        
+      return getSettingByNameAndType("application", "grantor").getValue();
     }
 
     public boolean getReleaseStudentContactInformation() {

--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -11,9 +11,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.tdl.vireo.model.Address;
+import org.tdl.vireo.model.Configuration;
 import org.tdl.vireo.model.DefaultConfiguration;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
 import org.tdl.vireo.service.DefaultSettingsService;
 import org.tdl.vireo.service.ProquestCodesService;
 
@@ -614,9 +616,9 @@ public class SubmissionHelperUtility {
 
     // NOTE: used context to get the default settings service
 
-    public DefaultConfiguration getSettingByNameAndType(String name, String type) {
-        DefaultSettingsService defaultSettingsService = SpringContext.bean(DefaultSettingsService.class);
-        return defaultSettingsService.getSettingByNameAndType(name, type);
+    public Configuration getSettingByNameAndType(String name, String type) {
+        ConfigurationRepo configurationRepo = SpringContext.bean(ConfigurationRepo.class);
+        return configurationRepo.getByNameAndType(name, type);
     }
 
     public Optional<String> getProQuestCodeByNameAndType(String name, String type) {

--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -570,7 +570,7 @@ public class SubmissionHelperUtility {
 
 
     public String getGrantor() {        
-      return getSettingByNameAndType("application", "grantor").getValue();
+      return getSettingByNameAndType("grantor","application").getValue();
     }
 
     public boolean getReleaseStudentContactInformation() {


### PR DESCRIPTION
SubmissionHelperUtility.java getSettingByNameAndType is updated to use ConfigurationRepo instead of DefaultSettings.  This results in data set in the UI being returned by getSettingsByNameAndType instead of just the values in the defaults json file.  This eliminates the need for a transient ConfigurationRepo being accessible via Submission.java.

The end result is that getGrantor will return the Degree Granting School value set in the UI in ApplicationSettings>SubmissionAvailability.  This value is needed for metadata_thesis.xml in the DSpace Simple Archive Format export.