### PR TITLE
1526 init

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -593,6 +593,18 @@ public class Submission extends ValidatingBaseEntity {
     }
 
     @JsonIgnore
+    public List<FieldValue> getFieldValuesByPredicateValueStartsWith(String predicateValue) {
+        List<FieldValue> fieldValues = new ArrayList<FieldValue>();
+        getFieldValues().forEach(fieldValue -> {
+            if (fieldValue.getFieldPredicate().getValue().startsWith(predicateValue)) {
+                fieldValues.add(fieldValue);
+            }
+        });
+        return fieldValues;
+    }   
+
+
+    @JsonIgnore
     public FieldValue getFieldValueByValueAndPredicate(String value, FieldPredicate fieldPredicate) {
         FieldValue foundFieldValue = null;
         for (FieldValue fieldValue : getFieldValues()) {

--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -535,7 +535,7 @@ public class SubmissionHelperUtility {
     }
 
     public List<FieldValue> getCommitteeChairFieldValues() {
-        return submission.getFieldValuesByPredicateValue("dc.contributor.advisor");
+        return submission.getFieldValuesByPredicateValueStartsWith("dc.contributor.advisor");
     }
 
     public String getFirstName(String name) {
@@ -574,7 +574,7 @@ public class SubmissionHelperUtility {
     }
 
     public List<FieldValue> getCommitteeMemberFieldValues() {
-        return submission.getFieldValuesByPredicateValue("dc.contributor.committeeMember");
+        return submission.getFieldValuesByPredicateValueStartsWith("dc.contributor.committeeMember");
     }
 
     public String getLanguageProQuestCode() {


### PR DESCRIPTION
In this particular example the site has the following alternate
advisor names, Co-Chair, Thesis Co-Director, Thesis Director, etc.

These values come from the vireo3 database and are recreated in vireo4 by editing the SYSTEM_Organization_Definition.json file

       {
          "fieldPredicate": {
            "value": "dc.contributor.advisor.Co-Chair",
            "documentTypePredicate": false
          },
          "originatingWorkflowStep": {
            "name": "Document Information"
          },
          "inputType": {
            "name": "INPUT_CONTACT_SELECT"
          },
          "repeatable": false,
          "overrideable": true,
          "enabled": true,
          "optional": false,
          "flagged": false,
          "logged": false,
          "usage": "",
          "help": "Select the name and email address for your committee Co-Chair.",
          "gloss": "Co-Chair",
          "controlledVocabulary": {
            "name": "Committee Members",
            "isEntityProperty": false
          }
        },

This sets field predicates used by field_value;

 37 | f                       | dc.contributor.advisor
 38 | f                       | dc.contributor.advisor.Co-Chair
 39 | f                       | dc.contributor.advisor.ThesisCo-Director
 40 | f                       | dc.contributor.advisor.ThesisDirector
 41 | f                       | dc.contributor.advisor.DissertationCo-Director
 42 | f                       | dc.contributor.advisor.Chair
 43 | f                       | dc.contributor.advisor.DissertationDirector
 44 | f                       | dc.contributor.committeeMember

These all get rendered in a DSpaceSimple export dublin_core.xml file as multiple <dcvalue element="contributor" qualifier="advisor"> elements, one for each advisor or alternate advisor.  Since the field_predicates other than 37 and 44 are not true dublin core names they get rendered as either advisor or committeeMember

