### PR TITLE
fixed location the jar packaging should look for CV files

### DIFF
--- a/src/main/java/org/tdl/vireo/service/AssetService.java
+++ b/src/main/java/org/tdl/vireo/service/AssetService.java
@@ -131,7 +131,7 @@ public class AssetService {
         Resource resource = getResource(resourceDirectory);
         URI uri = resource.getURI();
         if (uri.getScheme().equals("jar")) {
-            String directory = resourceDirectory.replace("classpath:", "/WEB-INF/classes").replace("file:", "/");
+            String directory = resourceDirectory.replace("classpath:", "/BOOT-INF/classes").replace("file:", "/");
             FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.<String, String>emptyMap());
             Path directoryPath = fileSystem.getPath(directory);
             Iterator<Path> it = Files.walk(directoryPath, 1).filter(Files::isRegularFile).iterator();


### PR DESCRIPTION
Controlled vocabulary files in the jar packaging get put in BOOT-INF not WEB-INF as expressed in AssetService.java