### PR TITLE
[1274] Redesign email handling to avoid race condition between Weaver and Spring.

### DIFF
--- a/src/main/java/org/tdl/vireo/auth/controller/AuthController.java
+++ b/src/main/java/org/tdl/vireo/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.mail.MessagingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,6 +31,7 @@ import org.tdl.vireo.model.EmailTemplate;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.EmailTemplateRepo;
 import org.tdl.vireo.model.repo.UserRepo;
+import org.tdl.vireo.service.VireoEmailSender;
 import org.tdl.vireo.utility.TemplateUtility;
 
 import edu.tamu.weaver.auth.controller.WeaverAuthController;
@@ -62,6 +64,9 @@ public class AuthController extends WeaverAuthController {
     @Autowired
     private VireoUserCredentialsService vireoUserCredentialsService;
 
+    @Autowired
+    protected VireoEmailSender emailSender;
+
     @RequestMapping(value = "/register", method = { POST, GET })
     public ApiResponse registration(@RequestBody(required = false) Map<String, String> data, @RequestParam Map<String, String> parameters) {
 
@@ -89,8 +94,8 @@ public class AuthController extends WeaverAuthController {
 
             try {
                 emailSender.sendEmail(email, emailTemplate.getSubject(), content);
-            } catch (javax.mail.MessagingException e) {
-                logger.debug("Unable to send email! " + email);
+            } catch (MessagingException e) {
+                logger.debug("Unable to send email " + email + ", because: " + e.getMessage());
                 return new ApiResponse(ERROR, "Unable to send email! " + email);
             }
 

--- a/src/main/java/org/tdl/vireo/config/AppEmailConfig.java
+++ b/src/main/java/org/tdl/vireo/config/AppEmailConfig.java
@@ -1,68 +1,20 @@
 package org.tdl.vireo.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.tdl.vireo.config.constant.ConfigurationName;
-import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.service.VireoEmailSender;
 
 import edu.tamu.weaver.email.config.WeaverEmailConfig;
 import edu.tamu.weaver.email.service.EmailSender;
-import edu.tamu.weaver.email.service.WeaverEmailService;
 
 @Configuration
 @Profile(value = { "!test" })
 public class AppEmailConfig extends WeaverEmailConfig {
 
-    @Autowired
-    private ConfigurationRepo configurationRepo;
-    
-    @Value("${app.email.username:''}")
-    private String username;
-    
-    @Value("${app.email.password:''}")
-    private String password;
-    
-    @Value("${app.email.port:25}")
-    private int port;
-    
-    @Value("${app.email.protocol:smtp}")
-    private String protocol;
-    
-    @Value("${app.email.channel:clear}")
-    private String channel;
-
     @Bean
     @Override
     public EmailSender emailSender() {
-        WeaverEmailService emailService = new WeaverEmailService();
-
-        emailService.setDefaultEncoding("UTF-8");
-
-        emailService.setHost(getConfigValue(ConfigurationName.APPLICATION_MAIL_HOST, defaultHost));
-        emailService.setFrom(getConfigValue(ConfigurationName.APPLICATION_MAIL_FROM, defaultFrom));
-        emailService.setReplyTo(getConfigValue(ConfigurationName.APPLICATION_MAIL_REPLYTO, defaultReplyTo));
-
-        // some hardcoded defaults
-        emailService.setPort(getConfigValue(ConfigurationName.APPLICATION_MAIL_PORT, port));
-        emailService.setProtocol(getConfigValue(ConfigurationName.APPLICATION_MAIL_PROTOCOL, protocol));
-        emailService.setUsername(getConfigValue(ConfigurationName.APPLICATION_MAIL_USER, (String) username));
-        emailService.setPassword(getConfigValue(ConfigurationName.APPLICATION_MAIL_PASSWORD, (String) password));
-        emailService.setChannel(getConfigValue(ConfigurationName.APPLICATION_MAIL_CHANNEL, channel));
-
-        return emailService;
+        return new VireoEmailSender();
     }
-
-    private String getConfigValue(String name, String defaultValue) {
-        String value = configurationRepo.getValueByName(name);
-        return (value != null) ? value : defaultValue;
-    }
-
-    private Integer getConfigValue(String name, Integer defaultValue) {
-        Integer value = Integer.getInteger(configurationRepo.getValueByName(name));
-        return (value != null) ? value : defaultValue;
-    }
-
 }

--- a/src/main/java/org/tdl/vireo/config/VireoEmailConfig.java
+++ b/src/main/java/org/tdl/vireo/config/VireoEmailConfig.java
@@ -1,0 +1,141 @@
+package org.tdl.vireo.config;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.tdl.vireo.config.constant.ConfigurationName;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
+
+@Configuration
+public class VireoEmailConfig {
+
+    @Autowired
+    private ConfigurationRepo configurationRepo;
+
+    @Value("${app.email.host:''}")
+    private String host;
+
+    @Value("${app.email.from:''}")
+    private String from;
+
+    @Value("${app.email.replyTo:''}")
+    private String replyTo;
+
+    @Value("${app.email.username:''}")
+    private String username;
+
+    @Value("${app.email.password:''}")
+    private String password;
+
+    @Value("${app.email.port:25}")
+    private int port;
+
+    @Value("${app.email.protocol:smtp}")
+    private String protocol;
+
+    @Value("${app.email.channel:clear}")
+    private String channel;
+
+    @Value("${app.email.encoding:UTF8}")
+    private String encoding;
+
+    @PostConstruct
+    public void postConstruct() {
+        host = getConfigValue(ConfigurationName.APPLICATION_MAIL_HOST, host);
+        from = getConfigValue(ConfigurationName.APPLICATION_MAIL_FROM, from);
+        replyTo = getConfigValue(ConfigurationName.APPLICATION_MAIL_REPLYTO, replyTo);
+
+        // some hardcoded defaults
+        port = getConfigValue(ConfigurationName.APPLICATION_MAIL_PORT, port);
+        protocol = getConfigValue(ConfigurationName.APPLICATION_MAIL_PROTOCOL, protocol);
+        username = getConfigValue(ConfigurationName.APPLICATION_MAIL_USER, username);
+        password = getConfigValue(ConfigurationName.APPLICATION_MAIL_PASSWORD, password);
+        channel = getConfigValue(ConfigurationName.APPLICATION_MAIL_CHANNEL, channel);
+        encoding = getConfigValue(ConfigurationName.APPLICATION_MAIL_ENCODING, encoding);
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getReplyTo() {
+        return replyTo;
+    }
+
+    public void setReplyTo(String replyTo) {
+        this.replyTo = replyTo;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+
+    public void setChannel(String channel) {
+        this.channel = channel;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    private String getConfigValue(String name, String defaultValue) {
+        String value = configurationRepo.getValueByName(name);
+        return (value != null) ? value : defaultValue;
+    }
+
+    private Integer getConfigValue(String name, Integer defaultValue) {
+        Integer value = Integer.getInteger(configurationRepo.getValueByName(name));
+        return (value != null) ? value : defaultValue;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/config/constant/ConfigurationName.java
+++ b/src/main/java/org/tdl/vireo/config/constant/ConfigurationName.java
@@ -106,6 +106,7 @@ public class ConfigurationName {
     public final static String APPLICATION_MAIL_PASSWORD = "mail.pass";
     public final static String APPLICATION_MAIL_CHANNEL = "mail.channel";
     public final static String APPLICATION_MAIL_PROTOCOL = "mail.protocol";
+    public final static String APPLICATION_MAIL_ENCODING = "mail.encoding";
     public final static String APPLICATION_AUTH_FORCE_SSL = "auth.forceSSL";
     public final static String APPLICATION_AUTH_PASS_ENABLED = "auth.pass.enabled";
     public final static String APPLICATION_AUTH_PASS_VISIBLE = "auth.pass.visible";

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -110,6 +110,7 @@ public class SubmissionEmailService {
 
                 if (!recipientList.isEmpty()) {
                     smm.setFrom(emailSender.getFrom());
+                    smm.setReplyTo(emailSender.getReplyTo());
                     smm.setTo(recipientList.toArray(new String[0]));
                     smm.setSubject(subject);
                     smm.setText(content);
@@ -161,6 +162,7 @@ public class SubmissionEmailService {
             }
 
             smm.setFrom(emailSender.getFrom());
+            smm.setReplyTo(emailSender.getReplyTo());
             smm.setSubject(subject);
             smm.setText(templatedMessage);
 
@@ -215,6 +217,7 @@ public class SubmissionEmailService {
                         }
 
                         smm.setFrom(emailSender.getFrom());
+                        smm.setReplyTo(emailSender.getReplyTo());
                         smm.setSubject(subject);
                         smm.setText(content);
 

--- a/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
+++ b/src/main/java/org/tdl/vireo/service/SubmissionEmailService.java
@@ -7,13 +7,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.mail.MessagingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
 import org.tdl.vireo.model.EmailRecipient;
@@ -35,15 +33,14 @@ import org.tdl.vireo.model.repo.FieldPredicateRepo;
 import org.tdl.vireo.model.repo.impl.AbstractEmailRecipientRepoImpl;
 import org.tdl.vireo.utility.TemplateUtility;
 
-import edu.tamu.weaver.email.service.EmailSender;
-import edu.tamu.weaver.email.service.WeaverEmailService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Provide e-mail sending specific to the Submission process.
  *
  * E-mails are built utilizing SimpleMailMessage and then sent via EmailSender.
  *
- * @see EmailSender
+ * @see VireoEmailSender
  * @see SimpleMailMessage
  */
 @Service
@@ -58,9 +55,6 @@ public class SubmissionEmailService {
     private ActionLogRepo actionLogRepo;
 
     @Autowired
-    private WeaverEmailService emailSender;
-
-    @Autowired
     private EmailWorkflowRuleRepo emailWorkflowRuleRepo;
 
     @Autowired
@@ -69,10 +63,8 @@ public class SubmissionEmailService {
     @Autowired
     private TemplateUtility templateUtility;
 
-    @Bean
-    public WeaverEmailService weaverEmailService()   {
-        return new WeaverEmailService();
-    }
+    @Autowired
+    private VireoEmailSender emailSender;
 
     /**
      * Manually send the e-mails to the advisors for a given Submission.
@@ -98,7 +90,7 @@ public class SubmissionEmailService {
                 String content = templateUtility.compileTemplate(template, submission);
 
                 List<FieldValue> advisorList = submission.getFieldValuesByPredicateValue("dc.contributor.advisor");
-                SimpleMailMessage smm = new SimpleMailMessage();
+
                 List<String> recipientList = new ArrayList<>();
                 advisorList.forEach(afv -> {
                   for (String afvcontact : afv.getContacts()) {
@@ -109,14 +101,14 @@ public class SubmissionEmailService {
                 });
 
                 if (!recipientList.isEmpty()) {
-                    smm.setFrom(emailSender.getFrom());
-                    smm.setReplyTo(emailSender.getReplyTo());
-                    smm.setTo(recipientList.toArray(new String[0]));
-                    smm.setSubject(subject);
-                    smm.setText(content);
+                    try {
+                        String[] to = recipientList.toArray(new String[0]);
+                        emailSender.sendEmail(to, subject, content);
 
-                    emailSender.send(smm);
-                    emailed = true;
+                        emailed = true;
+                    } catch (MessagingException me) {
+                        LOG.error("Problem sending email: " + me.getMessage());
+                    }
                 }
             }
 
@@ -143,32 +135,33 @@ public class SubmissionEmailService {
             String subject = templateUtility.compileString((String) data.get("subject"), submission);
             String templatedMessage = templateUtility.compileString((String) data.get("message"), submission);
             StringBuilder recipientEmails = new StringBuilder();
-            SimpleMailMessage smm = new SimpleMailMessage();
 
             List<String> recipientEmailAddresses = buildEmailRecipients("recipientEmails", submission, data);
-            smm.setTo(recipientEmailAddresses.toArray(new String[0]));
 
-            recipientEmails.append("Email sent to: [ " + String.join(";", recipientEmailAddresses) + " ]; ");
+            try {
+                String[] to = recipientEmailAddresses.toArray(new String[0]);
+                String[] cc = new String[] { };
+                String[] bcc = new String[] { };
 
-            if (data.containsKey("sendEmailToCCRecipient") && (boolean) data.get("sendEmailToCCRecipient")) {
-                List<String> ccRecipientEmailAddresses = buildEmailRecipients("ccRecipientEmails", submission, data);
-                smm.setCc(ccRecipientEmailAddresses.toArray(new String[0]));
-                recipientEmails.append(" and cc to: [ " + String.join(";", ccRecipientEmailAddresses) + " ]; ");
+                recipientEmails.append("Email sent to: [ " + String.join(";", recipientEmailAddresses) + " ]; ");
+
+                if (data.containsKey("sendEmailToCCRecipient") && (boolean) data.get("sendEmailToCCRecipient")) {
+                    List<String> ccRecipientEmailAddresses = buildEmailRecipients("ccRecipientEmails", submission, data);
+                    cc = ccRecipientEmailAddresses.toArray(new String[0]);
+                    recipientEmails.append(" and cc to: [ " + String.join(";", ccRecipientEmailAddresses) + " ]; ");
+                }
+
+                if (user.getSetting("ccEmail") != null && user.getSetting("ccEmail").equals("true")) {
+                    String preferredEmail = user.getSetting("preferedEmail");
+                    bcc = new String[] { preferredEmail == null ? user.getEmail() : preferredEmail } ;
+                }
+
+                emailSender.sendEmail(to, cc, bcc, subject, templatedMessage);
+
+                actionLogRepo.createPublicLog(submission, user, recipientEmails.toString() + subject + ": " + templatedMessage);
+            } catch (MessagingException me) {
+                LOG.error("Problem sending email: " + me.getMessage());
             }
-
-            if (user.getSetting("ccEmail") != null && user.getSetting("ccEmail").equals("true")) {
-                String preferredEmail = user.getSetting("preferedEmail");
-                smm.setBcc(preferredEmail == null ? user.getEmail() : preferredEmail);
-            }
-
-            smm.setFrom(emailSender.getFrom());
-            smm.setReplyTo(emailSender.getReplyTo());
-            smm.setSubject(subject);
-            smm.setText(templatedMessage);
-
-            emailSender.send(smm);
-
-            actionLogRepo.createPublicLog(submission, user, recipientEmails.toString() + subject + ": " + templatedMessage);
         }
     }
 
@@ -179,7 +172,6 @@ public class SubmissionEmailService {
      * @param submission Associated Submission.
      */
     public void sendWorkflowEmails(User user, Submission submission) {
-        SimpleMailMessage smm = new SimpleMailMessage();
 
         List<EmailWorkflowRule> rules = submission.getOrganization().getAggregateEmailWorkflowRules();
         Map<Long, List<String>> recipientLists = new HashMap<>();
@@ -207,22 +199,14 @@ public class SubmissionEmailService {
                     recipientLists.get(templateId).add(email);
 
                     try {
-                        LOG.debug("\tSending email to recipient at address " + email);
-
-                        smm.setTo(email);
-
                         if ("true".equals(user.getSetting("ccEmail"))) {
                             String preferedEmail = user.getSetting("preferedEmail");
-                            smm.setBcc(preferedEmail == null ? user.getEmail() : preferedEmail);
+                            String bcc = preferedEmail == null ? user.getEmail() : preferedEmail;
+                            emailSender.sendEmail(email, new String[] { bcc }, subject, content);
+                        } else {
+                            emailSender.sendEmail(email, subject, content);
                         }
-
-                        smm.setFrom(emailSender.getFrom());
-                        smm.setReplyTo(emailSender.getReplyTo());
-                        smm.setSubject(subject);
-                        smm.setText(content);
-
-                        emailSender.send(smm);
-                    } catch (MailException me) {
+                    } catch (MessagingException me) {
                         LOG.error("Problem sending email: " + me.getMessage());
                         recipientLists.get(templateId).remove(email);
                     }

--- a/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
+++ b/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
@@ -1,0 +1,94 @@
+package org.tdl.vireo.service;
+
+import java.util.Properties;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.tdl.vireo.config.VireoEmailConfig;
+
+import edu.tamu.weaver.email.service.EmailSender;
+
+/**
+ * Provide e-mail sending specific to the Submission process.
+ *
+ * E-mails are built utilizing MimeMessageHelper.
+ *
+ * @see EmailSender
+ * @see MimeMessageHelper
+ */
+@Service
+public class VireoEmailSender extends JavaMailSenderImpl implements EmailSender {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VireoEmailSender.class);
+
+    @Autowired
+    private VireoEmailConfig vireoEmailConfig;
+
+    public void loadConfiguration() {
+        setDefaultEncoding(vireoEmailConfig.getEncoding());
+        setHost(vireoEmailConfig.getHost());
+        setPort(vireoEmailConfig.getPort());
+        setProtocol(vireoEmailConfig.getProtocol());
+
+        Properties properties = super.getJavaMailProperties();
+
+        if (vireoEmailConfig.getUsername() != null && vireoEmailConfig.getPassword() != null) {
+            setUsername(vireoEmailConfig.getUsername());
+            setPassword(vireoEmailConfig.getPassword());
+
+            properties.setProperty("mail.smtp.auth", "true");
+        } else {
+            properties.setProperty("mail.smtp.auth", "false");
+        }
+
+        if (vireoEmailConfig.getChannel().equals("starttls")) {
+            properties.setProperty("mail.smtp.starttls.enable", "true");
+            properties.setProperty("mail.smtps.ssl.checkserveridentity", "false");
+        } else if (vireoEmailConfig.getChannel().equals("ssl")) {
+            properties.setProperty("mail.smtps.ssl.checkserveridentity", "true");
+            properties.setProperty("mail.smtp.starttls.enable", "false");
+        }
+
+        setJavaMailProperties(properties);
+    }
+
+    public void sendEmail(String to, String[] bcc, String subject, String content) throws MessagingException {
+        sendEmail(new String[] { to }, new String[] { }, bcc, subject, content);
+    }
+
+    @Override
+    public void sendEmail(String to, String subject, String content) throws MessagingException {
+        sendEmail(new String[] { to }, new String[] { }, new String[] { }, subject, content);
+    }
+
+    public void sendEmail(String[] to, String subject, String content) throws MessagingException {
+        sendEmail(to, new String[] { }, new String[] { }, subject, content);
+    }
+
+    public void sendEmail(String[] to, String[] cc, String[] bcc, String subject, String content) throws MessagingException {
+        loadConfiguration();
+
+        MimeMessage message = createMimeMessage();
+        MimeMessageHelper mm = new MimeMessageHelper(message);
+
+        mm.setFrom(vireoEmailConfig.getFrom());
+        mm.setReplyTo(vireoEmailConfig.getReplyTo());
+
+        mm.setTo(to);
+        mm.setCc(cc);
+        mm.setBcc(bcc);
+        mm.setSubject(subject);
+        mm.setText(content, false);
+
+        LOG.debug("\tSending email with subject '" + subject + "' from " + vireoEmailConfig.getFrom() + " to: [ " + String.join(";", to) + " ]; ");
+        send(message);
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -115,8 +115,8 @@ app:
 
   # edu.tamu.weaver.auth.service.UserCredentialsService
   authority.admins: admin@tdl.org,aggieJack@tamu.edu
-  
-  
+
+
   security:
     # edu.tamu.weaver.auth.service.CryptoService
     secret: verysecretsecret
@@ -134,6 +134,7 @@ app:
     #port: 587
     #protocol: smtp
     #channel: starttls
+    #encoding: UTF8
 
   # edu.tamu.weaver.reporting.controller.ReportingController
   reporting.address: reporting@tdl.org

--- a/src/test/java/org/tdl/vireo/controller/AuthControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/AuthControllerTest.java
@@ -2,11 +2,16 @@ package org.tdl.vireo.controller;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +21,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.tdl.vireo.auth.controller.AuthController;
@@ -24,6 +30,7 @@ import org.tdl.vireo.model.EmailTemplate;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.EmailTemplateRepo;
 import org.tdl.vireo.model.repo.UserRepo;
+import org.tdl.vireo.service.VireoEmailSender;
 
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiStatus;
@@ -34,6 +41,9 @@ public class AuthControllerTest extends AbstractControllerTest {
     public static final String REGISTRATION_TEMPLATE = "SYSTEM New User Registration";
 
     public static Long emailTemplatePosition = 0L;
+
+    @MockBean
+    private VireoEmailSender mockEmailSender;
 
     @Mock
     private UserRepo userRepo;
@@ -73,7 +83,7 @@ public class AuthControllerTest extends AbstractControllerTest {
     }
 
     @Before
-    public void setup() {
+    public void setup() throws MessagingException {
         MockitoAnnotations.initMocks(this);
 
         mockUsers = Arrays.asList(new User[] { TEST_USER, TEST_USER2, TEST_USER3, TEST_USER4 });
@@ -129,6 +139,12 @@ public class AuthControllerTest extends AbstractControllerTest {
             }
         });
 
+        doCallRealMethod().when(mockEmailSender).sendEmail(any(String.class), any(String.class), any(String.class));
+        doCallRealMethod().when(mockEmailSender).sendEmail(any(String[].class), any(String.class), any(String.class));
+        doCallRealMethod().when(mockEmailSender).sendEmail(any(String.class), any(String[].class), any(String.class), any(String.class));
+
+        doNothing().when(mockEmailSender).send(any(MimeMessage.class));
+        doNothing().when(mockEmailSender).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
     }
 
     @Test


### PR DESCRIPTION
resolves #1274

This is branched off of #1545, please review and ideally approve that PR prior to this one.

There is a race condition during the loading data during sprint boot.

The `EmailSender` Bean may be loaded either before or after the Spring `@Value` annotations are loaded.
If `EmailSender` is loader after the `@Value` annotations are loaded, then the e-mails works as expected.
If the opposite happens, then no data is loaded and the Weaver default (which uses a mailinator address) is incorrectly used.

To avoid this, this commit does the following:
1) Do not use any `@Value` annotations (or any Spring configuration loaders) in the `AppEmailConfig` (where the Bean is loaded).
2) Implement a custom AppConfig loader, called `VireoEmailConfig`, to handle loading of the data.
3) Have the `SubmissionEmailService` Autowire the `VireoEmailSender` and use that to send the e-mails.
4) Load the settings for each e-mail (not ideal, future work is recommended to improve this).

The encoding format shouldn't be hard coded when everything else is not.
Furthermore, it seems that the Weaver design doesn't appear to set the encoding properly (Code shows `UTF-8` and actual e-mail headers show `us-ascii`).

The `VireoEmailConfig` now needs to be available for testing.
The Mockito `verify()` static method does a bad job of detecting if something actually is called.
Even though the final `sendEmail()` method that has 5 arguments gets called (thanks to adding the `doCallRealMethod()`), the `verify()` fails to recognize this.
The tests have to be changed to handle the specific function call even if it is just a pass through method.