### PR TITLE
[1555] Email placeholders in Add Comment and Add File modals not working.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -27,11 +27,6 @@ import java.util.zip.ZipOutputStream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -92,6 +87,11 @@ import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.tamu.weaver.auth.annotation.WeaverCredentials;
 import edu.tamu.weaver.auth.annotation.WeaverUser;
@@ -241,7 +241,7 @@ public class SubmissionController {
     String commentVisibility = data.get("commentVisibility") != null ? (String) data.get("commentVisibility") : "public";
 
     if (commentVisibility.equals("public")) {
-        submissionEmailService.sendAutomatedEmails(user, submission, data);
+        submissionEmailService.sendAutomatedEmails(user, submission.getId(), data);
     } else {
       String subject = (String) data.get("subject");
       String templatedMessage = templateUtility.compileString((String) data.get("message"), submission);
@@ -251,36 +251,36 @@ public class SubmissionController {
     return new ApiResponse(SUCCESS);
   }
 
-  @RequestMapping(value = "/{submissionId}/send-email", method = RequestMethod.POST)
-  @PreAuthorize("hasRole('REVIEWER')")
-  public ApiResponse sendEmail(@WeaverUser User user, @PathVariable Long submissionId,
-      @RequestBody Map<String, Object> data) throws JsonProcessingException, IOException {
-    submissionEmailService.sendAutomatedEmails(user, submissionRepo.read(submissionId), data);
-    return new ApiResponse(SUCCESS);
-  }
+    @RequestMapping(value = "/{submissionId}/send-email", method = RequestMethod.POST)
+    @PreAuthorize("hasRole('REVIEWER')")
+    public ApiResponse sendEmail(@WeaverUser User user, @PathVariable Long submissionId,
+        @RequestBody Map<String, Object> data) throws JsonProcessingException, IOException {
 
+        submissionEmailService.sendAutomatedEmails(user, submissionId, data);
+        return new ApiResponse(SUCCESS);
+    }
 
     @RequestMapping(value = "/batch-comment")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse batchComment(@WeaverUser User user, @RequestBody Map<String, Object> data) {
         submissionRepo.batchDynamicSubmissionQuery(user.getActiveFilter(), user.getSubmissionViewColumns()).forEach(sub -> {
-            Map<String, Object> subMessage = new HashMap<String, Object>(data);
-            if (data.get("commentVisibility").toString().equalsIgnoreCase("public")) {
-                if (data.containsKey("sendEmailToRecipient") && (boolean) data.get("sendEmailToRecipient")) {
-                    subMessage.put("recipientEmail", subMessage.get("recipientEmail"));
+
+            String commentVisibility = data.get("commentVisibility") != null ? (String) data.get("commentVisibility") : "public";
+
+            if (commentVisibility.equals("public")) {
+                try {
+                    submissionEmailService.sendAutomatedEmails(user, sub.getId(), data);
+                } catch (IOException e) {
+                    e.printStackTrace();
                 }
-                if (data.containsKey("sendEmailToCCRecipient") && (boolean) data.get("sendEmailToCCRecipient")) {
-                    subMessage.put("ccRecipientEmail", subMessage.get("ccRecipientEmail"));
-                }
-            }
-            try {
-              addComment(user, sub.getId(), subMessage);
-            } catch (IOException e) {
-              e.printStackTrace();
+            } else {
+              String subject = (String) data.get("subject");
+              String templatedMessage = templateUtility.compileString((String) data.get("message"), sub);
+              actionLogRepo.createPrivateLog(sub, user, subject + ": " + templatedMessage);
             }
         });
-        return new ApiResponse(SUCCESS);
 
+        return new ApiResponse(SUCCESS);
     }
 
     @RequestMapping(value = "/{submissionId}/update-field-value/{fieldProfileId}", method = RequestMethod.POST)
@@ -392,7 +392,7 @@ public class SubmissionController {
         } else {
             response = new ApiResponse(ERROR, "Could not find a submission with ID " + submissionId);
         }
-        submissionEmailService.sendWorkflowEmails(user, submission);
+        submissionEmailService.sendWorkflowEmails(user, submission.getId());
         return response;
     }
 
@@ -402,7 +402,7 @@ public class SubmissionController {
         submissionRepo.batchDynamicSubmissionQuery(user.getActiveFilter(), user.getSubmissionViewColumns()).forEach(submission -> {
             SubmissionStatus submissionStatus = submissionStatusRepo.findByName(submissionStatusName);
             submission = submissionRepo.updateStatus(submission, submissionStatus, user);
-            submissionEmailService.sendWorkflowEmails(user, submission);
+            submissionEmailService.sendWorkflowEmails(user, submission.getId());
         });
         return new ApiResponse(SUCCESS);
 
@@ -444,7 +444,7 @@ public class SubmissionController {
             response = new ApiResponse(ERROR, "Could not find a submission with ID " + submissionId);
         }
 
-        submissionEmailService.sendWorkflowEmails(user, submission);
+        submissionEmailService.sendWorkflowEmails(user, submission.getId());
 
         return response;
     }
@@ -976,7 +976,7 @@ public class SubmissionController {
     @RequestMapping("/{submissionId}/send-advisor-email")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse sendAdvisorEmail(@WeaverUser User user, @PathVariable Long submissionId) {
-        submissionEmailService.sendAdvisorEmails(user, submissionRepo.read(submissionId));
+        submissionEmailService.sendAdvisorEmails(user, submissionId);
         return new ApiResponse(SUCCESS);
     }
 

--- a/src/main/java/org/tdl/vireo/model/EmailRecipientAssignee.java
+++ b/src/main/java/org/tdl/vireo/model/EmailRecipientAssignee.java
@@ -15,9 +15,9 @@ public class EmailRecipientAssignee extends AbstractEmailRecipient implements Em
     @Override
     public List<String> getEmails(Submission submission) {
         List<String> emails = new ArrayList<String>();
-        User adssignee = submission.getAssignee();
-        if(adssignee != null) {
-          emails.add(adssignee.getSetting("preferedEmail"));
+        User assignee = submission.getAssignee();
+        if(assignee != null) {
+          emails.add(assignee.getSetting("preferedEmail"));
         }
         return emails;
     }

--- a/src/main/java/org/tdl/vireo/model/EmailRecipientContact.java
+++ b/src/main/java/org/tdl/vireo/model/EmailRecipientContact.java
@@ -36,8 +36,9 @@ public class EmailRecipientContact extends AbstractEmailRecipient implements Ema
             LOG.debug("Looking at field value " + fv.getValue() + "(" + fv.getId() + ") gotten from submission " + submission.getId() + "'s predicates matching " + getFieldPredicate().getValue() + "(" + getFieldPredicate().getId());
             for (String contact : fv.getContacts()) {
                 LOG.debug("That field value has a contact value of " + contact);
-                if (!emails.contains(contact))
+                if (!emails.contains(contact)) {
                     emails.add(contact);
+                }
             }
         }
         return emails;

--- a/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
@@ -2,6 +2,7 @@ package org.tdl.vireo.model.repo;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.User;
@@ -26,6 +27,28 @@ public interface SubmissionRepo extends WeaverRepo<Submission>, SubmissionRepoCu
     public Submission findByCustomActionValuesDefinitionLabel(String label);
 
     public Long countByOrganizationId(Long id);
+
+    @EntityGraph(attributePaths = {
+        "submitter",
+        "assignee",
+        "submissionStatus",
+        "organization",
+        "fieldValues",
+        "submissionWorkflowSteps",
+        "approveEmbargoDate",
+        "approveApplicationDate",
+        "submissionDate",
+        "approveAdvisorDate",
+        "approveEmbargo",
+        "approveApplication",
+        "approveAdvisor",
+        "customActionValues",
+        "reviewerNotes",
+        "advisorAccessHash",
+        "advisorReviewURL",
+        "depositURL"
+     })
+    public Submission findGraphForEmailById(Long id);
 
     @Override
     public Submission update(Submission submission);

--- a/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
+++ b/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
@@ -87,7 +87,7 @@ public class VireoEmailSender extends JavaMailSenderImpl implements EmailSender 
         mm.setSubject(subject);
         mm.setText(content, false);
 
-        LOG.debug("\tSending email with subject '" + subject + "' from " + vireoEmailConfig.getFrom() + " to: [ " + String.join(";", to) + " ]; ");
+        LOG.debug("\tSending email with subject '" + subject + "' from " + vireoEmailConfig.getFrom() + " to: [ " + String.join("; ", to) + " ], cc: [ " + String.join(";", cc) + " ], bcc: [ " + String.join(";", bcc) + " ]; ");
         send(message);
     }
 

--- a/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
+++ b/src/test/java/org/tdl/vireo/service/SubmissionEmailServiceTest.java
@@ -338,6 +338,8 @@ public class SubmissionEmailServiceTest extends MockData {
         when(mockFieldPredicateRepo.findOne(TEST_FIELD_PREDICATE_COMMITTEE_MEMBER_ID)).thenReturn(TEST_FIELD_PREDICATE_COMMITTEE_MEMBER);
         when(mockFieldPredicateRepo.findByValue(TEST_FIELD_PREDICATE_COMMITTEE_MEMBER_VALUE)).thenReturn(TEST_FIELD_PREDICATE_COMMITTEE_MEMBER);
 
+        when(mockSubmissionRepo.findGraphForEmailById(mockSubmission.getId())).thenReturn(mockSubmission);
+
         when(mockAbstractEmailRecipientRepoImpl.createAdvisorRecipient()).thenReturn(TEST_EMAIL_RECIPIENT_ADVISOR);
 
         List<EmailWorkflowRule> emailWorkflowRuleAdvisors = new ArrayList<EmailWorkflowRule>();
@@ -350,24 +352,24 @@ public class SubmissionEmailServiceTest extends MockData {
 
     @Test
     public void testSendAdvisorEmails() throws MessagingException {
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, never()).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         mockFieldValues.add(TEST_FIELD_VALUE3);
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         TEST_USER.setSettings(TEST_USER1_SETTINGS2);
 
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         TEST_USER.setSettings(TEST_USER1_SETTINGS3);
 
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -376,7 +378,7 @@ public class SubmissionEmailServiceTest extends MockData {
     public void testSendAdvisorEmailsWithoutRules() throws MessagingException {
         mockEmailWorkflowRules.clear();
 
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, never()).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -387,7 +389,7 @@ public class SubmissionEmailServiceTest extends MockData {
 
         mockFieldValues.add(TEST_FIELD_VALUE3);
 
-        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendAdvisorEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -413,7 +415,25 @@ public class SubmissionEmailServiceTest extends MockData {
         mockData.put("sendEmailToRecipient", true);
         TEST_USER.setSettings(TEST_USER1_SETTINGS4);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
+        verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
+        reset(mockEmailSender);
+    }
+
+    @Test
+    public void testSendAutomatedEmailsWithCc() throws JsonProcessingException, IOException, MessagingException {
+        List<Map<String, Object>> emails = new ArrayList<Map<String, Object>>();
+        emails.add(TEST_EMAIL_RECIPIENT_MAP1);
+
+        mockData.put("commentVisibility", "public");
+        mockData.put("message", "Mock Message.");
+        mockData.put("recipientEmails", emails);
+        mockData.put("sendEmailToRecipient", true);
+        mockData.put("sendEmailToCCRecipient", true);
+        mockData.put("ccRecipientEmails", emails);
+        TEST_USER.setSettings(TEST_USER1_SETTINGS4);
+
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -431,7 +451,7 @@ public class SubmissionEmailServiceTest extends MockData {
         mockData.put("sendEmailToRecipient", true);
         TEST_USER.setSettings(TEST_USER1_SETTINGS4);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -440,25 +460,25 @@ public class SubmissionEmailServiceTest extends MockData {
     public void testSendWorkflowEmails() throws MessagingException {
         doCallRealMethod().when(mockEmailSender).sendEmail(any(String.class), any(String.class), any(String.class));
 
-        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         TEST_USER.setSettings(TEST_USER1_SETTINGS2);
 
-        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String.class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         TEST_USER.setSettings(TEST_USER1_SETTINGS3);
 
-        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String.class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         mockEmailWorkflowRules.clear();
 
-        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, never()).sendEmail(any(String.class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -467,7 +487,7 @@ public class SubmissionEmailServiceTest extends MockData {
     public void testSendWorkflowEmailsThrowMessagingException() throws MessagingException, JsonProcessingException, IOException {
         doThrow(MessagingException.class).when(mockEmailSender).sendEmail(any(String.class), any(String.class), any(String.class));
 
-        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission);
+        submissionEmailService.sendWorkflowEmails(TEST_USER, mockSubmission.getId());
         verify(mockEmailSender, times(1)).sendEmail(any(String.class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }
@@ -486,7 +506,7 @@ public class SubmissionEmailServiceTest extends MockData {
         ccEmails.add(TEST_EMAIL_RECIPIENT_MAP5);
         ccEmails.add(TEST_EMAIL_RECIPIENT_MAP6);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, never()).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
@@ -495,14 +515,14 @@ public class SubmissionEmailServiceTest extends MockData {
         mockData.put("recipientEmails", emails);
         mockData.put("ccRecipientEmails", ccEmails);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, never()).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         mockData.put("sendEmailToRecipient", true);
         mockData.put("sendEmailToCCRecipient", cc);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
@@ -510,7 +530,7 @@ public class SubmissionEmailServiceTest extends MockData {
         mockData.put("sendEmailToRecipient", false);
         mockData.put("sendEmailToCCRecipient", false);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, never()).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
@@ -519,13 +539,13 @@ public class SubmissionEmailServiceTest extends MockData {
         mockData.put("sendEmailToCCRecipient", cc);
         TEST_USER.setSettings(TEST_USER1_SETTINGS2);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
 
         TEST_USER.setSettings(TEST_USER1_SETTINGS3);
 
-        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission, mockData);
+        submissionEmailService.sendAutomatedEmails(TEST_USER, mockSubmission.getId(), mockData);
         verify(mockEmailSender, times(1)).sendEmail(any(String[].class), any(String[].class), any(String[].class), any(String.class), any(String.class));
         reset(mockEmailSender);
     }


### PR DESCRIPTION
resolves #1555 

This is primarily a regression caused by the Lazy loading performance improvements.
Because the data is lazily loaded, it is not available and no e-mails are obtained to be sent.
Utilize a graph to force Eager loading in the explicit case of e-mails.
This required:
- Relocating controller logic code into the relevant service model and performing the database load there.
- Utilizing the attribute path entity graphs, see links below for details.
- have the controller instead pass the submission id onto the e-mail service methods.

Add the BCC to the e-mail debug log as well.

see: https://www.baeldung.com/spring-data-jpa-named-entity-graphs
see: https://www.baeldung.com/spring-open-session-in-view