### PR TITLE
[907] Submission Repo SQL builder needs to account for order of operations in OR and AND for SQL.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -433,6 +433,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
         StringBuilder sqlOrderBysBuilder = new StringBuilder();
 
         ArrayList<StringBuilder> sqlWhereBuilderList;
+        ArrayList<StringBuilder> sqlAllColumnsWhereBuilderList = new ArrayList<StringBuilder>();
 
         int n = 0;
 
@@ -519,7 +520,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(pfv").append(n).append(".value) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     n++;
@@ -565,7 +566,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(ss").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -598,7 +599,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(o").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -631,7 +632,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(oc").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -662,7 +663,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -699,7 +700,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : allColumnSearchFilters) {
                         sqlWhereBuilder = new StringBuilder();
                         sqlWhereBuilder.append("LOWER(embs").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
-                        sqlWhereBuilderList.add(sqlWhereBuilder);
+                        sqlAllColumnsWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -836,13 +837,26 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
         // build WHERE query such that OR is used for conditions inside a column and AND is used across each different column.
         sqlWhereBuilder = new StringBuilder();
-        if (sqlColumnsBuilders.size() > 0 || sqlWheresExcludeBuilder.length() > 0) {
+        if (sqlColumnsBuilders.size() > 0 || sqlAllColumnsWhereBuilderList.size() > 0 || sqlWheresExcludeBuilder.length() > 0) {
             sqlWhereBuilder.append("\nWHERE ");
 
             for (Entry<Long, ArrayList<StringBuilder>> list : sqlColumnsBuilders.entrySet()) {
                 sqlWhereBuilder.append("(");
 
                 for (StringBuilder builder : list.getValue()) {
+                    sqlWhereBuilder.append("(").append(builder).append(") OR ");
+                }
+
+                // remove last " OR".
+                sqlWhereBuilder.setLength(sqlWhereBuilder.length() - 4);
+
+                sqlWhereBuilder.append(") AND ");
+            }
+
+            if (sqlAllColumnsWhereBuilderList.size() > 0) {
+                sqlWhereBuilder.append("(");
+
+                for (StringBuilder builder : sqlAllColumnsWhereBuilderList) {
                     sqlWhereBuilder.append("(").append(builder).append(") OR ");
                 }
 

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -13,8 +13,11 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
@@ -422,16 +425,25 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
         StringBuilder sqlCountSelectBuilder = new StringBuilder("SELECT COUNT(DISTINCT s.id) FROM submission s ");
 
+        Map<Long, ArrayList<StringBuilder>> sqlColumnsBuilders = new HashMap<Long, ArrayList<StringBuilder>>();
+
         StringBuilder sqlJoinsBuilder = new StringBuilder();
-        StringBuilder sqlWheresBuilder = new StringBuilder();
+        StringBuilder sqlWhereBuilder;
         StringBuilder sqlWheresExcludeBuilder = new StringBuilder();
         StringBuilder sqlOrderBysBuilder = new StringBuilder();
+
+        ArrayList<StringBuilder> sqlWhereBuilderList;
 
         int n = 0;
 
         for (SubmissionListColumn submissionListColumn : allSubmissionListColumns) {
 
             if (submissionListColumn.getSortOrder() > 0 || submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0 || submissionListColumn.getVisible()) {
+                if (sqlColumnsBuilders.containsKey(submissionListColumn.getId())) {
+                    sqlWhereBuilderList = sqlColumnsBuilders.get(submissionListColumn.getId());
+                } else {
+                    sqlWhereBuilderList = new ArrayList<StringBuilder>();
+                }
 
                 switch (String.join(".", submissionListColumn.getValuePath())) {
                 case "fieldValues.value":
@@ -452,12 +464,13 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
 
                         switch (submissionListColumn.getInputType().getName()) {
                         case "INPUT_DEGREEDATE":
                             // Column's values are of type datetime
                             filterString.replaceAll("[TZ:.\\-]", " ");
-                            sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
+                            sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
                             break;
                         case "INPUT_DATETIME":
                             // Column's values are of type datetime
@@ -467,46 +480,48 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                                 dates[0] = dates[0].replaceAll("[TZ:.\\-]", " ");
                                 dates[1] = dates[1].replaceAll("[TZ:.\\-]", " ");
 
-                                sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) BETWEEN to_timestamp('").append(dates[0]).append("', \'YYYY MM DD HH MI SS MS') AND to_timestamp('").append(dates[1]).append("', \'YYYY MM DD HH MI SS MS')) OR");
+                                sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) BETWEEN to_timestamp('").append(dates[0]).append("', \'YYYY MM DD HH MI SS MS') AND to_timestamp('").append(dates[1]).append("', \'YYYY MM DD HH MI SS MS')");
                             } else {
                                 // Date Match
                                 filterString.replaceAll("[TZ:.\\-]", " ");
-                                sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
+                                sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
                             }
                             break;
                         case "INPUT_CHECKBOX":
+                            sqlWhereBuilder.append("pfv").append(n).append(".value = '").append(filterString).append("'");
+
                             // Column's values are a boolean
-                            if (Boolean.valueOf(filterString)) {
-                                sqlWheresBuilder.append(" pfv").append(n).append(".value = '").append(filterString).append("' OR");
-                            } else {
-                                sqlWheresBuilder.append(" pfv").append(n).append(".value = '").append(filterString).append("' OR").append(" pfv").append(n).append(".value IS NULL ").append(" OR");
+                            if (!Boolean.valueOf(filterString)) {
+                                sqlWhereBuilderList.add(sqlWhereBuilder);
+                                sqlWhereBuilder = new StringBuilder();
+
+                                sqlWhereBuilder.append(" pfv").append(n).append(".value IS NULL");
                             }
                             break;
                         default:
                             // Column's values can be handled by this default
                             if (submissionListColumn.getExactMatch()) {
                                 // perform exact match
-                                sqlWheresBuilder.append(" pfv").append(n).append(".value = '").append(filterString).append("' OR");
+                                sqlWhereBuilder.append("pfv").append(n).append(".value = '").append(filterString).append("'");
                             } else {
                                 // perform like when input from text field
-                                sqlWheresBuilder.append(" LOWER(pfv").append(n).append(".value) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                                sqlWhereBuilder.append("LOWER(pfv").append(n).append(".value) LIKE '%").append(filterString.toLowerCase()).append("%'");
                             }
                             break;
                         }
 
+                        if (sqlWhereBuilder.length() > 0) {
+                            sqlWhereBuilderList.add(sqlWhereBuilder);
+                        }
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(pfv").append(n).append(".value) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(pfv").append(n).append(".value) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
-                    
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
-                    }
-                    
+
                     n++;
 
                     break;
@@ -518,13 +533,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
-                        sqlWheresBuilder.append(" s").append(".id = ").append(filterString).append(" OR");
-                    }
-                    
-                    if(submissionListColumn.getFilters().size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("s").append(".id = ").append(filterString);
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -538,26 +549,24 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
+
                         if (submissionListColumn.getExactMatch()) {
-                            sqlWheresBuilder.append(" ss").append(".name = '").append(filterString).append("' OR");
+                            sqlWhereBuilder.append("ss").append(".name = '").append(filterString).append("'");
                         } else {
                             // TODO: determine if status will ever be search using a like
-                            sqlWheresBuilder.append(" LOWER(ss").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                            sqlWhereBuilder.append("LOWER(ss").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
                         }
 
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(ss").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(ss").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
-                    
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
-                    }
-
 
                     break;
 
@@ -572,24 +581,24 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
+
                         if (submissionListColumn.getExactMatch()) {
-                            sqlWheresBuilder.append(" o").append(".name = '").append(filterString).append("' OR");
+                            sqlWhereBuilder.append("o").append(".name = '").append(filterString).append("'");
                         } else {
                             // TODO: determine if organization name will ever be
                             // search using a like
-                            sqlWheresBuilder.append(" LOWER(o").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                            sqlWhereBuilder.append("LOWER(o").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
                         }
+
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(o").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
-                    }
-                    
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(o").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -606,24 +615,23 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
                         if (submissionListColumn.getExactMatch()) {
-                            sqlWheresBuilder.append(" oc").append(".name = '").append(filterString).append("' OR");
+                            sqlWhereBuilder.append("oc").append(".name = '").append(filterString).append("'");
                         } else {
                             // TODO: determine if organization category name
                             // will ever be search using a like
-                            sqlWheresBuilder.append(" LOWER(oc").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                            sqlWhereBuilder.append("LOWER(oc").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
                         }
+
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(oc").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
-                    }
-
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(oc").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -637,24 +645,24 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
+
                         if (filterString == null) {
-                            sqlWheresBuilder.append(" a").append(".email IS NULL").append(" OR");
+                            sqlWhereBuilder.append("a").append(".email IS NULL");
                         } else if (submissionListColumn.getExactMatch()) {
-                            sqlWheresBuilder.append(" a").append(".email = '").append(filterString).append("' OR");
+                            sqlWhereBuilder.append("a").append(".email = '").append(filterString).append("'");
                         } else {
-                            sqlWheresBuilder.append(" LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
+                            sqlWhereBuilder.append("LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%'");
                         }
+
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
-                    }
-
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(a").append(".email) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -674,22 +682,24 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     }
 
                     for (String filterString : submissionListColumn.getFilters()) {
+                        sqlWhereBuilder = new StringBuilder();
+
+                        sqlWhereBuilder.append(" embs").append(".name = '").append(filterString).append("'");
+
                         if (filterString.equals("None")) {
-                            sqlWheresBuilder.append(" embs").append(".name = '").append(filterString).append("' OR").append(" embs.id IS NULL OR");
-                        } else {
-                            sqlWheresBuilder.append(" embs").append(".name = '").append(filterString).append("' OR");
+                            sqlWhereBuilderList.add(sqlWhereBuilder);
+                            sqlWhereBuilder = new StringBuilder();
+                            sqlWhereBuilder.append("embs.id IS NULL");
                         }
+
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     // all column search filter
                     for (String filterString : allColumnSearchFilters) {
-                        sqlWheresBuilder.append(" LOWER(embs").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%' OR");
-                    }
-
-                    if(submissionListColumn.getFilters().size() > 0 || allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("LOWER(embs").append(".name) LIKE '%").append(filterString.toLowerCase()).append("%'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -706,8 +716,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                                    .append("\n   ON action_logs_id = s.submission_status_id");
                     // @formatter:on
 
-                    // TODO:
-                    // @todo finish sqlWheresBuilder.
+                    // TODO: finish sqlWheresBuilder.
 
                     break;
 
@@ -735,13 +744,10 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         filterString.replaceAll("[TZ:.\\-]", " ");
-                        sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
-                    }
-                    
-                    if(submissionListColumn.getFilters().size() > 0 && allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -753,13 +759,10 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         filterString.replaceAll("[TZ:.\\-]", " ");
-                        sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
-                    }
 
-                    if(submissionListColumn.getFilters().size() > 0 && allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -771,13 +774,10 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         filterString.replaceAll("[TZ:.\\-]", " ");
-                        sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
-                    }
 
-                    if(submissionListColumn.getFilters().size() > 0 && allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -789,15 +789,12 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         filterString.replaceAll("[TZ:.\\-]", " ");
-                        sqlWheresBuilder.append(" ( CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("') OR");
+
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("CAST(pfv").append(n).append(".value AS TIMESTAMP) = '").append(filterString).append("'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
-                    if(submissionListColumn.getFilters().size() > 0 && allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
-                    }
-                    
                     break;
                 case "customActionValues":
 
@@ -811,13 +808,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     // @formatter:on
 
                     for (String filterString : submissionListColumn.getFilters()) {
-                        sqlWheresBuilder.append(" (scavcavcad.value = true AND scavcavcad.label = '" + filterString + "') OR ");
-                    }
-
-                    if(submissionListColumn.getFilters().size() > 0 && allColumnSearchFilters.size() > 0) {
-	                    //Strip the trailing OR and add an AND for across columns
-	                    sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 3);
-	                    sqlWheresBuilder.append(" AND ");
+                        sqlWhereBuilder = new StringBuilder();
+                        sqlWhereBuilder.append("scavcavcad.value = true AND scavcavcad.label = '" + filterString + "'");
+                        sqlWhereBuilderList.add(sqlWhereBuilder);
                     }
 
                     break;
@@ -825,6 +818,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     logger.info("No value path given for submission list column " + String.join(".", submissionListColumn.getValuePath()) + ": " + submissionListColumn.getTitle());
                 }
 
+                if (sqlWhereBuilderList.size() > 0) {
+                    sqlColumnsBuilders.put(submissionListColumn.getId(), sqlWhereBuilderList);
+                }
             }
         }
 
@@ -838,35 +834,41 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
             sqlOrderBysBuilder.setLength(sqlOrderBysBuilder.length() - 1);
         }
 
-        // if where, complete where clause and strip the tailing AND
-        if (sqlWheresBuilder.length() > 0) {
-            sqlWheresBuilder.insert(0, "\nWHERE (");
-            sqlWheresBuilder.setLength(sqlWheresBuilder.length() - 4);
-            sqlWheresBuilder.append(" )");
-            // append excluded submissions
-            if (sqlWheresExcludeBuilder.length() > 0) {
-                sqlWheresBuilder.append(" AND ").append(sqlWheresExcludeBuilder);
+        // build WHERE query such that OR is used for conditions inside a column and AND is used across each different column.
+        sqlWhereBuilder = new StringBuilder();
+        if (sqlColumnsBuilders.size() > 0 || sqlWheresExcludeBuilder.length() > 0) {
+            sqlWhereBuilder.append("\nWHERE ");
+
+            for (Entry<Long, ArrayList<StringBuilder>> list : sqlColumnsBuilders.entrySet()) {
+                sqlWhereBuilder.append("(");
+
+                for (StringBuilder builder : list.getValue()) {
+                    sqlWhereBuilder.append("(").append(builder).append(") OR ");
+                }
+
+                // remove last " OR".
+                sqlWhereBuilder.setLength(sqlWhereBuilder.length() - 4);
+
+                sqlWhereBuilder.append(") AND ");
             }
-            // if only exclude filter, complete where clause
-        } else {
+
             if (sqlWheresExcludeBuilder.length() > 0) {
-                sqlWheresBuilder.insert(0, "\nWHERE");
-                sqlWheresBuilder.append(sqlWheresExcludeBuilder);
+                sqlWhereBuilder.append("(").append(sqlWheresExcludeBuilder).append(")");
+            } else {
+                // remove last " AND"
+                sqlWhereBuilder.setLength(sqlWhereBuilder.length() - 5);
             }
         }
 
-        String sqlQuery;
+        String sqlQuery = sqlSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlWhereBuilder.toString();
+        String sqlCountQuery = sqlCountSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlWhereBuilder.toString();
 
         if (pageable != null) {
             // determine the offset and limit of the query
             int offset = pageable.getPageSize() * pageable.getPageNumber();
             int limit = pageable.getPageSize();
-            sqlQuery = sqlSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlWheresBuilder.toString() + sqlOrderBysBuilder.toString() + "\nLIMIT " + limit + " OFFSET " + offset + ";";
-        } else {
-            sqlQuery = sqlSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlWheresBuilder.toString();
+            sqlQuery += sqlOrderBysBuilder.toString() + "\nLIMIT " + limit + " OFFSET " + offset + ";";
         }
-
-        String sqlCountQuery = sqlCountSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlWheresBuilder.toString();
 
         logger.debug("QUERY:\n" + sqlQuery);
 


### PR DESCRIPTION
The Search Box text search needs to use `OR` instead of `AND`.

The previous design simply appends `AND` among `OR` conditions with no regard to order of operations.

Example:
  given four submissions:
    - submission (id = 1):
      - `E-mail` is `aggieJack@tamu.edu`.
      - `Title` is `Document 1`.
      - `Abstract` is  `This is some text.`.
    - submission (id = 2):
      - `E-mail` is `aggieJack@tamu.edu`.
      - `Title` is `Document 2`.
      - `Abstract` is  `My Abstract`.
    - submission (id = 3):
      - `E-mail` is `aggieJack@tamu.edu`.
      - `Title` is `` (not defined).
      - `Abstract` is  `This also has the word text in it.`.
    - submission (id = 4):
      - `E-mail` is `aggieJack@tamu.edu`.
      - `Title` is `Document 4`.
      - `Abstract` is  `` (not defined).

  set search:
    - `E-mail` to `aggie`.
    - `Abstract` to `text`.
    - `Abstract` to `my` (as a second abstract value).
    - `Title` to `document`.

  generated query WHERE:
    - previous implementation: `WHERE ( LOWER(pfv2.value) LIKE '%aggie%' AND  LOWER(pfv3.value) LIKE '%document%' AND  LOWER(pfv4.value) LIKE '%my%' OR LOWER(pfv4.value) LIKE '%text%'  )`.
    - this implementation: `WHERE ((LOWER(pfv2.value) LIKE '%aggie%')) AND ((LOWER(pfv3.value) LIKE '%document%')) AND ((LOWER(pfv4.value) LIKE '%my%') OR (LOWER(pfv4.value) LIKE '%text%'))`.

  results:
    - previous implementation:
       id
      ----
        1
        2
        3
      (3 rows)
    - this implementation:
       id
      ----
        1
        2
      (2 rows)

resolves: #907