### PR TITLE
Resolve issues with upgrading TinyMCE from 4.x to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ng-csv": "0.3.6",
     "ng-sortable": "1.3.8",
     "ng-table": "3.0.1",
-    "tinymce": "4.9.2"
+    "tinymce": "5.2.1"
   },
   "devDependencies": {
     "grunt": "1.0.3",

--- a/src/main/webapp/app/directives/lockingTextAreaDirective.js
+++ b/src/main/webapp/app/directives/lockingTextAreaDirective.js
@@ -56,9 +56,9 @@ vireo.directive("lockingtextarea", function ($timeout) {
                         save();
                     });
                 },
-                toolbar1: "formatselect,bold,italic,underline,separator,bullist,numlist,undo,redo",
-                theme: "modern",
-                plugins: $scope.plugins,
+                toolbar1: "formatselect bold italic underline | bullist numlist undo redo",
+                theme: "silver",
+                plugins: "autoresize",
                 menubar: false,
                 statusbar: false,
                 image_advtab: true,


### PR DESCRIPTION
The TinyMCE major version update from dependabot (https://github.com/TexasDigitalLibrary/Vireo/commit/7154baec90cff4eae10b4ad5590288c4aaf9de08) created a few issues with TinyMCE textareas. As noted in #1434, the Modern theme is no longer available in version 5.x. Additionally, the toolbar attribute has a different format, and the Autoresize plugin is now required to expand the textarea to fit the <div>.

NOTE: While debugging this issue, I noticed that $scope.plugins is undefined in the lockingtextarea directive. If that should be set somewhere else or in a different fashion, please let me know. 


References:
TinyMCE 4 to 5 migration guide: https://www.tiny.cloud/docs/migration-from-4x/#removededitorsettings
