### PR TITLE
[1485] Include mets.xml in DSpaceMETS export

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -622,8 +622,6 @@ public class SubmissionController {
                 ZipOutputStream zos = new ZipOutputStream(sos_mets);
 
                 for (Submission submission : submissionRepo.batchDynamicSubmissionQuery(filter, columns)) {
-
-//                    String submissionName = "submission_" + submission.getId() + "/";
                     ExportPackage exportPackage = packagerUtility.packageExport(packager, submission);
                     File exportFile = (File) exportPackage.getPayload();
                     byte[] fileBytes =  FileUtils.readFileToByteArray(exportFile);

--- a/src/main/java/org/tdl/vireo/model/packager/DSpaceMetsPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/DSpaceMetsPackager.java
@@ -5,12 +5,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
-import java.util.Map;
-import java.util.HashMap;
 
 import javax.persistence.Entity;
 
@@ -63,7 +62,6 @@ public class DSpaceMetsPackager extends AbstractPackager<ZipExportPackage> {
 
             List<FieldValue> documentFieldValues = submission.getAllDocumentFieldValues();
             for (FieldValue documentFieldValue : documentFieldValues) {
-
                 // TODO: add file whitelist for publish
 
                 File exportFile = getAbsolutePath(documentFieldValue.getValue()).toFile();
@@ -71,7 +69,6 @@ public class DSpaceMetsPackager extends AbstractPackager<ZipExportPackage> {
                 zos.putNextEntry(new ZipEntry(documentFieldValue.getFileName()));
                 zos.write(Files.readAllBytes(exportFile.toPath()));
                 zos.closeEntry();
-
             }
 
             zos.close();

--- a/src/main/java/org/tdl/vireo/utility/PackagerUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/PackagerUtility.java
@@ -26,10 +26,14 @@ public class PackagerUtility {
 
     public ExportPackage packageExport(Packager<?> packager, Submission submission) throws Exception {
         Map<String, String> formatterMap = formatterUtility.renderManifestMap(packager.getFormatter(), submission);
-        if (formatterMap.isEmpty() || !formatterMap.containsKey(TEMPLATE_KEY)) {
+        if (formatterMap.isEmpty()) {
             throw new UnsupportedFormatterException("Required manifest not found!");
         }
-        return packager.packageExport(submission, formatterMap.get(TEMPLATE_KEY));
+        if (!formatterMap.containsKey(TEMPLATE_KEY)) {
+            return this.packageExport(packager, submission, formatterMap);
+        } else {
+            return packager.packageExport(submission, formatterMap.get(TEMPLATE_KEY));
+        }
     }
 
     public ExportPackage packageExport(Packager<?> packager, Submission submission, List<SubmissionListColumn> columns) {


### PR DESCRIPTION
Resolves #1485 

The existing DSpaceMETS export code was confused and gathering the same secondary files twice, once in the packager, then again in the SubmissionController. It was also ignoring the files generated by the packager altogether, which is where the mets.xml comes from.

This PR removes the duplicate file building code from the controller and instead adds each submission entry's zip file (with mets.xml) from the packager to a zip file of submission zip files.

This PR also fixes a problem in the PackagerUtility that was preventing exports from working for any export whose formatter didn't use TEMPLATE_KEY in its file map.