### PR TITLE
[1494] Add missing replyTo address to e-mails.

### DIFF
--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -110,6 +110,7 @@ public class SubmissionEmailService {
 
                 if (!recipientList.isEmpty()) {
                     smm.setFrom(emailSender.getFrom());
+                    smm.setReplyTo(emailSender.getReplyTo());
                     smm.setTo(recipientList.toArray(new String[0]));
                     smm.setSubject(subject);
                     smm.setText(content);
@@ -161,6 +162,7 @@ public class SubmissionEmailService {
             }
 
             smm.setFrom(emailSender.getFrom());
+            smm.setReplyTo(emailSender.getReplyTo());
             smm.setSubject(subject);
             smm.setText(templatedMessage);
 
@@ -215,6 +217,7 @@ public class SubmissionEmailService {
                         }
 
                         smm.setFrom(emailSender.getFrom());
+                        smm.setReplyTo(emailSender.getReplyTo());
                         smm.setSubject(subject);
                         smm.setText(content);
 


### PR DESCRIPTION
resolves #1494 (in regards to the `replyTo` address).

The other problem is not addressed as I was not able to reproduce it and e-mails seem to work as far as I can tell.
I suspect that this other problem might be some configuration or some packaging problem.
