### PR TITLE
removed prefixes meant for another format and suffixes except primary…

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -732,7 +732,7 @@ public class SubmissionController {
                     if (exportPackage.isMap()) {
                         for (Map.Entry<String, File> fileEntry : ((Map<String, File>) exportPackage.getPayload()).entrySet()) {
                             zos.putNextEntry(new ZipEntry(submissionName + fileEntry.getKey()));
-                            contentsText.append("MD " + fileEntry.getKey() + "\n");
+                            contentsText.append(fileEntry.getKey()+"\n");
                             zos.write(Files.readAllBytes(fileEntry.getValue().toPath()));
                             zos.closeEntry();
                         }
@@ -743,7 +743,7 @@ public class SubmissionController {
                         Path path = assetService.getAssetsAbsolutePath(ldfv.getValue());
                         byte[] fileBytes = Files.readAllBytes(path);
                         zos.putNextEntry(new ZipEntry(submissionName + ldfv.getFileName()));
-                        contentsText.append(ldfv.getFileName() + " bundle:LICENSE\n");
+                        contentsText.append(ldfv.getFileName()+"\n");
                         zos.write(fileBytes);
                         zos.closeEntry();
                     }
@@ -752,8 +752,8 @@ public class SubmissionController {
                     FieldValue primaryDoc = submission.getPrimaryDocumentFieldValue();
                     Path path = assetService.getAssetsAbsolutePath(primaryDoc.getValue());
                     byte[] fileBytes = Files.readAllBytes(path);
-                    zos.putNextEntry(new ZipEntry(submissionName + primaryDoc.getFileName()));
-                    contentsText.append(primaryDoc.getFileName() + "  bundle:CONTENT  primary:true\n");
+                    zos.putNextEntry(new ZipEntry(submissionName+primaryDoc.getFileName()));
+                    contentsText.append(primaryDoc.getFileName()+"\tprimary:true\n");
                     zos.write(fileBytes);
                     zos.closeEntry();
 
@@ -764,8 +764,8 @@ public class SubmissionController {
                     for (FieldValue supplDoc : supplDocs) {
                         Path supplPath = assetService.getAssetsAbsolutePath(supplDoc.getValue());
                         byte[] supplFileBytes = Files.readAllBytes(supplPath);
-                        zos.putNextEntry(new ZipEntry(submissionName + supplDoc.getFileName()));
-                        contentsText.append(supplDoc.getFileName() + "  bundle:CONTENT\n");
+                        zos.putNextEntry(new ZipEntry(submissionName+supplDoc.getFileName()));
+                        contentsText.append(supplDoc.getFileName()+"\n");
                         zos.write(supplFileBytes);
                         zos.closeEntry();
                     }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -729,6 +729,7 @@ public class SubmissionController {
 
                     ExportPackage exportPackage = packagerUtility.packageExport(packager, submission);
 
+					//METADATA
                     if (exportPackage.isMap()) {
                         for (Map.Entry<String, File> fileEntry : ((Map<String, File>) exportPackage.getPayload()).entrySet()) {
                             zos.putNextEntry(new ZipEntry(submissionName + fileEntry.getKey()));
@@ -743,7 +744,7 @@ public class SubmissionController {
                         Path path = assetService.getAssetsAbsolutePath(ldfv.getValue());
                         byte[] fileBytes = Files.readAllBytes(path);
                         zos.putNextEntry(new ZipEntry(submissionName + ldfv.getFileName()));
-                        contentsText.append(ldfv.getFileName()+"\n");
+                        contentsText.append(ldfv.getFileName()+"\tBUNDLE:LICENSE\n");
                         zos.write(fileBytes);
                         zos.closeEntry();
                     }
@@ -753,19 +754,17 @@ public class SubmissionController {
                     Path path = assetService.getAssetsAbsolutePath(primaryDoc.getValue());
                     byte[] fileBytes = Files.readAllBytes(path);
                     zos.putNextEntry(new ZipEntry(submissionName+primaryDoc.getFileName()));
-                    contentsText.append(primaryDoc.getFileName()+"\tprimary:true\n");
+                    contentsText.append(primaryDoc.getFileName()+"\tBUNDLE:CONTENT\tprimary:true\n");
                     zos.write(fileBytes);
                     zos.closeEntry();
 
                     // SUPPLEMENTAL_DOCS
-                    // supplemental, source, administrative
-                    // ask Stephanie about administrative
                     List<FieldValue> supplDocs = submission.getSupplementalAndSourceDocumentFieldValues();
                     for (FieldValue supplDoc : supplDocs) {
                         Path supplPath = assetService.getAssetsAbsolutePath(supplDoc.getValue());
                         byte[] supplFileBytes = Files.readAllBytes(supplPath);
                         zos.putNextEntry(new ZipEntry(submissionName+supplDoc.getFileName()));
-                        contentsText.append(supplDoc.getFileName()+"\n");
+                        contentsText.append(supplDoc.getFileName()+"\tBUNDLE:CONTENT\n");
                         zos.write(supplFileBytes);
                         zos.closeEntry();
                     }


### PR DESCRIPTION
…:true for dspace export contents file

fixed export 'contents' file so dspace zip file can now be successfully imported by dspace6.