### PR TITLE
Add Deposit URL to mets file

### DIFF
--- a/src/main/resources/formats/dspace_mets.xml
+++ b/src/main/resources/formats/dspace_mets.xml
@@ -59,7 +59,7 @@
                     <!-- thesis.degree.grantor = Global configuration setting (settings tab - application settings) -->
                 
                     <!-- dc.identifier.uri == Deposit ID, this would only be available when re-depositing -->
-                    
+                    <dim:field mdschema="dc"  element="identifier" qualifier="uri" th:text="${DEPOSIT_URL}"></dim:field>
                     
                     <!-- dc.type.material = "text" // constant -->
                     <dim:field mdschema="dc" element="type" qualifier="material">text</dim:field>


### PR DESCRIPTION
The DEPOSIT_URL identifier was/is missing in the dpaces_mets.xml