### PR TITLE
Sprint posttcdl 1236 metadata keys

### DIFF
--- a/src/main/resources/organization/SYSTEM_Organization_Definition.json
+++ b/src/main/resources/organization/SYSTEM_Organization_Definition.json
@@ -238,7 +238,7 @@
         },
         {
           "fieldPredicate":{
-            "value":"thesis.degree.discipline",
+            "value":"thesis.degree.program",
             "documentTypePredicate":false
           },
           "originatingWorkflowStep":{

--- a/src/main/resources/organization/SYSTEM_Organization_Definition.json
+++ b/src/main/resources/organization/SYSTEM_Organization_Definition.json
@@ -194,7 +194,7 @@
         },
         {
           "fieldPredicate":{
-            "value":"school",
+            "value":"thesis.degree.school",
             "documentTypePredicate":false
           },
           "originatingWorkflowStep":{


### PR DESCRIPTION
Update metadata keys: change 'school' to  'thesis.degree.school' and 'thesis.degree.discipline' to  'thesis.degree.program' per 1236

Fixes #1236


