### PR TITLE
E-mail forms (comment and comment/batch) should only add e-mail once

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -257,10 +257,10 @@ public class SubmissionController {
         submissionRepo.batchDynamicSubmissionQuery(user.getActiveFilter(), user.getSubmissionViewColumns()).forEach(sub -> {
             Map<String, Object> subMessage = new HashMap<String, Object>(data);
             if (data.get("commentVisibility").toString().equalsIgnoreCase("public")) {
-                if (data.get("sendEmailToRecipient") != null) {
+                if (data.containsKey("sendEmailToRecipient") && (boolean) data.get("sendEmailToRecipient")) {
                     subMessage.put("recipientEmail", subMessage.get("recipientEmail"));
                 }
-                if (data.get("sendEmailToCCRecipient") != null) {
+                if (data.containsKey("sendEmailToCCRecipient") && (boolean) data.get("sendEmailToCCRecipient")) {
                     subMessage.put("ccRecipientEmail", subMessage.get("ccRecipientEmail"));
                 }
             }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -12,10 +12,8 @@ import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -36,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.mail.MailException;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,18 +48,7 @@ import org.tdl.vireo.exception.DepositException;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsExcception;
 import org.tdl.vireo.model.CustomActionValue;
 import org.tdl.vireo.model.DepositLocation;
-import org.tdl.vireo.model.EmailRecipient;
-import org.tdl.vireo.model.EmailRecipientAssignee;
-import org.tdl.vireo.model.EmailRecipientContact;
-import org.tdl.vireo.model.EmailRecipientOrganization;
-import org.tdl.vireo.model.EmailRecipientPlainAddress;
-import org.tdl.vireo.model.EmailRecipientSubmitter;
-import org.tdl.vireo.model.EmailRecipientType;
-import org.tdl.vireo.model.EmailTemplate;
-import org.tdl.vireo.model.EmailWorkflowRule;
-import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
-import org.tdl.vireo.model.InputType;
 import org.tdl.vireo.model.NamedSearchFilterGroup;
 import org.tdl.vireo.model.Role;
 import org.tdl.vireo.model.Submission;
@@ -78,10 +63,7 @@ import org.tdl.vireo.model.repo.ActionLogRepo;
 import org.tdl.vireo.model.repo.ConfigurationRepo;
 import org.tdl.vireo.model.repo.CustomActionValueRepo;
 import org.tdl.vireo.model.repo.DepositLocationRepo;
-import org.tdl.vireo.model.repo.EmailTemplateRepo;
 import org.tdl.vireo.model.repo.FieldValueRepo;
-import org.tdl.vireo.model.repo.FieldPredicateRepo;
-import org.tdl.vireo.model.repo.InputTypeRepo;
 import org.tdl.vireo.model.repo.NamedSearchFilterGroupRepo;
 import org.tdl.vireo.model.repo.OrganizationRepo;
 import org.tdl.vireo.model.repo.SubmissionFieldProfileRepo;
@@ -91,6 +73,7 @@ import org.tdl.vireo.model.repo.UserRepo;
 import org.tdl.vireo.model.validation.FieldValueValidator;
 import org.tdl.vireo.service.AssetService;
 import org.tdl.vireo.service.DepositorService;
+import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
@@ -104,7 +87,6 @@ import edu.tamu.weaver.auth.annotation.WeaverCredentials;
 import edu.tamu.weaver.auth.annotation.WeaverUser;
 import edu.tamu.weaver.auth.model.Credentials;
 import edu.tamu.weaver.data.model.ApiPage;
-import edu.tamu.weaver.email.service.EmailSender;
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiView;
 import edu.tamu.weaver.validation.results.ValidationResults;
@@ -131,9 +113,6 @@ public class SubmissionController {
   private FieldValueRepo fieldValueRepo;
 
   @Autowired
-  private FieldPredicateRepo fieldPredicateRepo;
-
-  @Autowired
   private SubmissionFieldProfileRepo submissionFieldProfileRepo;
 
   @Autowired
@@ -143,16 +122,10 @@ public class SubmissionController {
   private OrganizationRepo organizationRepo;
 
   @Autowired
-  private InputTypeRepo inputTypeRepo;
-
-  @Autowired
   private SubmissionStatusRepo submissionStatusRepo;
 
   @Autowired
-  private EmailSender emailSender;
-
-  @Autowired
-  private EmailTemplateRepo emailTemplateRepo;
+  private SubmissionEmailService submissionEmailService;
 
   @Autowired
   private TemplateUtility templateUtility;
@@ -259,7 +232,7 @@ public class SubmissionController {
     String commentVisibility = data.get("commentVisibility") != null ? (String) data.get("commentVisibility") : "public";
 
     if (commentVisibility.equals("public")) {
-      sendEmail(user, submission, data);
+        submissionEmailService.sendAutomatedEmails(user, submission, data);
     } else {
       String subject = (String) data.get("subject");
       String templatedMessage = templateUtility.compileString((String) data.get("message"), submission);
@@ -273,104 +246,10 @@ public class SubmissionController {
   @PreAuthorize("hasRole('REVIEWER')")
   public ApiResponse sendEmail(@WeaverUser User user, @PathVariable Long submissionId,
       @RequestBody Map<String, Object> data) throws JsonProcessingException, IOException {
-    sendEmail(user, submissionRepo.read(submissionId), data);
+    submissionEmailService.sendAutomatedEmails(user, submissionRepo.read(submissionId), data);
     return new ApiResponse(SUCCESS);
   }
 
-  private void sendEmail(User user, Submission submission, Map<String, Object> data)
-      throws JsonProcessingException, IOException {
-
-        String subject = (String) data.get("subject");
-
-        String templatedMessage = templateUtility.compileString((String) data.get("message"), submission);
-
-        StringBuilder recipientEmails = new StringBuilder();
-
-        boolean sendRecipientEmail = (boolean) data.get("sendEmailToRecipient");
-
-        if (sendRecipientEmail) {
-            boolean sendCCRecipientEmail = (boolean) data.get("sendEmailToCCRecipient");
-
-            SimpleMailMessage smm = new SimpleMailMessage();
-
-            @SuppressWarnings("unchecked")
-            List<HashMap<String,Object>> recipientEmailAddressesList = (List<HashMap<String,Object>>) data.get("recipientEmails");
-            List<String> recipientEmailAddresses = new ArrayList<String>();
-            recipientEmailAddressesList.forEach(emailRecipientNode->{
-                String type = (String) emailRecipientNode.get("type");
-                EmailRecipient recipient = buildEmailRecipient(type, emailRecipientNode, submission);
-                if(recipient != null) {
-                  recipientEmailAddresses.addAll(recipient.getEmails(submission));
-                }
-            });
-
-            smm.setTo(recipientEmailAddresses.toArray(new String[0]));
-            recipientEmails.append("Email sent to: [ " + String.join(";",recipientEmailAddresses) + " ]; ");
-
-            if (sendCCRecipientEmail) {
-              @SuppressWarnings("unchecked")
-              List<HashMap<String,Object>> ccRecipientEmailAddressesList = (List<HashMap<String,Object>>) data.get("ccRecipientEmails");
-              List<String> ccRecipientEmailAddresses = new ArrayList<String>();
-              ccRecipientEmailAddressesList.forEach(emailRecipientNode->{
-                  String type = (String) emailRecipientNode.get("type");
-                  EmailRecipient recipient = buildEmailRecipient(type, emailRecipientNode, submission);
-                  if(recipient != null) {
-                    ccRecipientEmailAddresses.addAll(recipient.getEmails(submission));
-                  }
-              });
-
-              smm.setCc(ccRecipientEmailAddresses.toArray(new String[0]));
-              recipientEmails.append(" and cc to: [ " + String.join(";", ccRecipientEmailAddresses) + " ]; ");
-            } else {
-              recipientEmails.append(";");
-            }
-
-            String preferredEmail = user.getSetting("preferedEmail");
-
-            if (user.getSetting("ccEmail") != null && user.getSetting("ccEmail").equals("true")) {
-                smm.setBcc(preferredEmail == null ? user.getEmail() : preferredEmail);
-            }
-
-            smm.setSubject(subject);
-            smm.setText(templatedMessage);
-
-            emailSender.send(smm);
-        }
-
-        actionLogRepo.createPublicLog(submission, user, recipientEmails.toString() + subject + ": " + templatedMessage);
-    }
-
-    private EmailRecipient buildEmailRecipient(String type, HashMap<String, Object> emailRecipientMap, Submission submission) {
-      EmailRecipient recipient = null;
-
-      switch(EmailRecipientType.valueOf(type)) {
-        case ASSIGNEE: {
-          recipient = new EmailRecipientAssignee();
-          break;
-        }
-        case CONTACT: {
-          String label = (String) emailRecipientMap.get("name");
-          FieldPredicate fp = fieldPredicateRepo.getOne(new Long((Integer)emailRecipientMap.get("data")));
-          if(label!=null & fp != null) {
-            recipient = new EmailRecipientContact(label, fp);
-          }
-          break;
-        }
-        case PLAIN_ADDRESS: {
-          recipient = new EmailRecipientPlainAddress((String) emailRecipientMap.get("name"));
-          break;
-        }
-        case ORGANIZATION: {
-          recipient = new EmailRecipientOrganization(submission.getOrganization());
-          break;
-        }
-        case SUBMITTER: {
-          recipient = new EmailRecipientSubmitter();
-          break;
-        }
-      }
-      return recipient;
-    }
 
     @RequestMapping(value = "/batch-comment")
     @PreAuthorize("hasRole('REVIEWER')")
@@ -378,10 +257,10 @@ public class SubmissionController {
         submissionRepo.batchDynamicSubmissionQuery(user.getActiveFilter(), user.getSubmissionViewColumns()).forEach(sub -> {
             Map<String, Object> subMessage = new HashMap<String, Object>(data);
             if (data.get("commentVisibility").toString().equalsIgnoreCase("public")) {
-                if ((boolean) data.get("sendEmailToRecipient")) {
+                if (data.get("sendEmailToRecipient") != null) {
                     subMessage.put("recipientEmail", subMessage.get("recipientEmail"));
                 }
-                if ((boolean) data.get("sendEmailToCCRecipient")) {
+                if (data.get("sendEmailToCCRecipient") != null) {
                     subMessage.put("ccRecipientEmail", subMessage.get("ccRecipientEmail"));
                 }
             }
@@ -504,7 +383,7 @@ public class SubmissionController {
         } else {
             response = new ApiResponse(ERROR, "Could not find a submission with ID " + submissionId);
         }
-        processEmailWorkflowRules(user, submission);
+        submissionEmailService.sendWorkflowEmails(user, submission);
         return response;
     }
 
@@ -514,7 +393,7 @@ public class SubmissionController {
         submissionRepo.batchDynamicSubmissionQuery(user.getActiveFilter(), user.getSubmissionViewColumns()).forEach(submission -> {
             SubmissionStatus submissionStatus = submissionStatusRepo.findByName(submissionStatusName);
             submission = submissionRepo.updateStatus(submission, submissionStatus, user);
-            processEmailWorkflowRules(user, submission);
+            submissionEmailService.sendWorkflowEmails(user, submission);
         });
         return new ApiResponse(SUCCESS);
 
@@ -556,7 +435,7 @@ public class SubmissionController {
             response = new ApiResponse(ERROR, "Could not find a submission with ID " + submissionId);
         }
 
-        processEmailWorkflowRules(user, submission);
+        submissionEmailService.sendWorkflowEmails(user, submission);
 
         return response;
     }
@@ -963,7 +842,7 @@ public class SubmissionController {
         Page<Submission> submissions = submissionRepo.pageableDynamicSubmissionQuery(activeFilter, activeFilter.getColumnsFlag() ? activeFilter.getSavedColumns() : submissionListColumns, new PageRequest(page, size));
         long endTime = System.nanoTime();
         long duration = (endTime - startTime);
-        LOG.info("Dynamic query took " + (double) (duration / 1000000000.0) + " seconds");
+        LOG.info("Dynamic query took " + duration / 1000000000.0 + " seconds");
         return new ApiResponse(SUCCESS, new ApiPage<Submission>(submissions));
     }
 
@@ -1052,39 +931,7 @@ public class SubmissionController {
     @RequestMapping("/{submissionId}/send-advisor-email")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse sendAdvisorEmail(@WeaverUser User user, @PathVariable Long submissionId) {
-
-        Submission submission = submissionRepo.read(submissionId);
-
-        InputType contactInputType = inputTypeRepo.findByName("INPUT_CONTACT");
-
-        EmailTemplate template = emailTemplateRepo.findByNameAndSystemRequired("SYSTEM Advisor Review Request", true);
-
-        String subject = templateUtility.compileString(template.getSubject(), submission);
-        String content = templateUtility.compileTemplate(template, submission);
-
-        // TODO: this needs to only send email to the advisor not any field value that
-        // is contact type
-        submission.getFieldValuesByInputType(contactInputType).forEach(fv -> {
-
-            SimpleMailMessage smm = new SimpleMailMessage();
-
-            smm.setTo(String.join(",", fv.getContacts()));
-
-            String preferedEmail = user.getSetting("preferedEmail");
-
-            if ("true".equals(user.getSetting("ccEmail"))) {
-                smm.setBcc(preferedEmail == null ? user.getEmail() : preferedEmail);
-            }
-
-            smm.setSubject(subject);
-            smm.setText(content);
-
-            emailSender.send(smm);
-
-        });
-
-        actionLogRepo.createPublicLog(submission, user, "Advisor review email manually generated.");
-
+        submissionEmailService.sendAdvisorEmails(user, submissionRepo.read(submissionId));
         return new ApiResponse(SUCCESS);
     }
 
@@ -1154,50 +1001,6 @@ public class SubmissionController {
             clearAdvisorMessage += " Rejection.";
         }
         actionLogRepo.createAdvisorPublicLog(submission, clearAdvisorMessage);
-    }
-
-    private void processEmailWorkflowRules(User user, Submission submission) {
-
-        SimpleMailMessage smm = new SimpleMailMessage();
-
-        List<EmailWorkflowRule> rules = submission.getOrganization().getAggregateEmailWorkflowRules();
-
-        for (EmailWorkflowRule rule : rules) {
-
-            LOG.debug("Email Workflow Rule " + rule.getId() + " firing for submission " + submission.getId());
-
-            if (rule.getSubmissionStatus().equals(submission.getSubmissionStatus()) && !rule.isDisabled()) {
-
-                // TODO: Not all variables are currently being replaced.
-                String subject = templateUtility.compileString(rule.getEmailTemplate().getSubject(), submission);
-                String content = templateUtility.compileTemplate(rule.getEmailTemplate(), submission);
-
-                for (String email : rule.getEmailRecipient().getEmails(submission)) {
-
-                    try {
-                        LOG.debug("\tSending email to recipient at address " + email);
-
-                        smm.setTo(email);
-
-                        String preferedEmail = user.getSetting("preferedEmail");
-
-                        if ("true".equals(user.getSetting("ccEmail"))) {
-                            smm.setBcc(preferedEmail == null ? user.getEmail() : preferedEmail);
-                        }
-
-                        smm.setSubject(subject);
-                        smm.setText(content);
-
-                        emailSender.send(smm);
-                    } catch (MailException me) {
-                        LOG.error("Problem sending email: " + me.getMessage());
-                    }
-                }
-
-            } else {
-                LOG.debug("\tRule disabled or of irrelevant status condition.");
-            }
-        }
     }
 
 }

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -220,9 +220,8 @@ public class SubmissionEmailService {
         List<String> recipients = new ArrayList<>();
         List<HashMap<String, Object>> emails = (List<HashMap<String, Object>>) data.get(property);
 
-        emails.forEach(emailRecipientNode -> {
-            String type = (String) emailRecipientNode.get("type");
-            EmailRecipient recipient = buildEmailRecipient(type, emailRecipientNode, submission);
+        emails.forEach(emailRecipientMap -> {
+            EmailRecipient recipient = buildEmailRecipient(emailRecipientMap, submission);
             if (recipient != null) {
                 for (String recipientEmail : recipient.getEmails(submission)) {
                     if (!recipients.contains(recipientEmail)) {
@@ -238,13 +237,13 @@ public class SubmissionEmailService {
     /**
      * Build the e-mail recipient.
      *
-     * @param type Type of the e-mail.
      * @param emailRecipientMap Recipient e-mail mapping.
      * @param submission Associated Submission.
      *
      * @return A single e-mail recipient.
      */
-    private EmailRecipient buildEmailRecipient(String type, HashMap<String, Object> emailRecipientMap, Submission submission) {
+    private EmailRecipient buildEmailRecipient(HashMap<String, Object> emailRecipientMap, Submission submission) {
+      String type = (String) emailRecipientMap.get("type");
       EmailRecipient recipient = null;
 
       switch(EmailRecipientType.valueOf(type)) {

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -35,6 +35,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.tamu.weaver.email.service.EmailSender;
 
+/**
+ * Provide e-mail sending specific to the Submission process.
+ *
+ * E-mails are built utilizing SimpleMailMessage and then sent via EmailSender.
+ *
+ * @see EmailSender
+ * @see SimpleMailMessage
+ */
 @Service
 public class SubmissionEmailService {
 

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -1,0 +1,280 @@
+package org.tdl.vireo.service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+import org.tdl.vireo.model.EmailRecipient;
+import org.tdl.vireo.model.EmailRecipientAssignee;
+import org.tdl.vireo.model.EmailRecipientContact;
+import org.tdl.vireo.model.EmailRecipientOrganization;
+import org.tdl.vireo.model.EmailRecipientPlainAddress;
+import org.tdl.vireo.model.EmailRecipientSubmitter;
+import org.tdl.vireo.model.EmailRecipientType;
+import org.tdl.vireo.model.EmailTemplate;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.InputType;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.repo.ActionLogRepo;
+import org.tdl.vireo.model.repo.EmailTemplateRepo;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
+import org.tdl.vireo.model.repo.InputTypeRepo;
+import org.tdl.vireo.utility.TemplateUtility;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.tamu.weaver.email.service.EmailSender;
+
+@Service
+public class SubmissionEmailService {
+
+    private Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private ActionLogRepo actionLogRepo;
+
+    @Autowired
+    private EmailSender emailSender;
+
+    @Autowired
+    private EmailTemplateRepo emailTemplateRepo;
+
+    @Autowired
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @Autowired
+    private InputTypeRepo inputTypeRepo;
+
+    @Autowired
+    private TemplateUtility templateUtility;
+
+    /**
+     * Manually send the e-mails to the advisors for a given Submission.
+     *
+     * @param user Associated User.
+     * @param submission Associated Submission.
+     */
+    public void sendAdvisorEmails(User user, Submission submission) {
+        InputType contactInputType = inputTypeRepo.findByName("INPUT_CONTACT");
+        EmailTemplate template = emailTemplateRepo.findByNameAndSystemRequired("SYSTEM Advisor Review Request", true);
+
+        String subject = templateUtility.compileString(template.getSubject(), submission);
+        String content = templateUtility.compileTemplate(template, submission);
+
+        List<String> fullRecipientList = new ArrayList<>();
+
+        // TODO: this needs to only send email to the advisor not any field value that is contact type
+        submission.getFieldValuesByInputType(contactInputType).forEach(fv -> {
+            SimpleMailMessage smm = new SimpleMailMessage();
+
+            List<String> recipientList = new ArrayList<>();
+            for (String contact : fv.getContacts()) {
+                if (!fullRecipientList.contains(contact)) {
+                    fullRecipientList.add(contact);
+                    recipientList.add(contact);
+                }
+            }
+
+            smm.setTo(String.join(",", recipientList));
+            smm.setTo(recipientList.toArray(new String[0]));
+
+            if ("true".equals(user.getSetting("ccEmail"))) {
+                String preferedEmail = user.getSetting("preferedEmail");
+                smm.setBcc(preferedEmail == null ? user.getEmail() : preferedEmail);
+            }
+
+            smm.setSubject(subject);
+            smm.setText(content);
+
+            emailSender.send(smm);
+        });
+
+        actionLogRepo.createPublicLog(submission, user, "Advisor review email manually generated.");
+    }
+
+    /**
+     * Send an e-mail associated with the given user and submission.
+     *
+     * @param user Associated User.
+     * @param submission Associated Submission.
+     * @param data Mapping of data.
+     *
+     * @throws JsonProcessingException
+     * @throws IOException
+     */
+    public void sendAutomatedEmails(User user, Submission submission, Map<String, Object> data) throws JsonProcessingException, IOException {
+        if (data.containsKey("sendEmailToRecipient") && (boolean) data.get("sendEmailToRecipient")) {
+            String subject = (String) data.get("subject");
+            String templatedMessage = templateUtility.compileString((String) data.get("message"), submission);
+            StringBuilder recipientEmails = new StringBuilder();
+            SimpleMailMessage smm = new SimpleMailMessage();
+
+            List<String> recipientEmailAddresses = buildEmailRecipients("recipientEmails", submission, data);
+            smm.setTo(recipientEmailAddresses.toArray(new String[0]));
+
+            recipientEmails.append("Email sent to: [ " + String.join(";", recipientEmailAddresses) + " ]; ");
+
+            if (data.containsKey("sendEmailToCCRecipient") && (boolean) data.get("sendEmailToCCRecipient")) {
+                List<String> ccRecipientEmailAddresses = buildEmailRecipients("ccRecipientEmails", submission, data);
+                smm.setCc(ccRecipientEmailAddresses.toArray(new String[0]));
+                recipientEmails.append(" and cc to: [ " + String.join(";", ccRecipientEmailAddresses) + " ]; ");
+            } else {
+                recipientEmails.append(";");
+            }
+
+            if (user.getSetting("ccEmail") != null && user.getSetting("ccEmail").equals("true")) {
+                String preferredEmail = user.getSetting("preferedEmail");
+                smm.setBcc(preferredEmail == null ? user.getEmail() : preferredEmail);
+            }
+
+            smm.setSubject(subject);
+            smm.setText(templatedMessage);
+
+            emailSender.send(smm);
+
+            actionLogRepo.createPublicLog(submission, user, recipientEmails.toString() + subject + ": " + templatedMessage);
+        }
+    }
+
+    /**
+     * Process workflow and send e-mails as needed for the given submission.
+     *
+     * @param user Associated User.
+     * @param submission Associated Submission.
+     */
+    public void sendWorkflowEmails(User user, Submission submission) {
+        SimpleMailMessage smm = new SimpleMailMessage();
+
+        List<EmailWorkflowRule> rules = submission.getOrganization().getAggregateEmailWorkflowRules();
+        Map<Long, List<String>> recipientLists = new HashMap<>();
+
+        for (EmailWorkflowRule rule : rules) {
+            LOG.debug("Email Workflow Rule " + rule.getId() + " firing for submission " + submission.getId());
+
+            if (rule.getSubmissionStatus().equals(submission.getSubmissionStatus()) && !rule.isDisabled()) {
+                Long templateId = rule.getEmailTemplate().getId();
+
+                if (!recipientLists.containsKey(templateId)) {
+                    recipientLists.put(templateId, new ArrayList<>());
+                }
+
+                // TODO: Not all variables are currently being replaced.
+                String subject = templateUtility.compileString(rule.getEmailTemplate().getSubject(), submission);
+                String content = templateUtility.compileTemplate(rule.getEmailTemplate(), submission);
+
+                for (String email : rule.getEmailRecipient().getEmails(submission)) {
+                    if (recipientLists.get(templateId).contains(email)) {
+                        LOG.debug("\tSkipping (already sent) email to recipient at address " + email);
+                        continue;
+                    }
+
+                    recipientLists.get(templateId).add(email);
+
+                    try {
+                        LOG.debug("\tSending email to recipient at address " + email);
+
+                        smm.setTo(email);
+
+                        if ("true".equals(user.getSetting("ccEmail"))) {
+                            String preferedEmail = user.getSetting("preferedEmail");
+                            smm.setBcc(preferedEmail == null ? user.getEmail() : preferedEmail);
+                        }
+
+                        smm.setSubject(subject);
+                        smm.setText(content);
+
+                        emailSender.send(smm);
+                    } catch (MailException me) {
+                        LOG.error("Problem sending email: " + me.getMessage());
+                        recipientLists.get(templateId).remove(email);
+                    }
+                }
+
+            } else {
+                LOG.debug("\tRule disabled or of irrelevant status condition.");
+            }
+        }
+    }
+
+    /**
+     * Build the e-mail recipient list.
+     *
+     * @param property Property name to extract from the data map.
+     * @param submission Associated Submission.
+     * @param data Mapping of data.
+     *
+     * @return A distinct array of e-mails.
+     */
+    @SuppressWarnings("unchecked")
+    private List<String> buildEmailRecipients(String property, Submission submission, Map<String, Object> data) {
+        List<String> recipients = new ArrayList<>();
+        List<HashMap<String, Object>> emails = (List<HashMap<String, Object>>) data.get(property);
+
+        emails.forEach(emailRecipientNode -> {
+            String type = (String) emailRecipientNode.get("type");
+            EmailRecipient recipient = buildEmailRecipient(type, emailRecipientNode, submission);
+            if (recipient != null) {
+                for (String recipientEmail : recipient.getEmails(submission)) {
+                    if (!recipients.contains(recipientEmail)) {
+                        recipients.add(recipientEmail);
+                    }
+                }
+            }
+        });
+
+        return recipients;
+    }
+
+    /**
+     * Build the e-mail recipient.
+     *
+     * @param type Type of the e-mail.
+     * @param emailRecipientMap Recipient e-mail mapping.
+     * @param submission Associated Submission.
+     *
+     * @return A single e-mail recipient.
+     */
+    private EmailRecipient buildEmailRecipient(String type, HashMap<String, Object> emailRecipientMap, Submission submission) {
+      EmailRecipient recipient = null;
+
+      switch(EmailRecipientType.valueOf(type)) {
+        case ASSIGNEE: {
+          recipient = new EmailRecipientAssignee();
+          break;
+        }
+        case CONTACT: {
+          String label = (String) emailRecipientMap.get("name");
+          FieldPredicate fp = fieldPredicateRepo.getOne(new Long((Integer)emailRecipientMap.get("data")));
+          if(label != null & fp != null) {
+            recipient = new EmailRecipientContact(label, fp);
+          }
+          break;
+        }
+        case PLAIN_ADDRESS: {
+          recipient = new EmailRecipientPlainAddress((String) emailRecipientMap.get("name"));
+          break;
+        }
+        case ORGANIZATION: {
+          recipient = new EmailRecipientOrganization(submission.getOrganization());
+          break;
+        }
+        case SUBMITTER: {
+          recipient = new EmailRecipientSubmitter();
+          break;
+        }
+      }
+
+      return recipient;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -271,6 +271,7 @@ public class SubmissionEmailService {
           recipient = new EmailRecipientSubmitter();
           break;
         }
+        default:
       }
 
       return recipient;

--- a/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
+++ b/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
@@ -104,6 +104,7 @@ public class SubmissionEmailServiceTest extends MockData {
         TEST_EMAIL_WORKFLOW_RULE1.setEmailRecipient(TEST_EMAIL_RECIPIENT1);
         TEST_EMAIL_WORKFLOW_RULE1.setSubmissionStatus(TEST_SUBMISSION_STATUS1);
         TEST_EMAIL_WORKFLOW_RULE1.setEmailTemplate(TEST_EMAIL_TEMPLATE1);
+        TEST_EMAIL_WORKFLOW_RULE1.isDisabled(false);
     }
 
     private static final EmailWorkflowRule TEST_EMAIL_WORKFLOW_RULE2 = new EmailWorkflowRule();
@@ -112,6 +113,7 @@ public class SubmissionEmailServiceTest extends MockData {
         TEST_EMAIL_WORKFLOW_RULE2.setEmailRecipient(TEST_EMAIL_RECIPIENT2);
         TEST_EMAIL_WORKFLOW_RULE2.setSubmissionStatus(TEST_SUBMISSION_STATUS2);
         TEST_EMAIL_WORKFLOW_RULE2.setEmailTemplate(TEST_EMAIL_TEMPLATE1);
+        TEST_EMAIL_WORKFLOW_RULE2.isDisabled(false);
     }
 
     private static final Map<String, Object> TEST_EMAIL_RECIPIENT_MAP1 = new HashMap<String, Object>();

--- a/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
+++ b/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
@@ -1,0 +1,170 @@
+package org.tdl.vireo.service;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.tdl.vireo.Application;
+import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsExcception;
+import org.tdl.vireo.mock.MockData;
+import org.tdl.vireo.model.ActionLog;
+import org.tdl.vireo.model.EmailRecipient;
+import org.tdl.vireo.model.EmailRecipientPlainAddress;
+import org.tdl.vireo.model.EmailTemplate;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.InputType;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.SubmissionState;
+import org.tdl.vireo.model.SubmissionStatus;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.repo.ActionLogRepo;
+import org.tdl.vireo.model.repo.EmailTemplateRepo;
+import org.tdl.vireo.model.repo.InputTypeRepo;
+import org.tdl.vireo.model.repo.SubmissionRepo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import edu.tamu.weaver.email.service.EmailSender;
+
+@ActiveProfiles("test")
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = { Application.class })
+public class SubmissionEmailServiceTest extends MockData {
+    private static final EmailRecipient TEST_EMAIL_RECIPIENT1 = new EmailRecipientPlainAddress(TEST_USER_EMAIL);
+    private static final EmailRecipient TEST_EMAIL_RECIPIENT2 = new EmailRecipientPlainAddress(TEST_USER_EMAIL);
+
+    private static final EmailTemplate TEST_EMAIL_TEMPLATE1 = new EmailTemplate();
+    static {
+        TEST_EMAIL_TEMPLATE1.setId(1L);
+        TEST_EMAIL_TEMPLATE1.setName(TEST_EMAIL_TEMPLATE_NAME);
+        TEST_EMAIL_TEMPLATE1.setMessage(TEST_EMAIL_TEMPLATE_MESSAGE);
+        TEST_EMAIL_TEMPLATE1.setSubject(TEST_EMAIL_TEMPLATE_SUBJECT);
+    }
+
+    private static final List<EmailTemplate> TEST_EMAIL_TEMPLATES1 = new ArrayList<EmailTemplate>();
+    static {
+        TEST_EMAIL_TEMPLATES1.add(TEST_EMAIL_TEMPLATE1);
+    }
+
+    private static final String TEST_ORGANIZATION1_NAME = "Test Organization 1";
+    private static final OrganizationCategory TEST_ORGANIZATION_CATEGORY1 = new OrganizationCategory("Test Organization Category 1");
+
+    private static final InputType TEST_INPUT_TYPE1 = new InputType("Test Input Type 1");
+
+    private static final SubmissionStatus TEST_SUBMISSION_STATUS1 = new SubmissionStatus("Test Submission Status 1", false, false, false, false, false, true, SubmissionState.IN_PROGRESS);
+    private static final SubmissionStatus TEST_SUBMISSION_STATUS2 = new SubmissionStatus("Test Submission Status 2", true, false, false, false, false, false, SubmissionState.CANCELED);
+
+    private static final Calendar TEST_CALENDAR1 = new Calendar.Builder().build();
+
+    private static final ActionLog TEST_ACTION_LOG1 = new ActionLog(TEST_SUBMISSION_STATUS1, TEST_CALENDAR1, "Test Action Log 1", false);
+
+    private static final EmailWorkflowRule TEST_EMAIL_WORKFLOW_RULE1 = new EmailWorkflowRule();
+    static {
+        TEST_EMAIL_WORKFLOW_RULE1.setId(1L);
+        TEST_EMAIL_WORKFLOW_RULE1.setEmailRecipient(TEST_EMAIL_RECIPIENT1);
+        TEST_EMAIL_WORKFLOW_RULE1.setSubmissionStatus(TEST_SUBMISSION_STATUS1);
+        TEST_EMAIL_WORKFLOW_RULE1.setEmailTemplate(TEST_EMAIL_TEMPLATE1);
+    }
+
+    private static final EmailWorkflowRule TEST_EMAIL_WORKFLOW_RULE2 = new EmailWorkflowRule();
+    static {
+        TEST_EMAIL_WORKFLOW_RULE2.setId(2L);
+        TEST_EMAIL_WORKFLOW_RULE2.setEmailRecipient(TEST_EMAIL_RECIPIENT2);
+        TEST_EMAIL_WORKFLOW_RULE2.setSubmissionStatus(TEST_SUBMISSION_STATUS2);
+        TEST_EMAIL_WORKFLOW_RULE2.setEmailTemplate(TEST_EMAIL_TEMPLATE1);
+    }
+
+    private Map<String, Object> mockData;
+
+    @MockBean
+    protected ActionLogRepo mockActionLogRepo;
+
+    @MockBean
+    protected SubmissionRepo mockSubmissionRepo;
+
+    @MockBean
+    protected EmailTemplateRepo mockEmailTemplateRepo;
+
+    @MockBean
+    private InputTypeRepo mockInputTypeRepo;
+
+    @Mock
+    private EmailSender mockEmailSender;
+
+    @Mock
+    private Organization mockOrganization;
+
+    @Mock
+    private Submission mockSubmission;
+
+    @Autowired
+    private SubmissionEmailService submissionEmailService;
+
+    @Before
+    public void setup() throws OrganizationDoesNotAcceptSubmissionsExcception {
+        mockData = new HashMap<>();
+
+        List<EmailWorkflowRule> emailWorkflowRules = new ArrayList<>();
+        emailWorkflowRules.add(TEST_EMAIL_WORKFLOW_RULE1);
+        emailWorkflowRules.add(TEST_EMAIL_WORKFLOW_RULE2);
+
+        when(mockOrganization.getId()).thenReturn(1L);
+        when(mockOrganization.getName()).thenReturn(TEST_ORGANIZATION1_NAME);
+        when(mockOrganization.getCategory()).thenReturn(TEST_ORGANIZATION_CATEGORY1);
+        when(mockOrganization.getAggregateEmailWorkflowRules()).thenReturn(emailWorkflowRules);
+
+        when(mockSubmission.getOrganization()).thenReturn(mockOrganization);
+        when(mockSubmission.getSubmissionStatus()).thenReturn(TEST_SUBMISSION_STATUS1);
+        when(mockSubmission.getSubmitter()).thenReturn(TEST_USER);
+
+        when(mockInputTypeRepo.getOne(1L)).thenReturn(TEST_INPUT_TYPE1);
+        when(mockInputTypeRepo.findOne(1L)).thenReturn(TEST_INPUT_TYPE1);
+        when(mockInputTypeRepo.findByName(any(String.class))).thenReturn(TEST_INPUT_TYPE1);
+
+        when(mockEmailTemplateRepo.getOne(1L)).thenReturn(TEST_EMAIL_TEMPLATE1);
+        when(mockEmailTemplateRepo.findOne(1L)).thenReturn(TEST_EMAIL_TEMPLATE1);
+        when(mockEmailTemplateRepo.findByName(any(String.class))).thenReturn(TEST_EMAIL_TEMPLATES1);
+        when(mockEmailTemplateRepo.findByNameAndSystemRequired(any(String.class), any(Boolean.class))).thenReturn(TEST_EMAIL_TEMPLATE1);
+
+        when(mockActionLogRepo.createPublicLog(any(Submission.class), any(User.class), any(String.class))).thenReturn(TEST_ACTION_LOG1);
+    }
+
+    @Test
+    public void testSendAdvisorEmails() {
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+    }
+
+    @Test
+    public void testSendAutomatedEmails() throws JsonProcessingException, IOException {
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+    }
+
+    @Test
+    public void testSendWorkflowEmails() {
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+    }
+
+    @After
+    public void cleanup() {
+
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
+++ b/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,8 +43,6 @@ import org.tdl.vireo.model.repo.InputTypeRepo;
 import org.tdl.vireo.model.repo.SubmissionRepo;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-
-import edu.tamu.weaver.email.service.EmailSender;
 
 @ActiveProfiles("test")
 @RunWith(SpringRunner.class)
@@ -192,9 +189,6 @@ public class SubmissionEmailServiceTest extends MockData {
     private InputTypeRepo mockInputTypeRepo;
 
     @Mock
-    private EmailSender mockEmailSender;
-
-    @Mock
     private Organization mockOrganization;
 
     @Mock
@@ -204,7 +198,7 @@ public class SubmissionEmailServiceTest extends MockData {
     private SubmissionEmailService submissionEmailService;
 
     @Before
-    public void setup() throws OrganizationDoesNotAcceptSubmissionsExcception {
+    public void setUp() throws OrganizationDoesNotAcceptSubmissionsExcception {
         mockData = new HashMap<>();
         mockFieldValues = new ArrayList<>();
 
@@ -272,11 +266,6 @@ public class SubmissionEmailServiceTest extends MockData {
         TEST_USER.setSettings(TEST_USER1_SETTINGS3);
 
         submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
-    }
-
-    @After
-    public void cleanup() {
-
     }
 
     private void doTestSendAutomatedEmails(boolean cc) throws JsonProcessingException, IOException {


### PR DESCRIPTION
Moves the submission email sending to its own file as a Service.
Adds additional logic to ensure that if an e-mail is already present in the TO or CC e-mail headers, do not add the duplicate e-mail.
Very basic tests are implemented.

Resolves #1273