### PR TITLE
[#1157] Please report error modal does not close when close button is clicked

### DIFF
--- a/src/main/webapp/app/controllers/abstractController.js
+++ b/src/main/webapp/app/controllers/abstractController.js
@@ -38,7 +38,7 @@ vireo.controller('AbstractController', function ($scope, $window, ModalService, 
             method: 'error',
             data: alert
         }).then(function () {
-            angular.element("#reportModal").modal('show');
+            $scope.openModal('#reportModal');
         }, function (response) {
             if (response.data === null || response.data.message != "EXPIRED_JWT") {
                 var subject = 'Error Report';

--- a/src/main/webapp/tests/core/utility/coreUtility.js
+++ b/src/main/webapp/tests/core/utility/coreUtility.js
@@ -77,3 +77,12 @@ var mockParameterModel = function($q, mockModel) {
         return model;
     };
 };
+
+var mockWindow = function() {
+    return {
+        location: {
+            href: '',
+            replace: function() {}
+        }
+    };
+}

--- a/src/main/webapp/tests/core/utility/coreUtility.js
+++ b/src/main/webapp/tests/core/utility/coreUtility.js
@@ -57,6 +57,19 @@ var rejectPromise = function (defer, payload, messageStatus, httpStatus) {
     return defer.promise;
 };
 
+var failurePromise = function (defer, payload, messageStatus, httpStatus) {
+    defer.reject({
+        data: {
+            meta: {
+                status: messageStatus ? messageStatus : 'INVALID',
+            },
+            payload: payload,
+            status: httpStatus ? httpStatus : 500
+        }
+    });
+    return defer.promise;
+};
+
 var mockParameterModel = function($q, mockModel) {
     return function(toMock) {
         var model = new mockModel($q);

--- a/src/main/webapp/tests/mocks/models/mockEmailRecipient.js
+++ b/src/main/webapp/tests/mocks/models/mockEmailRecipient.js
@@ -1,0 +1,32 @@
+var dataEmailRecipient1 = {
+    id: 1
+};
+
+var dataEmailRecipient2 = {
+    id: 2
+};
+
+var dataEmailRecipient3 = {
+    id: 3
+};
+
+var dataEmailRecipient4 = {
+    id: 4
+};
+
+var dataEmailRecipient5 = {
+    id: 5
+};
+
+var dataEmailRecipient6 = {
+    id: 6
+};
+
+var mockEmailRecipient = function($q) {
+    var model = mockModel("EmailRecipient", $q, dataEmailRecipient1);
+
+    return model;
+};
+
+angular.module('mock.emailRecipient', []).service('EmailRecipient', mockEmailRecipient);
+

--- a/src/main/webapp/tests/mocks/models/mockFilterCriterion.js
+++ b/src/main/webapp/tests/mocks/models/mockFilterCriterion.js
@@ -1,0 +1,56 @@
+var dataFilterCriterion1 = {
+    id: 1,
+    criterionName: 'criterion name 1',
+    exactMatch: true,
+    filterGloss: 'filter gloss 1',
+    filterValue: 'filter value 1'
+};
+
+var dataFilterCriterion2 = {
+    id: 2,
+    criterionName: 'criterion name 2',
+    exactMatch: false,
+    filterGloss: 'filter gloss 2',
+    filterValue: 'filter value 2'
+};
+
+var dataFilterCriterion3 = {
+    id: 3,
+    criterionName: 'criterion name 3',
+    exactMatch: true,
+    filterGloss: 'filter gloss 3',
+    filterValue: 'filter value 3'
+};
+
+var dataFilterCriterion4 = {
+    id: 4,
+    criterionName: 'criterion name 4',
+    exactMatch: true,
+    filterGloss: 'filter gloss 4',
+    filterValue: 'filter value 4'
+};
+
+var dataFilterCriterion5 = {
+    id: 5,
+    criterionName: 'criterion name 5',
+    exactMatch: false,
+    filterGloss: 'filter gloss 5',
+    filterValue: 'filter value 5'
+};
+
+var dataFilterCriterion6 = {
+    id: 6,
+    criterionName: 'criterion name 6',
+    exactMatch: false,
+    filterGloss: 'filter gloss 6',
+    filterValue: 'filter value 6'
+};
+
+var mockFilterCriterion = function($q) {
+    var model = mockModel("FilterCriterion", $q, dataFilterCriterion1);
+
+    return model;
+};
+
+angular.module('mock.filterCriterion', []).service('FilterCriterion', mockFilterCriterion);
+

--- a/src/main/webapp/tests/mocks/models/mockInputType.js
+++ b/src/main/webapp/tests/mocks/models/mockInputType.js
@@ -1,25 +1,53 @@
 var dataInputType1 = {
-    id: 1
+    id: 1,
+    name: "input type 1",
+    validationPattern: "name",
+    validation: [
+        {
+            message: "name validation pattern",
+            pattern: ".*"
+        }
+    ]
 };
 
 var dataInputType2 = {
-    id: 2
+    id: 2,
+    name: "input type 2",
+    validationPattern: "email",
+    validation: [
+        {
+            message: "email validation pattern",
+            pattern: "^([_A-Za-z0-9-\+]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9]+)*(\.[A-Za-z]{2,})|)$"
+        }
+    ]
 };
 
 var dataInputType3 = {
-    id: 3
+    id: 3,
+    name: "input type 3",
+    validationPattern: "",
+    validation: []
 };
 
 var dataInputType4 = {
-    id: 4
+    id: 4,
+    name: "input type 4",
+    validationPattern: "",
+    validation: []
 };
 
 var dataInputType5 = {
-    id: 5
+    id: 5,
+    name: "input type 5",
+    validationPattern: "",
+    validation: []
 };
 
 var dataInputType6 = {
-    id: 6
+    id: 6,
+    name: "input type 6",
+    validationPattern: "",
+    validation: []
 };
 
 var mockInputType = function($q) {

--- a/src/main/webapp/tests/mocks/models/mockNamedSearchFilter.js
+++ b/src/main/webapp/tests/mocks/models/mockNamedSearchFilter.js
@@ -1,0 +1,56 @@
+var dataNamedSearchFilter1 = {
+    id: 1,
+    allColumnSearch: true,
+    exactMatch: true,
+    filterCriteria: {},
+    name: 'named search filter 1'
+};
+
+var dataNamedSearchFilter2 = {
+    id: 2,
+    allColumnSearch: false,
+    exactMatch: true,
+    filterCriteria: {},
+    name: 'named search filter 2'
+};
+
+var dataNamedSearchFilter3 = {
+    id: 3,
+    allColumnSearch: true,
+    exactMatch: false,
+    filterCriteria: {},
+    name: 'named search filter 3'
+};
+
+var dataNamedSearchFilter4 = {
+    id: 4,
+    allColumnSearch: true,
+    exactMatch: false,
+    filterCriteria: {},
+    name: 'named search filter 4'
+};
+
+var dataNamedSearchFilter5 = {
+    id: 5,
+    allColumnSearch: false,
+    exactMatch: true,
+    filterCriteria: {},
+    name: 'named search filter 5'
+};
+
+var dataNamedSearchFilter6 = {
+    id: 6,
+    allColumnSearch: false,
+    exactMatch: false,
+    filterCriteria: {},
+    name: 'named search filter 6'
+};
+
+var mockNamedSearchFilter = function($q) {
+    var model = mockModel("NamedSearchFilter", $q, dataNamedSearchFilter1);
+
+    return model;
+};
+
+angular.module('mock.namedSearchFilter', []).service('NamedSearchFilter', mockNamedSearchFilter);
+

--- a/src/main/webapp/tests/mocks/models/mockNamedSearchFilterGroup.js
+++ b/src/main/webapp/tests/mocks/models/mockNamedSearchFilterGroup.js
@@ -1,39 +1,104 @@
 var dataNamedSearchFilterGroup1 = {
-    id: 1
+    id: 1,
+    columnsFlag: true,
+    name: 'named search filter group 1',
+    namedSearchFilters: [],
+    publicFlag: true,
+    savedColumns: [],
+    umiRelease: true
 };
 
 var dataNamedSearchFilterGroup2 = {
-    id: 2
+    id: 2,
+    columnsFlag: false,
+    name: 'named search filter group 2',
+    publicFlag: false,
+    namedSearchFilters: [],
+    savedColumns: [],
+    umiRelease: false
 };
 
 var dataNamedSearchFilterGroup3 = {
-    id: 3
+    id: 3,
+    columnsFlag: false,
+    name: 'named search filter group 3',
+    publicFlag: true,
+    namedSearchFilters: [],
+    savedColumns: [],
+    umiRelease: true
 };
 
 var dataNamedSearchFilterGroup4 = {
-    id: 4
+    id: 4,
+    columnsFlag: false,
+    name: 'named search filter group 4',
+    publicFlag: true,
+    namedSearchFilters: [],
+    savedColumns: [],
+    umiRelease: false
 };
 
 var dataNamedSearchFilterGroup5 = {
-    id: 5
+    id: 5,
+    columnsFlag: true,
+    name: 'named search filter group 5',
+    publicFlag: false,
+    namedSearchFilters: [],
+    savedColumns: [],
+    umiRelease: false
 };
 
 var dataNamedSearchFilterGroup6 = {
-    id: 6
+    id: 6,
+    columnsFlag: true,
+    name: 'named search filter group 6',
+    publicFlag: false,
+    namedSearchFilters: [],
+    savedColumns: [],
+    umiRelease: true
 };
 
 var mockNamedSearchFilterGroup = function($q) {
     var model = mockModel("NamedSearchFilterGroup", $q, dataNamedSearchFilterGroup1);
 
     model.addFilter = function(criterionName, filterValue, filterGloss, exactMatch) {
-        return payloadPromise($q.defer());
+        var found;
+
+        for (var filter in model.namedSearchFilters) {
+            if (filter.name === criterionName) {
+                found = filter;
+                break;
+            }
+        }
+
+        if (found) {
+            return payloadPromise($q.defer(), found);
+        }
+
+        var filterCriterion = new mockFilterCriterion($q);
+        filterCriterion.criterionName = criterionName;
+        filterCriterion.filterValue = filterValue;
+        filterCriterion.filterGloss = filterGloss;
+        filterCriterion.exactMatch = exactMatch;
+
+        model.namedSearchFilters.push(filterCriterion);
+
+        return payloadPromise($q.defer(), filterCriterion);
     };
 
     model.clearFilters = function() {
+        filter.length = 0;
         return payloadPromise($q.defer());
     };
 
     model.removeFilter = function(namedSearchFilterName, filterCriterion) {
+        for (var i = 0; i < model.namedSearchFilters.length; i++) {
+            if (model.namedSearchFilters[i].name === criterionName) {
+                delete model.namedSearchFilters[i];
+                break;
+            }
+        }
+
         return payloadPromise($q.defer());
     };
 

--- a/src/main/webapp/tests/mocks/models/mockSavedFilter.js
+++ b/src/main/webapp/tests/mocks/models/mockSavedFilter.js
@@ -1,25 +1,49 @@
 var dataSavedFilter1 = {
-    id: 1
+    id: 1,
+    name: "filter 1",
+    submissionListColumn: {},
+    allColumnSearch: true,
+    exactMatch: true
 };
 
 var dataSavedFilter2 = {
-    id: 2
+    id: 2,
+    name: "filter 2",
+    submissionListColumn: {},
+    allColumnSearch: false,
+    exactMatch: true
 };
 
 var dataSavedFilter3 = {
-    id: 3
+    id: 3,
+    name: "filter 3",
+    submissionListColumn: {},
+    allColumnSearch: true,
+    exactMatch: false
 };
 
 var dataSavedFilter4 = {
-    id: 4
+    id: 4,
+    name: "filter 4",
+    submissionListColumn: {},
+    allColumnSearch: false,
+    exactMatch: false
 };
 
 var dataSavedFilter5 = {
-    id: 5
+    id: 5,
+    name: "filter 5",
+    submissionListColumn: {},
+    allColumnSearch: true,
+    exactMatch: false
 };
 
 var dataSavedFilter6 = {
-    id: 6
+    id: 6,
+    name: "filter 6",
+    submissionListColumn: {},
+    allColumnSearch: false,
+    exactMatch: true
 };
 
 var mockSavedFilter = function($q) {

--- a/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
+++ b/src/main/webapp/tests/mocks/models/mockStudentSubmission.js
@@ -249,7 +249,7 @@ var mockStudentSubmission = function($q) {
     model.updateAdvisorApproval = function (approval) {
         var payload = {
             Submission: angular.copy(model)
-        }
+        };
         return payloadPromise($q.defer(), payload);
     };
 

--- a/src/main/webapp/tests/mocks/models/mockSubmission.js
+++ b/src/main/webapp/tests/mocks/models/mockSubmission.js
@@ -253,7 +253,7 @@ var mockSubmission = function($q) {
     model.updateAdvisorApproval = function (approval) {
         var payload = {
             Submission: angular.copy(model)
-        }
+        };
         return payloadPromise($q.defer(), payload);
     };
 

--- a/src/main/webapp/tests/mocks/models/mockSubmissionListColumn.js
+++ b/src/main/webapp/tests/mocks/models/mockSubmissionListColumn.js
@@ -1,25 +1,99 @@
 var dataSubmissionListColumn1 = {
-    id: 1
+    id: 1,
+    exactMatch: true,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 1",
+    sort: "ASC",
+    sortOrder: 1,
+    status: "status",
+    title: "submission list column 1",
+    valuePath: [
+        "path1"
+    ],
+    visible: true
 };
 
 var dataSubmissionListColumn2 = {
-    id: 2
+    id: 2,
+    exactMatch: true,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 2",
+    sort: "DESC",
+    sortOrder: 2,
+    status: "status",
+    title: "submission list column 2",
+    valuePath: [
+        "path2"
+    ],
+    visible: false
 };
 
 var dataSubmissionListColumn3 = {
-    id: 3
+    id: 3,
+    exactMatch: false,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 3",
+    sort: "NONE",
+    sortOrder: 3,
+    status: "status",
+    title: "submission list column 3",
+    valuePath: [
+        "path3",
+        "3path"
+    ],
+    visible: true
 };
 
 var dataSubmissionListColumn4 = {
-    id: 4
+    id: 4,
+    exactMatch: false,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 1",
+    sort: "DESC",
+    sortOrder: 1,
+    status: "status",
+    title: "submission list column 4",
+    valuePath: [
+        "path2"
+    ],
+    visible: false
 };
 
 var dataSubmissionListColumn5 = {
-    id: 5
+    id: 5,
+    exactMatch: false,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 2",
+    sort: "ASC",
+    sortOrder: 2,
+    status: "status",
+    title: "submission list column 5",
+    valuePath: [
+        "path3",
+        "3path"
+    ],
+    visible: true
 };
 
 var dataSubmissionListColumn6 = {
-    id: 6
+    id: 6,
+    exactMatch: true,
+    filters: [],
+    inputType: {},
+    predicate: "predicate 3",
+    sort: "NONE",
+    sortOrder: 3,
+    status: "status",
+    title: "submission list column 6",
+    valuePath: [
+        "path1"
+    ],
+    visible: false
 };
 
 var mockSubmissionListColumn = function($q) {

--- a/src/main/webapp/tests/mocks/models/mockValidation.js
+++ b/src/main/webapp/tests/mocks/models/mockValidation.js
@@ -1,0 +1,44 @@
+var dataValidation1 = {
+    id: 1,
+    message: "name validation pattern",
+    pattern: ".*"
+};
+
+var dataValidation2 = {
+    id: 2,
+    message: "email validation pattern",
+    pattern: "^([_A-Za-z0-9-\+]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9]+)*(\.[A-Za-z]{2,})|)$"
+};
+
+var dataValidation3 = {
+    id: 3,
+    message: "mock validation pattern",
+    pattern: "^mock$"
+};
+
+var dataValidation4 = {
+    id: 4,
+    message: "mock4 validation pattern",
+    pattern: "^mock4$"
+};
+
+var dataValidation5 = {
+    id: 5,
+    message: "mock digit validation pattern",
+    pattern: "^mock[0-9]+$"
+};
+
+var dataValidation6 = {
+    id: 6,
+    message: "mock optional digit validation pattern",
+    pattern: "^mock[0-9]*$"
+};
+
+var mockValidation = function($q) {
+    var model = mockModel("Validation", $q, dataValidation1);
+
+    return model;
+};
+
+angular.module('mock.validation', []).service('Validation', mockValidation);
+

--- a/src/main/webapp/tests/unit/controllers/abstractControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/abstractControllerTest.js
@@ -162,18 +162,21 @@ describe('controller: AbstractController', function () {
             expect(result).toBe(true);
         });
         it('reportError should report an error', function () {
-            var alert = {
-                channel: "test",
-                time: 0,
-                type: "",
-                message: ""
+            scope.closeModal();
+
+            scope.reportError({});
+            scope.$digest();
+
+            scope.closeModal();
+
+            RestApi.post = function () {
+                return failurePromise(q.defer(), {});
             };
 
-            spyOn(RestApi, "post").and.callThrough();
+            scope.reportError({});
+            scope.$digest();
 
-            scope.reportError(alert);
-
-            expect(RestApi.post).toHaveBeenCalled();
+            scope.closeModal();
         });
     });
 

--- a/src/main/webapp/tests/unit/controllers/abstractControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/abstractControllerTest.js
@@ -1,11 +1,12 @@
 describe('controller: AbstractController', function () {
 
-    var controller, scope, window, RestApi;
+    var controller, q, scope, window, RestApi;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, $window, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+            q = $q;
             scope = $rootScope.$new();
-            window = $window;
+            window = mockWindow();
 
             RestApi = _RestApi_;
 
@@ -14,7 +15,7 @@ describe('controller: AbstractController', function () {
 
             controller = $controller('AbstractController', {
                 $scope: scope,
-                $window: $window,
+                $window: window,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 StorageService: _StorageService_,

--- a/src/main/webapp/tests/unit/controllers/adminControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/adminControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: AdminController', function () {
     var controller, scope, location;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $rootScope, $window, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $location, $rootScope, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             location = $location;
             scope = $rootScope.$new();
 
@@ -13,7 +13,7 @@ describe('controller: AdminController', function () {
             controller = $controller('AdminController', {
                 $scope: scope,
                 $location: $location,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 StorageService: _StorageService_,

--- a/src/main/webapp/tests/unit/controllers/applicationAuthenticationControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/applicationAuthenticationControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: ApplicationAuthenticationController', function () {
     var controller, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $rootScope, $window, _ModalService_, _RestApi_, _StorageService_, _UserService_, _ValidationStore_, _WsApi_) {
+        inject(function ($controller, $location, $rootScope, _ModalService_, _RestApi_, _StorageService_, _UserService_, _ValidationStore_, _WsApi_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -12,7 +12,7 @@ describe('controller: ApplicationAuthenticationController', function () {
             controller = $controller('ApplicationAuthenticationController', {
                 $location: $location,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 StorageService: _StorageService_,

--- a/src/main/webapp/tests/unit/controllers/applicationSettingsControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/applicationSettingsControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: ApplicationSettingsController', function () {
     var controller, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, $window, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $rootScope, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -11,7 +11,7 @@ describe('controller: ApplicationSettingsController', function () {
 
             controller = $controller('ApplicationSettingsController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 SidebarService: _SidebarService_,

--- a/src/main/webapp/tests/unit/controllers/headerControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/headerControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: HeaderController', function () {
     var controller, location, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $rootScope, $timeout, $window, _AbstractRepo_, _AbstractAppRepo_, _AlertService_, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $location, $rootScope, $timeout, _AbstractRepo_, _AbstractAppRepo_, _AlertService_, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             location = $location;
             scope = $rootScope.$new();
 
@@ -14,7 +14,7 @@ describe('controller: HeaderController', function () {
                 $scope: scope,
                 $location: $location,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 AbstractRepo: _AbstractRepo_,
                 AbstractAppRepo: _AbstractAppRepo_,
                 AlertService: _AlertService_,

--- a/src/main/webapp/tests/unit/controllers/organizationSettingsControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/organizationSettingsControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: OrganizationSettingsController', function () {
     var controller, q, scope, AccordionService, OrganizationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _AccordionService_, _ModalService_, _OrganizationRepo_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _AccordionService_, _ModalService_, _OrganizationRepo_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: OrganizationSettingsController', function () {
 
             controller = $controller('OrganizationSettingsController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 AccordionService: _AccordionService_,
                 ModalService: _ModalService_,
                 OrganizationRepo: _OrganizationRepo_,

--- a/src/main/webapp/tests/unit/controllers/settings/controlledVocabularyRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/controlledVocabularyRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: ControlledVocabularyRepoController', function () {
     var controller, q, scope, ControlledVocabularyRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $timeout, $window, _ControlledVocabularyRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, $timeout, _ControlledVocabularyRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -16,7 +16,7 @@ describe('controller: ControlledVocabularyRepoController', function () {
                 $q: q,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 ControlledVocabularyRepo: _ControlledVocabularyRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/customActionSettingsControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/customActionSettingsControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: CustomActionSettingsController', function () {
     var controller, q, scope, CustomActionDefinitionRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $timeout, $window, _CustomActionDefinitionRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, $timeout, _CustomActionDefinitionRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -16,7 +16,7 @@ describe('controller: CustomActionSettingsController', function () {
                 $q: q,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 CustomActionDefinitionRepo: _CustomActionDefinitionRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/degreeRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/degreeRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: DegreeRepoController', function () {
     var controller, q, scope, DegreeRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DegreeRepo_, _DegreeLevelRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DegreeRepo_, _DegreeLevelRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: DegreeRepoController', function () {
             controller = $controller('DegreeRepoController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DegreeRepo: _DegreeRepo_,
                 DegreeLevelRepo: _DegreeLevelRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,

--- a/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: DepositLocationRepoController', function () {
     var controller, q, scope, DepositLocationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DepositLocationRepo_, _DragAndDropListenerFactory_, _ModalService_, _PackagerRepo_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DepositLocationRepo_, _DragAndDropListenerFactory_, _ModalService_, _PackagerRepo_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: DepositLocationRepoController', function () {
             controller = $controller('DepositLocationRepoController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DepositLocationRepo: _DepositLocationRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/documentTypesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/documentTypesControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: DocumentTypesController', function () {
     var controller, q, scope, DocumentTypeRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DocumentTypeRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DocumentTypeRepo_, _DragAndDropListenerFactory_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -14,7 +14,7 @@ describe('controller: DocumentTypesController', function () {
 
             controller = $controller('DocumentTypesController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DocumentTypeRepo: _DocumentTypeRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/emailTemplateRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/emailTemplateRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: EmailTemplateRepoController', function () {
     var controller, q, scope, EmailTemplateRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DragAndDropListenerFactory_, _EmailTemplateRepo_, _FieldPredicateRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DragAndDropListenerFactory_, _EmailTemplateRepo_, _FieldPredicateRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: EmailTemplateRepoController', function () {
             controller = $controller('EmailTemplateRepoController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 EmailTemplateRepo: _EmailTemplateRepo_,
                 FieldPredicateRepo: _FieldPredicateRepo_,

--- a/src/main/webapp/tests/unit/controllers/settings/emailWorkflowRulesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/emailWorkflowRulesControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: EmailWorkflowRulesController', function () {
     var controller, q, scope, OrganizationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _EmailTemplateRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _SubmissionStatusRepo_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _EmailTemplateRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _SubmissionStatusRepo_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: EmailWorkflowRulesController', function () {
             controller = $controller('EmailWorkflowRulesController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 EmailTemplateRepo: _EmailTemplateRepo_,
                 ModalService: _ModalService_,
                 OrganizationRepo: _OrganizationRepo_,
@@ -123,7 +123,7 @@ describe('controller: EmailWorkflowRulesController', function () {
             scope.$digest();
 
             scope.buildRecipients();
-            
+
             expect(typeof scope.recipients).toBe("object");
         });
         it('cancelDeleteEmailWorkflowRule should close a modal', function () {

--- a/src/main/webapp/tests/unit/controllers/settings/embargoRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/embargoRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: EmbargoRepoController', function () {
     var controller, q, scope, EmbargoRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $filter, $q, $rootScope, $window, _DragAndDropListenerFactory_, _EmbargoRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $filter, $q, $rootScope, _DragAndDropListenerFactory_, _EmbargoRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -16,7 +16,7 @@ describe('controller: EmbargoRepoController', function () {
                 $filter: $filter,
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 EmbargoRepo: _EmbargoRepo_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/fieldPredicatesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/fieldPredicatesControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: FieldPredicatesController', function () {
     var controller, q, scope, FieldPredicateRepo;
 
     var initializeController = function(settings) {
-        inject(function ($filter, $q, $controller, $rootScope, $timeout, $window, _DragAndDropListenerFactory_, _FieldPredicateRepo_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
+        inject(function ($filter, $q, $controller, $rootScope, $timeout, _DragAndDropListenerFactory_, _FieldPredicateRepo_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -17,7 +17,7 @@ describe('controller: FieldPredicatesController', function () {
                 $q: q,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 FieldPredicateRepo: _FieldPredicateRepo_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/fieldProfileManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/fieldProfileManagementControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: FieldProfileManagementController', function () {
     var controller, q, scope, FieldPredicateRepo, FieldProfileRepo, WorkflowStepRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $filter, $q, $rootScope, $window, _ControlledVocabularyRepo_, _DocumentTypeRepo_, _DragAndDropListenerFactory_, _FieldPredicateRepo_, _FieldProfileRepo_, _InputTypeRepo_, _ManagedConfigurationRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
+        inject(function ($controller, $filter, $q, $rootScope, _ControlledVocabularyRepo_, _DocumentTypeRepo_, _DragAndDropListenerFactory_, _FieldPredicateRepo_, _FieldProfileRepo_, _InputTypeRepo_, _ManagedConfigurationRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -23,7 +23,7 @@ describe('controller: FieldProfileManagementController', function () {
                 $filter: $filter,
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ControlledVocabularyRepo: _ControlledVocabularyRepo_,
                 DocumentTypeRepo: _DocumentTypeRepo_,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,

--- a/src/main/webapp/tests/unit/controllers/settings/graduationMonthRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/graduationMonthRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: GraduationMonthRepoController', function () {
     var controller, q, scope, GraduationMonthRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DragAndDropListenerFactory_, _GraduationMonthRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DragAndDropListenerFactory_, _GraduationMonthRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -14,7 +14,7 @@ describe('controller: GraduationMonthRepoController', function () {
 
             controller = $controller('GraduationMonthRepoController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 GraduationMonthRepo: _GraduationMonthRepo_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/languagesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/languagesControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: LanguagesController', function () {
     var controller, q, scope, LanguageRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $timeout, $window, _DragAndDropListenerFactory_, _LanguageRepo_, _StorageService_, _ModalService_, _RestApi_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, $timeout, _DragAndDropListenerFactory_, _LanguageRepo_, _StorageService_, _ModalService_, _RestApi_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -16,7 +16,7 @@ describe('controller: LanguagesController', function () {
                 $q: q,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 LanguageRepo: _LanguageRepo_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settings/lookAndFeelControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/lookAndFeelControllerTest.js
@@ -3,10 +3,10 @@ describe('controller: LookAndFeelController', function () {
     var controller, q, scope, window;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _FileService_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _FileService_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
-            window = $window;
+            window = mockWindow();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
@@ -28,7 +28,7 @@ describe('controller: LookAndFeelController', function () {
             controller = $controller('LookAndFeelController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: window,
                 FileService: _FileService_,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
@@ -84,6 +84,7 @@ describe('controller: LookAndFeelController', function () {
                 readAsDataURL: mockReadAsDataURL
             };
 
+            window.FileReader = function() {};
             spyOn(window, "FileReader").and.returnValue(mockFileReader)
             spyOn(angular, "element").and.callThrough();
 

--- a/src/main/webapp/tests/unit/controllers/settings/noteManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/noteManagementControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: NoteManagementController', function () {
     var controller, q, scope, NoteRepo, WorkflowStepRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DragAndDropListenerFactory_, _ModalService_, _NoteRepo_, _OrganizationRepo_, _RestApi_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DragAndDropListenerFactory_, _ModalService_, _NoteRepo_, _OrganizationRepo_, _RestApi_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -18,7 +18,7 @@ describe('controller: NoteManagementController', function () {
 
             controller = $controller('NoteManagementController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,
                 Note: mockParameterModel(q, mockNote),

--- a/src/main/webapp/tests/unit/controllers/settings/organizationCategoriesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/organizationCategoriesControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: OrganizationCategoriesController', function () {
     var controller, q, scope, OrganizationCategoryRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _DragAndDropListenerFactory_, _ModalService_, _OrganizationCategoryRepo_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _DragAndDropListenerFactory_, _ModalService_, _OrganizationCategoryRepo_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: OrganizationCategoriesController', function () {
             controller = $controller('OrganizationCategoriesController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,
                 OrganizationCategoryRepo: _OrganizationCategoryRepo_,

--- a/src/main/webapp/tests/unit/controllers/settings/organizationManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/organizationManagementControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: OrganizationManagementController', function () {
     var controller, q, scope, timeout, AccordionService, AlertService, OrganizationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $q, $rootScope, $route, $timeout, $window, _AccordionService_, _AlertService_, _ModalService_, _OrganizationRepo_, _RestApi_, _SidebarService_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
+        inject(function ($controller, $location, $q, $rootScope, $route, $timeout, _AccordionService_, _AlertService_, _ModalService_, _OrganizationRepo_, _RestApi_, _SidebarService_, _StorageService_, _WorkflowStepRepo_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
             timeout = $timeout;
@@ -19,7 +19,7 @@ describe('controller: OrganizationManagementController', function () {
             // This results in having additional methods on the scope that OrganizationManagementController requires.
             $controller('OrganizationSettingsController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 AccordionService: _AccordionService_,
                 ModalService: _ModalService_,
                 OrganizationRepo: _OrganizationRepo_,
@@ -35,7 +35,7 @@ describe('controller: OrganizationManagementController', function () {
                 $route: $route,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 AccordionService: _AccordionService_,
                 AlertService: _AlertService_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/settingsControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settingsControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: SettingsController', function () {
     var controller, q, scope, timeout, StudentSubmissionRepo, SubmissionStates;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $injector, $q, $rootScope, $timeout, $window, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _SubmissionStates_, _UserService_, _WsApi_) {
+        inject(function ($controller, $injector, $q, $rootScope, $timeout, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _SubmissionStates_, _UserService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
             timeout = $timeout;
@@ -18,7 +18,7 @@ describe('controller: SettingsController', function () {
                 $scope: scope,
                 $injector: $injector,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 ManagedConfigurationRepo: _ManagedConfigurationRepo_,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,

--- a/src/main/webapp/tests/unit/controllers/sidebar/organizationSideBarControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/sidebar/organizationSideBarControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: OrganizationSideBarController', function () {
     var controller, q, scope, OrganizationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _ModalService_, _OrganizationCategoryRepo_, _OrganizationRepo_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _ModalService_, _OrganizationCategoryRepo_, _OrganizationRepo_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -15,7 +15,7 @@ describe('controller: OrganizationSideBarController', function () {
             controller = $controller('OrganizationSideBarController', {
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 OrganizationCategoryRepo: _OrganizationCategoryRepo_,
                 OrganizationRepo: _OrganizationRepo_,

--- a/src/main/webapp/tests/unit/controllers/sidebarControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/sidebarControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: SidebarController', function () {
     var controller, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, $window, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $rootScope, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -11,7 +11,7 @@ describe('controller: SidebarController', function () {
 
             controller = $controller('SidebarController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 SidebarService: _SidebarService_,

--- a/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: AdminSubmissionViewController', function () {
     var controller, q, scope, FileUploadService;
 
     var initializeController = function(settings) {
-        inject(function ($anchorScroll, $controller, $location, $q, $route, $routeParams, $rootScope, $window, _DepositLocationRepo_, _EmailTemplateRepo_, _FieldPredicateRepo_, _FieldValue_, _FileUploadService_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _UserService_, _WsApi_) {
+        inject(function ($anchorScroll, $controller, $location, $q, $route, $routeParams, $rootScope, $window, _DepositLocationRepo_, _EmailRecipient_, _EmailTemplateRepo_, _FieldPredicateRepo_, _FieldValue_, _FileUploadService_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _UserService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -20,6 +20,7 @@ describe('controller: AdminSubmissionViewController', function () {
                 $scope: scope,
                 $window: $window,
                 DepositLocationRepo: _DepositLocationRepo_,
+                EmailRecipient: _EmailRecipient_,
                 EmailTemplateRepo: _EmailTemplateRepo_,
                 FieldPredicateRepo: _FieldPredicateRepo_,
                 FieldValue: mockParameterModel(q, mockFieldValue),
@@ -47,6 +48,7 @@ describe('controller: AdminSubmissionViewController', function () {
         module('core');
         module('vireo');
         module('mock.depositLocationRepo');
+        module('mock.emailRecipient');
         module('mock.emailTemplateRepo');
         module('mock.fieldPredicateRepo');
         module('mock.fieldValue');
@@ -227,7 +229,7 @@ describe('controller: AdminSubmissionViewController', function () {
         it('addEmailAddressee should update the destination', function () {
             var mockEmails = { push: jasmine.createSpy() };
             var mockFormField =  {
-              $$rawModelValue: {}, 
+              $$rawModelValue: {},
               $$attr: {name:""}
             };
 

--- a/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: AdminSubmissionViewController', function () {
     var controller, q, scope, FileUploadService;
 
     var initializeController = function(settings) {
-        inject(function ($anchorScroll, $controller, $location, $q, $route, $routeParams, $rootScope, $window, _DepositLocationRepo_, _EmailRecipient_, _EmailTemplateRepo_, _FieldPredicateRepo_, _FieldValue_, _FileUploadService_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _UserService_, _WsApi_) {
+        inject(function ($anchorScroll, $controller, $location, $q, $route, $routeParams, $rootScope, _DepositLocationRepo_, _EmailRecipient_, _EmailTemplateRepo_, _FieldPredicateRepo_, _FieldValue_, _FileUploadService_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _UserService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -18,7 +18,7 @@ describe('controller: AdminSubmissionViewController', function () {
                 $route: $route,
                 $routeParams: $routeParams,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 DepositLocationRepo: _DepositLocationRepo_,
                 EmailRecipient: _EmailRecipient_,
                 EmailTemplateRepo: _EmailTemplateRepo_,

--- a/src/main/webapp/tests/unit/controllers/submission/advisorSubmissionReviewControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/advisorSubmissionReviewControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: AdvisorSubmissionReviewController', function () {
     var controller, q, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $window, _AdvisorSubmissionRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, _AdvisorSubmissionRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -12,7 +12,7 @@ describe('controller: AdvisorSubmissionReviewController', function () {
 
             controller = $controller('AdvisorSubmissionReviewController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 AdvisorSubmissionRepo: _AdvisorSubmissionRepo_,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,

--- a/src/main/webapp/tests/unit/controllers/submission/completeSubmissionControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/completeSubmissionControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: CompleteSubmissionController', function () {
     var controller, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, $window, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $rootScope, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _WsApi_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -11,7 +11,7 @@ describe('controller: CompleteSubmissionController', function () {
 
             controller = $controller('CompleteSubmissionController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ManagedConfigurationRepo: _ManagedConfigurationRepo_,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,

--- a/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: NewSubmissionController', function () {
     var controller, location, q, scope, OrganizationRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $q, $rootScope, $window, SubmissionStates, _ManagedConfigurationRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
+        inject(function ($controller, $location, $q, $rootScope, SubmissionStates, _ManagedConfigurationRepo_, _ModalService_, _OrganizationRepo_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
             location = $location;
             q = $q;
             scope = $rootScope.$new();
@@ -17,7 +17,7 @@ describe('controller: NewSubmissionController', function () {
                 $location: $location,
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 SubmissionStates: SubmissionStates,
                 ManagedConfigurationRepo: _ManagedConfigurationRepo_,
                 ModalService: _ModalService_,

--- a/src/main/webapp/tests/unit/controllers/submission/studentSubmissionControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/studentSubmissionControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: StudentSubmissionController', function () {
     var controller, q, location, routeParams, scope, timeout;
 
     var initializeController = function(settings) {
-        inject(function ($anchorScroll, $controller, $location, $q, $rootScope, $routeParams, $timeout, $window, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
+        inject(function ($anchorScroll, $controller, $location, $q, $rootScope, $routeParams, $timeout, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
             location = $location;
             q = $q;
             routeParams = $routeParams;
@@ -23,7 +23,7 @@ describe('controller: StudentSubmissionController', function () {
                 $routeParams: $routeParams,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 ManagedConfigurationRepo: _ManagedConfigurationRepo_,
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,

--- a/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: SubmissionHistoryController', function () {
     var controller, location, q, scope, timeout, NgTableParams;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $q, $rootScope, $timeout, $window, SubmissionStates, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
+        inject(function ($controller, $location, $q, $rootScope, $timeout, SubmissionStates, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _WsApi_) {
             location = $location;
             q = $q;
             scope = $rootScope.$new();
@@ -16,7 +16,7 @@ describe('controller: SubmissionHistoryController', function () {
                 $location: $location,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 SubmissionStates: SubmissionStates,
                 ModalService: _ModalService_,
                 NgTableParams: mockNgTableParams,

--- a/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
@@ -1,18 +1,19 @@
 describe('controller: SubmissionListController', function () {
 
-    var controller, location, q, scope, ManagerFilterColumnRepo, SavedFilterRepo;
+    var controller, location, q, scope, ManagerFilterColumnRepo, SavedFilterRepo, SubmissionRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $filter, $location, $q, $rootScope, $window, _ControlledVocabularyRepo_, _CustomActionDefinitionRepo_, _CustomActionValueRepo_, _DepositLocationRepo_, _DocumentTypeRepo_, _EmailTemplateRepo_, _EmbargoRepo_, _ManagerFilterColumnRepo_, _ManagerSubmissionListColumnRepo_, _ModalService_, _OrganizationCategory_, _OrganizationCategoryRepo_, _Organization_, _OrganizationRepo_, _Packager_, _PackagerRepo_, _RestApi_, _SavedFilterRepo_, _SidebarService_, _StorageService_, _SubmissionListColumnRepo_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _WsApi_) {
+        inject(function ($controller, $filter, $location, $q, $rootScope, $window, _ControlledVocabularyRepo_, _CustomActionDefinitionRepo_, _CustomActionValueRepo_, _DepositLocationRepo_, _DocumentTypeRepo_, _EmailRecipient_, _EmailTemplateRepo_, _EmbargoRepo_, _ManagerFilterColumnRepo_, _ManagerSubmissionListColumnRepo_, _ModalService_, _OrganizationCategory_, _OrganizationCategoryRepo_, _Organization_, _OrganizationRepo_, _Packager_, _PackagerRepo_, _RestApi_, _SavedFilterRepo_, _SidebarService_, _StorageService_, _SubmissionListColumnRepo_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _WsApi_) {
             location = $location;
             q = $q;
-            scope = $rootScope.$new()
+            scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
 
             ManagerFilterColumnRepo = _ManagerFilterColumnRepo_;
             SavedFilterRepo = _SavedFilterRepo_;
+            SubmissionRepo = _SubmissionRepo_;
 
             controller = $controller('SubmissionListController', {
                 $filter: $filter,
@@ -25,6 +26,7 @@ describe('controller: SubmissionListController', function () {
                 CustomActionValueRepo: _CustomActionValueRepo_,
                 DepositLocationRepo: _DepositLocationRepo_,
                 DocumentTypeRepo: _DocumentTypeRepo_,
+                EmailRecipient: mockParameterModel(q, mockEmailRecipient),
                 EmailTemplateRepo: _EmailTemplateRepo_,
                 EmbargoRepo: _EmbargoRepo_,
                 ManagerFilterColumnRepo: _ManagerFilterColumnRepo_,
@@ -67,14 +69,18 @@ describe('controller: SubmissionListController', function () {
         module('mock.depositLocationRepo');
         module('mock.documentType');
         module('mock.documentTypeRepo');
+        module('mock.emailRecipient');
         module('mock.emailTemplate');
         module('mock.emailTemplateRepo');
         module('mock.embargo');
         module('mock.embargoRepo');
         module('mock.fieldProfile');
+        module('mock.filterCriterion');
+        module('mock.inputType');
         module('mock.managerFilterColumnRepo');
         module('mock.managerSubmissionListColumnRepo');
         module('mock.modalService');
+        module('mock.namedSearchFilter');
         module('mock.namedSearchFilterGroup');
         module('mock.ngTableParams');
         module('mock.organizationCategory');
@@ -96,6 +102,7 @@ describe('controller: SubmissionListController', function () {
         module('mock.submissionStatusRepo');
         module('mock.userRepo');
         module('mock.userSettings');
+        module('mock.validation');
         module('mock.wsApi');
 
         installPromiseMatchers();
@@ -208,6 +215,72 @@ describe('controller: SubmissionListController', function () {
         it('viewSubmission should be defined', function () {
             expect(scope.viewSubmission).toBeDefined();
             expect(typeof scope.viewSubmission).toEqual("function");
+        });
+    });
+
+    describe('Are the scope.furtherFilterBy methods defined', function () {
+        it('addFilter should be defined', function () {
+            expect(scope.furtherFilterBy.addFilter).toBeDefined();
+            expect(typeof scope.furtherFilterBy.addFilter).toEqual("function");
+        });
+        it('addExactMatchFilter should be defined', function () {
+            expect(scope.furtherFilterBy.addExactMatchFilter).toBeDefined();
+            expect(typeof scope.furtherFilterBy.addExactMatchFilter).toEqual("function");
+        });
+        it('addDateFilter should be defined', function () {
+            expect(scope.furtherFilterBy.addDateFilter).toBeDefined();
+            expect(typeof scope.furtherFilterBy.addDateFilter).toEqual("function");
+        });
+        it('getTypeAheadByPredicateName should be defined', function () {
+            expect(scope.furtherFilterBy.getTypeAheadByPredicateName).toBeDefined();
+            expect(typeof scope.furtherFilterBy.getTypeAheadByPredicateName).toEqual("function");
+        });
+    });
+
+    describe('Are the scope.advancedfeaturesBox methods defined', function () {
+        it('getFiltersWithColumns should be defined', function () {
+            expect(scope.advancedfeaturesBox.getFiltersWithColumns).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.getFiltersWithColumns).toEqual("function");
+        });
+        it('getFiltersWithoutColumns should be defined', function () {
+            expect(scope.advancedfeaturesBox.getFiltersWithoutColumns).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.getFiltersWithoutColumns).toEqual("function");
+        });
+        it('resetBatchProcess should be defined', function () {
+            expect(scope.advancedfeaturesBox.resetBatchProcess).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.resetBatchProcess).toEqual("function");
+        });
+        it('batchUpdateStatus should be defined', function () {
+            expect(scope.advancedfeaturesBox.batchUpdateStatus).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.batchUpdateStatus).toEqual("function");
+        });
+        it('batchAssignTo should be defined', function () {
+            expect(scope.advancedfeaturesBox.batchAssignTo).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.batchAssignTo).toEqual("function");
+        });
+        it('batchPublish should be defined', function () {
+            expect(scope.advancedfeaturesBox.batchPublish).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.batchPublish).toEqual("function");
+        });
+        it('resetBatchCommentEmailModal should be defined', function () {
+            expect(scope.advancedfeaturesBox.resetBatchCommentEmailModal).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.resetBatchCommentEmailModal).toEqual("function");
+        });
+        it('resetBatchCommentEmailModal should be defined', function () {
+            expect(scope.advancedfeaturesBox.resetBatchCommentEmailModal).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.resetBatchCommentEmailModal).toEqual("function");
+        });
+        it('addBatchCommentEmail should be defined', function () {
+            expect(scope.advancedfeaturesBox.addBatchCommentEmail).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.addBatchCommentEmail).toEqual("function");
+        });
+        it('updateTemplate should be defined', function () {
+            expect(scope.advancedfeaturesBox.updateTemplate).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.updateTemplate).toEqual("function");
+        });
+        it('batchDownloadExport should be defined', function () {
+            expect(scope.advancedfeaturesBox.batchDownloadExport).toBeDefined();
+            expect(typeof scope.advancedfeaturesBox.batchDownloadExport).toEqual("function");
         });
     });
 
@@ -452,5 +525,114 @@ describe('controller: SubmissionListController', function () {
 
             expect(location.path).toHaveBeenCalled();
         });
+    });
+
+    describe('Do the scope.furtherFilterBy methods work as expected', function () {
+        it('addFilter should add a filter', function () {
+            var mockColumn = new mockSubmissionListColumn(q);
+            scope.furtherFilterBy[mockColumn.title.split(" ").join("")] = {
+                d1: new Date(),
+                d2: new Date()
+            };
+            scope.furtherFilterBy.addFilter(mockColumn, "gloss");
+        });
+        it('addExactMatchFilter should filter by', function () {
+            var mockColumn = new mockSubmissionListColumn(q);
+            scope.furtherFilterBy[mockColumn.title.split(" ").join("")] = {
+                d1: new Date(),
+                d2: new Date()
+            };
+            scope.furtherFilterBy.addExactMatchFilter(mockColumn, "gloss");
+        });
+        it('addDateFilter should add a date filter', function () {
+            var mockColumn = new mockSubmissionListColumn(q);
+            scope.furtherFilterBy[mockColumn.title.split(" ").join("")] = {
+                d1: new Date(),
+                d2: new Date()
+            };
+            scope.furtherFilterBy.addDateFilter(mockColumn);
+        });
+        it('getTypeAheadByPredicateName should perform type ahead', function () {
+            scope.furtherFilterBy.getTypeAheadByPredicateName("predicate value");
+        });
+    });
+
+    describe('Do the scope.advancedfeaturesBox methods work as expected', function () {
+        // TODO: more work needed for this method.
+        /*
+        it('getFiltersWithColumns should return filters', function () {
+            scope.advancedfeaturesBox.getFiltersWithColumns();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('getFiltersWithColumns should return filters', function () {
+            scope.advancedfeaturesBox.getFiltersWithColumns();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('getFiltersWithoutColumns should return filters', function () {
+            scope.advancedfeaturesBox.getFiltersWithoutColumns();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('resetBatchProcess should reset the batch process', function () {
+            scope.advancedfeaturesBox.resetBatchProcess();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('batchUpdateStatus should update the batch', function () {
+            scope.advancedfeaturesBox.batchUpdateStatus();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('batchAssignTo should assign the batch', function () {
+            scope.advancedfeaturesBox.batchAssignTo();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('batchPublish should publish the batch', function () {
+            scope.advancedfeaturesBox.batchPublish();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('resetBatchCommentEmailModal should open a modal', function () {
+            scope.advancedfeaturesBox.resetBatchCommentEmailModal();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('resetBatchCommentEmailModal should open a modal', function () {
+            scope.advancedfeaturesBox.resetBatchCommentEmailModal();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('addBatchCommentEmail should add a comment', function () {
+            scope.advancedfeaturesBox.addBatchCommentEmail();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('updateTemplate should update the template', function () {
+            scope.advancedfeaturesBox.updateTemplate();
+        });
+        */
+        // TODO: more work needed for this method.
+        /*
+        it('batchDownloadExport should perform a download', function () {
+            spyOn(SubmissionRepo, "batchExport");
+
+            scope.advancedfeaturesBox.batchDownloadExport();
+
+            expect(SubmissionRepo.batchExport).toHaveBeenCalled();
+        });
+        */
     });
 });

--- a/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
@@ -535,6 +535,7 @@ describe('controller: SubmissionListController', function () {
                 d2: new Date()
             };
             scope.furtherFilterBy.addFilter(mockColumn, "gloss");
+            scope.$digest();
         });
         it('addExactMatchFilter should filter by', function () {
             var mockColumn = new mockSubmissionListColumn(q);
@@ -543,6 +544,7 @@ describe('controller: SubmissionListController', function () {
                 d2: new Date()
             };
             scope.furtherFilterBy.addExactMatchFilter(mockColumn, "gloss");
+            scope.$digest();
         });
         it('addDateFilter should add a date filter', function () {
             var mockColumn = new mockSubmissionListColumn(q);
@@ -551,6 +553,7 @@ describe('controller: SubmissionListController', function () {
                 d2: new Date()
             };
             scope.furtherFilterBy.addDateFilter(mockColumn);
+            scope.$digest();
         });
         it('getTypeAheadByPredicateName should perform type ahead', function () {
             scope.furtherFilterBy.getTypeAheadByPredicateName("predicate value");

--- a/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: SubmissionListController', function () {
     var controller, location, q, scope, ManagerFilterColumnRepo, SavedFilterRepo, SubmissionRepo;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $filter, $location, $q, $rootScope, $window, _ControlledVocabularyRepo_, _CustomActionDefinitionRepo_, _CustomActionValueRepo_, _DepositLocationRepo_, _DocumentTypeRepo_, _EmailRecipient_, _EmailTemplateRepo_, _EmbargoRepo_, _ManagerFilterColumnRepo_, _ManagerSubmissionListColumnRepo_, _ModalService_, _OrganizationCategory_, _OrganizationCategoryRepo_, _Organization_, _OrganizationRepo_, _Packager_, _PackagerRepo_, _RestApi_, _SavedFilterRepo_, _SidebarService_, _StorageService_, _SubmissionListColumnRepo_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _WsApi_) {
+        inject(function ($controller, $filter, $location, $q, $rootScope, _ControlledVocabularyRepo_, _CustomActionDefinitionRepo_, _CustomActionValueRepo_, _DepositLocationRepo_, _DocumentTypeRepo_, _EmailRecipient_, _EmailTemplateRepo_, _EmbargoRepo_, _ManagerFilterColumnRepo_, _ManagerSubmissionListColumnRepo_, _ModalService_, _OrganizationCategory_, _OrganizationCategoryRepo_, _Organization_, _OrganizationRepo_, _Packager_, _PackagerRepo_, _RestApi_, _SavedFilterRepo_, _SidebarService_, _StorageService_, _SubmissionListColumnRepo_, _SubmissionRepo_, _SubmissionStatusRepo_, _UserRepo_, _WsApi_) {
             location = $location;
             q = $q;
             scope = $rootScope.$new();
@@ -20,7 +20,7 @@ describe('controller: SubmissionListController', function () {
                 $location: $location,
                 $q: q,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ControlledVocabularyRepo: _ControlledVocabularyRepo_,
                 CustomActionDefinitionRepo: _CustomActionDefinitionRepo_,
                 CustomActionValueRepo: _CustomActionValueRepo_,

--- a/src/main/webapp/tests/unit/controllers/submission/submissionViewControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionViewControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: SubmissionViewController', function () {
     var controller, q, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $q, $rootScope, $routeParams, $window, _CustomActionDefinitionRepo_, _FieldPredicateRepo_, _FileUploadService_, _ModalService_, _StorageService_, _RestApi_, _StudentSubmission_, _StudentSubmissionRepo_, _WsApi_) {
+        inject(function ($controller, $q, $rootScope, $routeParams, _CustomActionDefinitionRepo_, _FieldPredicateRepo_, _FileUploadService_, _ModalService_, _StorageService_, _RestApi_, _StudentSubmission_, _StudentSubmissionRepo_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -14,7 +14,7 @@ describe('controller: SubmissionViewController', function () {
                 $q: q,
                 $routeParams: $routeParams,
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 CustomActionDefinitionRepo: _CustomActionDefinitionRepo_,
                 FieldPredicateRepo: _FieldPredicateRepo_,
                 FileUploadService: _FileUploadService_,

--- a/src/main/webapp/tests/unit/controllers/userRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/userRepoControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: UserRepoController', function () {
     var controller, q, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $route, $q, $rootScope, $timeout, $window, _ModalService_, _RestApi_, _StorageService_, _UserRepo_, _UserService_, _WsApi_) {
+        inject(function ($controller, $location, $route, $q, $rootScope, $timeout, _ModalService_, _RestApi_, _StorageService_, _UserRepo_, _UserService_, _WsApi_) {
             q = $q;
             scope = $rootScope.$new();
 
@@ -16,7 +16,7 @@ describe('controller: UserRepoController', function () {
                 $route: $route,
                 $scope: scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 StorageService: _StorageService_,

--- a/src/main/webapp/tests/unit/controllers/workflowManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/workflowManagementControllerTest.js
@@ -3,7 +3,7 @@ describe('controller: WorkflowManagementController', function () {
     var controller, scope;
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, $window, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
+        inject(function ($controller, $rootScope, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _WsApi_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -11,7 +11,7 @@ describe('controller: WorkflowManagementController', function () {
 
             controller = $controller('WorkflowManagementController', {
                 $scope: scope,
-                $window: $window,
+                $window: mockWindow(),
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 SidebarService: _SidebarService_,


### PR DESCRIPTION
Use weaver's openModal() method for opening the modal
    
There is a secondary bug in weaver that prevents the close button from being clicked.
When the address defined in the configuration `reporting.address` is unreachable (or otherwise fails), the close button does not work.
This secondary error is resolved in the PR: TAMULib/Weaver-UI-Core#142.
 
This depends on PR #1249 for relevant test improvements.

Resolves #1157