### PR TITLE
Update travis-ci xfvb startup method according to new syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
     node_js: "6"
     addons:
       - chrome: stable
+    services:
+      - xvfb
     before_script:
-      - export DISPLAY=:99.0
       - export COVERALLS_PARALLEL=true
       - export CI_NAME="travis-ci"
       - export CI_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
-      - sh -e /etc/init.d/xvfb start
       - npm start > /dev/null &
       - npm run update-webdriver
       - sleep 1 # give server time to start


### PR DESCRIPTION
see: https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123
see: https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services-xvfb