### PR TITLE
Fix travis-ci building for Java, switch to openjdk8 and reduce download message verbosity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - name: "Java Tests"
     sudo: required
     language: java
-    jdk: oraclejdk8
+    jdk: openjdk8
     before_script:
       - export COVERALLS_PARALLEL=true
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       - export COVERALLS_PARALLEL=true
     install:
       - mvn clean package -Dproduction -DskipTests=true -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-      - mvn test-compile -Dclient -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+      - mvn test-compile -Dclient -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
     after_success:
       - mvn clean test cobertura:cobertura jacoco:report coveralls:report -DserviceName="travis-ci" -DserviceBuildNumber=$TRAVIS_BUILD_NUMBER
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ matrix:
     node_js: "6"
     addons:
       - chrome: stable
+    services:
+      - xvfb
     before_script:
-      - export DISPLAY=:99.0
       - export COVERALLS_PARALLEL=true
       - export CI_NAME="travis-ci"
       - export CI_BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
-      - sh -e /etc/init.d/xvfb start
       - npm start > /dev/null &
       - npm run update-webdriver
       - sleep 1 # give server time to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     before_script:
       - export COVERALLS_PARALLEL=true
     install:
-      - mvn clean package -Dproduction -DskipTests=true
+      - mvn clean package -Dproduction -DskipTests=true -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - mvn test-compile -Dclient -DskipTests=true -Dmaven.javadoc.skip=true -B -V
     after_success:
       - mvn clean test cobertura:cobertura jacoco:report coveralls:report -DserviceName="travis-ci" -DserviceBuildNumber=$TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
oraclejdk8 is no longer supported in travis-ci and openjdk8 must now be used.

The download messages overfill travis-ci's buffer causes a failure do to the buffer limit being exceeded. Add additional parameters to the configuration to disable the download messages (keep warnings and errors). This is done by switching to batch mode, which in turn passes the output through the logger and the logger can then have its output restricted.

relates: #1346