### PR TITLE
[1521] Customizable footer links for Webmaster, Legal, Comments, Accessibility.

### DIFF
--- a/src/main/java/org/tdl/vireo/config/constant/ConfigurationName.java
+++ b/src/main/java/org/tdl/vireo/config/constant/ConfigurationName.java
@@ -33,6 +33,19 @@ public class ConfigurationName {
     /** The replyTo address attached to every email by default **/
     public final static String EMAIL_REPLY_TO = "email_reply_to";
 
+    // Website links shown on the Footer.
+    /** Provide a link to the webmaster, such as an e-mail link. */
+    public final static String FOOTER_LINK_WEBMASTER = "footer.link_webmaster";
+
+    /** Provide a link to the legal, such as an URL link. */
+    public final static String FOOTER_LINK_LEGAL = "footer.link_legal";
+
+    /** Provide a link to the comments, such as an e-mail link. */
+    public final static String FOOTER_LINK_COMMENTS = "footer.link_comments";
+
+    /** Provide a link to the accessibility, such as an URL link. */
+    public final static String FOOTER_LINK_ACCESSIBILITY = "footer.link_accessibility";
+
     // Theme settings
     /** Background main color */
     public final static String THEME_PATH = "theme_path";

--- a/src/main/resources/settings/SYSTEM_Defaults.json
+++ b/src/main/resources/settings/SYSTEM_Defaults.json
@@ -25,6 +25,20 @@
       "new_submission_header_text":"Choose Your Organization"
     }
   ],
