### PR TITLE
update accounts generation to separate student/reviewer/manager from …

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -126,16 +126,32 @@ public class Cli implements CommandLineRunner {
                     }
                     for (int i = 0; i < acct; i++) {
                         String enc_pwd = passwordEncoder.encode("password");
-                        User submitter = userRepo.create("anonymous" + (i + 1) + "@example.com", "anonymous", "example", enc_pwd, Role.ROLE_ANONYMOUS);
-                        userRepo.saveAndFlush(submitter);
-                        submitter = userRepo.create("student" + (i + 1) + "@example.com", "student", "example", enc_pwd, Role.ROLE_STUDENT);
-                        userRepo.saveAndFlush(submitter);
-                        submitter = userRepo.create("reviewer" + (i + 1) + "@example.com", "reviewer", "example", enc_pwd, Role.ROLE_REVIEWER);
-                        userRepo.saveAndFlush(submitter);
-                        submitter = userRepo.create("manager" + (i + 1) + "@example.com", "", "manager", enc_pwd, Role.ROLE_MANAGER);
-                        userRepo.saveAndFlush(submitter);
-                        submitter = userRepo.create("admin" + (i + 1) + "@example.com", "", "admin", enc_pwd, Role.ROLE_ADMIN);
-                        userRepo.saveAndFlush(submitter);
+                        User testacct = userRepo.create("student" + (i + 1) + "@example.com", "student"+(i+1), "example", enc_pwd, Role.ROLE_STUDENT);
+                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_STUDENT");
+                        userRepo.saveAndFlush(testacct);
+                        testacct = userRepo.create("reviewer" + (i + 1) + "@example.com", "reviewer"+(i+1), "example", enc_pwd, Role.ROLE_REVIEWER);
+                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_REVIEWER");
+                        userRepo.saveAndFlush(testacct);
+                        testacct = userRepo.create("manager" + (i + 1) + "@example.com", "", "manager"+(i+1), enc_pwd, Role.ROLE_MANAGER);
+                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_MANAGER");
+                        userRepo.saveAndFlush(testacct);
+                    }
+                    break;
+
+                case "admin_accounts":
+                    int admin_acct = 0;
+                    if (commandArgs.size() > 0) {
+                        try {
+                            admin_acct = Integer.parseInt(commandArgs.get(0));
+                        } catch (Exception e) {
+                            System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
+                        }
+                    }
+                    for (int i = 0; i < admin_acct; i++) {
+                        String enc_pwd = passwordEncoder.encode("password");
+                        User testacct = userRepo.create("admin" + (i + 1) + "@example.com", "", "admin"+(i+1), enc_pwd, Role.ROLE_ADMIN);
+                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_ADMIN");
+                        userRepo.saveAndFlush(testacct);
                     }
                     break;
 

--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -32,9 +32,8 @@ import edu.tamu.weaver.auth.model.Credentials;
 
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-
 /**
- * Activate the Vireo command line interface by passing the console argument to Maven 
+ * Activate the Vireo command line interface by passing the console argument to Maven
  *
  * mvn clean spring-boot:run -Drun.arguments=console
  * 
@@ -126,14 +125,14 @@ public class Cli implements CommandLineRunner {
                     }
                     for (int i = 0; i < acct; i++) {
                         String enc_pwd = passwordEncoder.encode("password");
-                        User testacct = userRepo.create("student" + (i + 1) + "@example.com", "student"+(i+1), "example", enc_pwd, Role.ROLE_STUDENT);
-                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_STUDENT");
+                        User testacct = userRepo.create("student" + (i + 1) + "@example.com", "student" + (i + 1), "example", enc_pwd, Role.ROLE_STUDENT);
+                        System.out.println("Creating account with email " + testacct.getEmail() + " with role ROLE_STUDENT");
                         userRepo.saveAndFlush(testacct);
-                        testacct = userRepo.create("reviewer" + (i + 1) + "@example.com", "reviewer"+(i+1), "example", enc_pwd, Role.ROLE_REVIEWER);
-                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_REVIEWER");
+                        testacct = userRepo.create("reviewer" + (i + 1) + "@example.com", "reviewer" + (i + 1), "example", enc_pwd, Role.ROLE_REVIEWER);
+                        System.out.println("Creating account with email " + testacct.getEmail() + " with role ROLE_REVIEWER");
                         userRepo.saveAndFlush(testacct);
-                        testacct = userRepo.create("manager" + (i + 1) + "@example.com", "", "manager"+(i+1), enc_pwd, Role.ROLE_MANAGER);
-                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_MANAGER");
+                        testacct = userRepo.create("manager" + (i + 1) + "@example.com", "", "manager" + (i + 1), enc_pwd, Role.ROLE_MANAGER);
+                        System.out.println("Creating account with email " + testacct.getEmail() + " with role ROLE_MANAGER");
                         userRepo.saveAndFlush(testacct);
                     }
                     break;
@@ -149,8 +148,8 @@ public class Cli implements CommandLineRunner {
                     }
                     for (int i = 0; i < admin_acct; i++) {
                         String enc_pwd = passwordEncoder.encode("password");
-                        User testacct = userRepo.create("admin" + (i + 1) + "@example.com", "", "admin"+(i+1), enc_pwd, Role.ROLE_ADMIN);
-                        System.out.println("Creating account with email "+testacct.getEmail()+" with role ROLE_ADMIN");
+                        User testacct = userRepo.create("admin" + (i + 1) + "@example.com", "", "admin" + (i + 1), enc_pwd, Role.ROLE_ADMIN);
+                        System.out.println("Creating account with email " + testacct.getEmail() + " with role ROLE_ADMIN");
                         userRepo.saveAndFlush(testacct);
                     }
                     break;


### PR DESCRIPTION
…admin

test-etd.tdl.org will provide test accounts for users who with to quickly set up to test drive features held by different account roles.  The changes in this PR separates admin test account generation from the creation of student, reviewer, and manager accounts.  This will allow me to set up the latter 3 accounts but not provide admin test accounts on the public test-etd.tdl site.
