### PR TITLE
[1525] Remove unique index on Submission, replacing it with a normal index.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -26,22 +26,24 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonView;
-
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.SubmissionValidator;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 
 @Entity
 @JsonIgnoreProperties(value = { "organization" }, allowGetters = true)
 @Table(
-    uniqueConstraints = @UniqueConstraint(columnNames = { "submitter_id", "organization_id" }),
-    indexes = @Index(columnList = "submitter_id", name = "submission_submitter_id_idx")
+    indexes = {
+        @Index(columnList = "submitter_id", name = "submission_submitter_id_idx"),
+        @Index(columnList = "submitter_id, organization_id", name = "submission_organization_idx")
+    }
 )
 public class Submission extends ValidatingBaseEntity {
 

--- a/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
@@ -11,7 +11,7 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface SubmissionRepo extends WeaverRepo<Submission>, SubmissionRepoCustom {
 
-    public Submission findBySubmitterAndOrganization(User submitter, Organization organization);
+    public List<Submission> findAllBySubmitterAndOrganization(User submitter, Organization organization);
 
     public List<Submission> findByOrganization(Organization organization);
 

--- a/src/main/webapp/app/views/submission/submissionNew.html
+++ b/src/main/webapp/app/views/submission/submissionNew.html
@@ -3,13 +3,13 @@
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-4">
         <form name="newSubmission" ng-if="ready">
-          <button ng-if="!hasSubmission(getSelectedOrganization()) && getSelectedOrganization().acceptsSubmissions" class="btn btn-primary triptych-start-submission form-control" ng-click="createSubmission(getSelectedOrganization())" ng-disabled="creatingSubmission">
+          <button ng-if="getSelectedOrganization().acceptsSubmissions" class="btn btn-primary triptych-start-submission form-control" ng-click="createSubmission(getSelectedOrganization())" ng-disabled="creatingSubmission">
             <span>Start {{getSelectedOrganization().name}} Submission <span ng-if="creatingSubmission" class="glyphicon glyphicon-refresh spinning"> </span></span>
           </button>
-          <button ng-if="hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission form-control" ng-click="gotoSubmission(getSelectedOrganization())">
+          <button ng-if="!getSelectedOrganization().acceptsSubmissions && hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission form-control" ng-click="gotoSubmission(getSelectedOrganization())">
             <span>Continue {{getSelectedOrganization().name}} Submission</span>
           </button>
-          <button ng-if="!getSelectedOrganization().acceptsSubmissions" class="btn btn-primary triptych-start-submission disabled form-control">
+          <button ng-if="!getSelectedOrganization().acceptsSubmissions && !hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission disabled form-control">
             <span>Choose an Organization that allows Submissions</span>
           </button>
         </form>


### PR DESCRIPTION
resolves #1525 

Using `submissionDate` is not possible because it can be NULL and is NULL while the submission is In Progress.
A person intending to create two submissions for the same organization might not have at least one submitted.
Furthermore, the granularity of the `submissionDate` is per-day which is too large (it would need to include seconds at the least).

Replace the unique index with a normal index to at least maintain any performance gains of an index while dropping the uniqueness aspect.

The UI also needs changes to allow for creating a new submission.
The pre-existing behavior always tries to continue editing if an existing submission has the same organization for a new submission.
This makes it impossible to create a new submission for the same organization as an existing submission.
The if condition logic is changed such that only when the existing submissions organization no longer allows submissions shall it perform a "continue submission" rather than creating a new submission.

This introduces a new situation that did not exist before that needs additional consideration that is (partially) outside the scope of this change.
When there are two or more existing submissions for the same organization and that organization no longer allows submissions then there is way to select which of the existing submissions to continue.
This requires design change considerations.
Rather than make these decisions within the scope of this issue, I have opted to have this problem addressed in a separate issue.
The current implementation preserves the existing nuances where "continue" should still happen as it did before, so long as there is a single submission for some organization or that organization allows new submission.

The tests have been updating accordingly because the pre-existing tests are expecting uniqueness.
The `findBySubmitterAndOrganization()` method is only used by tests and has been update to `findAllBySubmitterAndOrganization()`.