### PR TITLE
Added conditional to populate missing fieldValue

### DIFF
--- a/src/main/webapp/app/filters/fieldValuePerProfile.js
+++ b/src/main/webapp/app/filters/fieldValuePerProfile.js
@@ -1,4 +1,4 @@
-vireo.filter('fieldValuePerProfile', function() {
+vireo.filter('fieldValuePerProfile', function(FieldValue) {
     return function(fieldValues, fieldPredicate) {
         var fieldProfileValues = [];
         angular.forEach(fieldValues, function(fieldValue) {
@@ -6,6 +6,15 @@ vireo.filter('fieldValuePerProfile', function() {
                 fieldProfileValues.push(fieldValue);
             }
         });
+
+        if(fieldProfileValues.length===0) {
+          var fv = new FieldValue({
+            fieldPredicate: fieldPredicate
+          });
+          fieldValues.push(fv);
+          fieldProfileValues.push(fv);
+        }
+        
         return fieldProfileValues;
     };
 });


### PR DESCRIPTION
Resolves #1089 : Erasing field value to empty on Admin Submission view broadcasts to Submission view removing the entire input field

This introduces a conditional into the fieldValuePerProfile filter that ensures that when no matching predicate is found a dummy FieldValue is created and pushed into the submission and the retuned array of fieldValues. This is similar to what happens when the submission view loads. 