+  "footer":[
+    {
+      "link_webmaster":"dev@tdl.org"
+    },
+    {
+      "link_legal":"dev@tdl.org"
+    },
+    {
+      "link_comments":"dev@tdl.org"
+    },
+    {
+      "link_accessibility":"dev@tdl.org"
+    }
+  ],
   "orcid":[
     {
       "orcid_validation":true

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -146,23 +146,23 @@
 
   </main>
 
-  <footer class="footer">
+  <footer class="footer" ng-controller="FooterController">
     <div class="container">
       <ul class="inline-list">
         <li>&copy; Vireo
           <span app-version></span>
         </li>
         <li>
-          <a href="#">Webmaster</a>
+          <a href="{{webmaster}}">Webmaster</a>
         </li>
         <li>
-          <a href="#">Legal</a>
+          <a href="{{legal}}">Legal</a>
         </li>
         <li>
-          <a href="#">Comments</a>
+          <a href="{{comments}}">Comments</a>
         </li>
         <li>
-          <a href="#">Accessibility</a>
+          <a href="{{accessibility}}">Accessibility</a>
         </li>
       </ul>
     </div>
@@ -411,6 +411,7 @@
   <script src="controllers/abstractController.js"></script>
   <script src="controllers/adminController.js"></script>
   <script src="controllers/headerController.js"></script>
+  <script src="controllers/footerController.js"></script>
   <script src="controllers/applicationSettingsController.js"></script>
   <script src="controllers/organizationSettingsController.js"></script>
   <script src="controllers/workflowManagementController.js"></script>

--- a/src/main/webapp/app/controllers/footerController.js
+++ b/src/main/webapp/app/controllers/footerController.js
@@ -1,0 +1,37 @@
+vireo.controller("FooterController", function ($scope, $controller, ManagedConfigurationRepo) {
+
+    angular.extend($scope, $controller("AbstractController", { $scope: $scope }));
+
+    $scope.configurable = ManagedConfigurationRepo.getAll();
+
+    $scope.webmaster = "#";
+    $scope.legal = "#";
+    $scope.comments = "#";
+    $scope.accessibility = "#";
+
+    ManagedConfigurationRepo.ready().then(function() {
+
+        if ($scope.configurable.footer) {
+            $scope.webmaster = $scope.buildLink($scope.configurable.footer.link_webmaster);
+            $scope.legal = $scope.buildLink($scope.configurable.footer.link_legal);
+            $scope.comments = $scope.buildLink($scope.configurable.footer.link_comments);
+            $scope.accessibility = $scope.buildLink($scope.configurable.footer.link_accessibility);
+        }
+    });
+
+    $scope.buildLink = function (setting) {
+
+        if (setting && setting.value) {
+            var regex = /^[^@]{1,}@[^@]{1,}$/;
+
+            if (regex.test(setting.value)) {
+                return "mailto:" + setting.value;
+            }
+
+            return setting.value;
+        }
+
+        return "#";
+    };
+
+});

--- a/src/main/webapp/app/views/admin/settings/application.html
+++ b/src/main/webapp/app/views/admin/settings/application.html
@@ -10,6 +10,7 @@
       <vireo-pane query="whoHasAccess" html="views/admin/settings/application/whoHasAccess.html">WHO HAS ACCESS</vireo-pane>
       <vireo-pane query="lookAndFeel" html="views/admin/settings/application/lookAndFeel.html">LOOK AND FEEL</vireo-pane>
       <vireo-pane query="emailTemplates" html="views/admin/settings/application/emailTemplates.html">EMAIL TEMPLATES</vireo-pane>
+      <vireo-pane query="footerLinks" html="views/admin/settings/application/footerLinks.html">FOOTER LINKS</vireo-pane>
     </vireo-accordion>
   </div>
 </div>

--- a/src/main/webapp/app/views/admin/settings/application/footerLinks.html
+++ b/src/main/webapp/app/views/admin/settings/application/footerLinks.html
@@ -1,0 +1,51 @@
+<div class="row">
+    <div class="col-md-10 col-md-offset-1">
+        <validatedinput
+            id="webmaster-value"
+            type="text"
+            label="Webmaster Link"
+            model="settings.configurable.footer.link_webmaster"
+            property="value"
+            validations="settings.configurable.footer.footer_link_webmaster.getValidations()"
+            confirm="updateConfiguration('footer', 'link_webmaster')"
+            form-view="true"
+            tool-tip="A URL to a page regarding the webmaster or an e-mail link to the webmaster.">
+        </validatedinput>
+
+        <validatedinput
+            id="legal-value"
+            type="text"
+            label="Legal Link"
+            model="settings.configurable.footer.link_legal"
+            property="value"
+            validations="settings.configurable.footer.footer_link_webmaster.getValidations()"
+            confirm="updateConfiguration('footer', 'link_legal')"
+            form-view="true"
+            tool-tip="A URL to a page regarding the legal or an e-mail for a legal related purposes.">
+        </validatedinput>
+
+        <validatedinput
+            id="comments-value"
+            type="text"
+            label="Comments Link"
+            model="settings.configurable.footer.link_comments"
+            property="value"
+            validations="settings.configurable.footer.footer_link_webmaster.getValidations()"
+            confirm="updateConfiguration('footer', 'link_comments')"
+            form-view="true"
+            tool-tip="A URL to a page regarding comments or an e-mail for receiving comments.">
+        </validatedinput>
+
+        <validatedinput
+            id="accessibility-value"
+            type="text"
+            label="Accessibility Link"
+            model="settings.configurable.footer.link_accessibility"
+            property="value"
+            validations="settings.configurable.footer.footer_link_webmaster.getValidations()"
+            confirm="updateConfiguration('footer', 'link_accessibility')"
+            form-view="true"
+            tool-tip="A URL to a page regarding the accessibility or an e-mail for a accessibility related purposes.">
+        </validatedinput>
+    </div>
+</div>

--- a/src/main/webapp/tests/unit/controllers/footerControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/footerControllerTest.js
@@ -1,0 +1,103 @@
+describe("controller: FooterController", function () {
+
+    var controller, scope, WsApi;
+
+    var initializeVariables = function(settings) {
+        inject(function ($location, $timeout, _WsApi_) {
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeController = function(settings) {
+        inject(function ($controller, $rootScope, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_) {
+            scope = $rootScope.$new();
+
+            sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
+            sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
+
+            if (settings && settings.configurable) {
+                scope.configurable = settings.configurable;
+            }
+
+            controller = $controller("FooterController", {
+                $scope: scope,
+                $window: mockWindow(),
+                ManagedConfigurationRepo: _ManagedConfigurationRepo_,
+                ModalService: _ModalService_,
+                RestApi: _RestApi_,
+                StorageService: _StorageService_,
+                WsApi: WsApi
+            });
+
+            // ensure that the isReady() is called.
+            if (!scope.$$phase) {
+                scope.$digest();
+            }
+        });
+    };
+
+    beforeEach(function() {
+        module("core");
+        module("vireo");
+        module("mock.managedConfiguration");
+        module("mock.managedConfigurationRepo");
+        module("mock.modalService");
+        module("mock.restApi");
+        module("mock.storageService");
+        module("mock.wsApi");
+
+        installPromiseMatchers();
+        initializeVariables();
+        initializeController();
+    });
+
+    describe("Is the controller defined", function () {
+        it("should be defined", function () {
+            expect(controller).toBeDefined();
+        });
+    });
+
+    describe("Are the scope methods defined", function () {
+        it("buildLink should be defined", function () {
+            expect(scope.buildLink).toBeDefined();
+            expect(typeof scope.buildLink).toEqual("function");
+        });
+    });
+
+    describe("Do the scope methods work as expected", function () {
+        it("buildLink should generate default link", function () {
+            var built;
+
+            built = scope.buildLink();
+            expect(built).toBe("#");
+
+            built = scope.buildLink(null);
+            expect(built).toBe("#");
+
+            built = scope.buildLink({});
+            expect(built).toBe("#");
+
+            built = scope.buildLink({ value: null });
+            expect(built).toBe("#");
+        });
+        it("buildLink should generate link as-is", function () {
+            var built;
+
+            built = scope.buildLink({ value: "#a" });
+            expect(built).toBe("#a");
+
+            built = scope.buildLink({ value: "http://example.com/" });
+            expect(built).toBe("http://example.com/");
+        });
+        it("buildLink should generate e-mail link", function () {
+            var built;
+
+            built = scope.buildLink({ value: "a@b" });
+            expect(built).toBe("mailto:a@b");
+
+            built = scope.buildLink({ value: "\"user name\"@example.com" });
+            expect(built).toBe("mailto:\"user name\"@example.com");
+        });
+    });
+
+});


### PR DESCRIPTION
resolves #1521

I am not sure what "links" should be, so opted to make the program a little more intelligent.

This is designed to either:
1) Accept an e-mail address and prepend mailto:.
2) Accept anything else, such as a URL, and use it directly.

This can easily be simplified into only supporting e-mail addresses if so desired.
It just feels like some of these could go to a page that then has information and links rather than directly use an e-mail link.

There are new configurations introduced by this:
1) `footer.link_webmaster`
2) `footer.link_legal`
3) `footer.link_comments`
4) `footer.link_accessibility`

The customization menu is placed under "Application Settings" below "EMAIL TEMPLATES" and is called "FOOTER LINKS".