### PR TITLE
Actual fix to modal backdrop breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start-dev": "wvr server -b /vireo --uid vireo-webserver"
   },
   "dependencies": {
-    "@wvr/core": "next",
+    "@wvr/core": "2.2.0",
     "angular-ui-tinymce": "0.0.19",
     "file-saver": "2.0.0",
     "ng-csv": "0.3.6",

--- a/src/main/webapp/app/views/admin/settings/organization.html
+++ b/src/main/webapp/app/views/admin/settings/organization.html
@@ -8,10 +8,9 @@
 
 	<div class="row">
 		<div id="organizationManagement" class="col-xs-12" ng-controller="OrganizationManagementController">
-			<div class="row" ng-if="showOrganizationManagement()">
+			<div class="row" ng-show="showOrganizationManagement()">
 				<div class="panel-heading">
 					<h3 class="panel-title">
-
 						<ul class="inline-list">
 							<li ng-click="activateManagementPane('edit')">
 								<span	class="management-pane-selector"

--- a/src/main/webapp/app/views/directives/triptych.html
+++ b/src/main/webapp/app/views/directives/triptych.html
@@ -17,15 +17,13 @@
 				</div>
 			</div>
 		</div>
-		<div class="row" ng-if="organizations.length == 1">
+		<div class="row" ng-if="organizations.length === 1">
 			<div class="col-xs-12">
 				<p>Your Institution has no child organizations. Use the 'Create Organization' side module to create your first organization.</p>
 			</div>
 		</div>
 		<div class="row triptych-panels">
-		
 			<div class="col-xs-12 col-sm-6 col-md-4 panel-wrapper" ng-repeat="panel in navigation.panels | filter:{visible:true}" ng-class="{'opening': panel.opening, 'closing': panel.closing, 'showing': panel.visible, 'back': navigation.backward}">
-
 				<div class="panel panel-default triptych-panel" ng-class="{'active': panel.active, 'previously-active': panel.previouslyActive}" ng-if="organizations.length > 1">
 					<div class="panel-heading" ng-click="navigation.expanded = true">
 						<span ng-repeat="category in panel.categories" ng-click="panel.filter = category">
@@ -58,16 +56,14 @@
 									</li>
 								</ul>
 								<span>
-									{{organization.name}}
+									<span>{{organization.name}}</span>
 									<span class="badge" ng-if="organization.childrenOrganizations.length">{{organization.childrenOrganizations.length}}</span>
 									<span class="category-label" ng-if="panel.categories.length > 1">{{organization.category.name}}</span>
 								</span>
 							</li>
 						</ul>
 					</div>
-
 				</div>
-
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Discovered that the modal backdrop still does not close on delete of organization. As the binding has improved during repo updates on broadcast, it still cannot maintain the binding of a selected organization being deleted. 

The actual cause of the modal not closing properly was this ng-if which removed several views when the selected organizations' binding breaks. Changing to ng-show keeps the views on the DOM but hidden, thus allowing bootstrap to close the modal.