### PR TITLE
jar and war deploy delimiter fix in pom.xml and application.xml - als…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <delimiters>
-            <delimiter>$</delimiter>
+            <delimiter>${*}</delimiter>
           </delimiters>
         </configuration>
       </plugin>

--- a/src/main/java/org/tdl/vireo/service/AssetService.java
+++ b/src/main/java/org/tdl/vireo/service/AssetService.java
@@ -127,11 +127,16 @@ public class AssetService {
         return resource.getFile();
     }
 
-    public List<File> getResouceDirectoryListing(String resourceDirectory) throws IOException {
+    public List<File> getResourceDirectoryListing(String resourceDirectory) throws IOException {
         Resource resource = getResource(resourceDirectory);
         URI uri = resource.getURI();
         if (uri.getScheme().equals("jar")) {
-            String directory = resourceDirectory.replace("classpath:", "/BOOT-INF/classes").replace("file:", "/");
+            String directory = null;
+        	if (uri.toString().contains(".jar!")) {
+                directory = resourceDirectory.replace("classpath:", "/BOOT-INF/classes").replace("file:", "/");
+            }else{ //.war!
+                directory = resourceDirectory.replace("classpath:", "/WEB-INF/classes").replace("file:", "/");
+            }
             FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.<String, String>emptyMap());
             Path directoryPath = fileSystem.getPath(directory);
             Iterator<Path> it = Files.walk(directoryPath, 1).filter(Files::isRegularFile).iterator();

--- a/src/main/java/org/tdl/vireo/service/SystemDataLoader.java
+++ b/src/main/java/org/tdl/vireo/service/SystemDataLoader.java
@@ -248,7 +248,7 @@ public class SystemDataLoader {
 
         List<File> controlledVocabularyFiles = new ArrayList<File>();
         try {
-            controlledVocabularyFiles = fileIOUtility.getResouceDirectoryListing("classpath:/controlled_vocabularies/");
+            controlledVocabularyFiles = fileIOUtility.getResourceDirectoryListing("classpath:/controlled_vocabularies/");
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ multipart:
 
 
 spring:
-  profiles.active: $profile$
+  profiles.active: ${profile}
   template.cache: false
   http.multipart:
     maxFileSize: 20MB
@@ -80,11 +80,11 @@ logging:
 # generated values
 info:
   build:
-    production: $production$
-    artifact: $project.artifactId$
-    name: $project.name$
-    description: $project.description$
-    version: $project.version$
+    production: ${production}
+    artifact: ${project.artifactId}
+    name: ${project.name}
+    description: ${project.description}
+    version: ${project.version}
 
 
 app:
@@ -93,7 +93,7 @@ app:
   # value generated from property assets.uri
   # either defined in pom.xml or via package argument
   # i.e. `mvn clean package -Dassets.uri=file:/opt/vireo/`
-  assets.uri: $assets.uri$
+  assets.uri: ${assets.uri}
 
   public.folder: public
 


### PR DESCRIPTION
…o fixed resource directory location in service

pom.xml and application.xml changes:
war file build ignores the pom.xml delimiter of ('$*$') and uses default ('${*}') instead.
jar file adheres to delimiter directive.
Set application.yaml to use the default so only need to change the package elements value to 'jar' or 'war'.

service changes:
Fixed spelling error in AssetService.java and SystemDataLoader.java for 'Resouce'
Also fixed detection of jar vs war deploy for finding resource directory which is packaged in different locations based on jar vs war.
Scheme detection was not sufficient as both were invoked using 'jar' but the full URI string can be used to find the suffix of .jar or .war.

