### PR TITLE
upgrade tika to 121 at the suggestion of security warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.19.1</version>
+      <version>1.21</version>
       <exclusions>
         <exclusion>
           <groupId>xom</groupId>


### PR DESCRIPTION
observed the getMimeType method and verified it detected an application/pdf correctly. 
fixes #1307 