### PR TITLE
[1549] UI: Too many users, needs pagination to limit as well as a paginated table for "Who has Access" and "Add Member".

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/UserController.java
+++ b/src/main/java/org/tdl/vireo/controller/UserController.java
@@ -6,19 +6,25 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 import static org.springframework.beans.BeanUtils.copyProperties;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +37,7 @@ import edu.tamu.weaver.auth.annotation.WeaverCredentials;
 import edu.tamu.weaver.auth.annotation.WeaverUser;
 import edu.tamu.weaver.auth.model.Credentials;
 import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.user.model.IRole;
 import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
 import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 
@@ -64,23 +71,84 @@ public class UserController {
         return new ApiResponse(SUCCESS, userRepo.findAll(filteredPageRequest.getUserSpecification(), filteredPageRequest.getPageRequest()));
     }
 
-    @RequestMapping("/assignable")
+    @GetMapping("/assignable")
     @PreAuthorize("hasRole('ROLE_REVIEWER')")
-    public ApiResponse allAssignableUsers() {
-        List<User> assignable = new ArrayList<User>();
-        assignable.addAll(userRepo.findAllByRole(Role.ROLE_ADMIN));
-        assignable.addAll(userRepo.findAllByRole(Role.ROLE_MANAGER));
-        assignable.addAll(userRepo.findAllByRole(Role.ROLE_REVIEWER));
-        return new ApiResponse(SUCCESS, assignable);
+    public ApiResponse allAssignableUsers(@RequestParam(defaultValue = "0", name = "size") Integer size, @RequestParam(defaultValue = "", name = "name") String name, @PageableDefault(direction = Direction.ASC, sort = { "firstName", "LastName" }) Pageable pageable) {
+        List<IRole> roles = Arrays.asList(new IRole[] {
+            Role.ROLE_ADMIN,
+            Role.ROLE_MANAGER,
+            Role.ROLE_REVIEWER
+        });
+
+        // Pageable's size is not allowed to be 0, but by adding a requestParam the 0 can be intercepted and used for disabling pagination.
+        if (size == 0) {
+            if (StringUtils.isEmpty(name)) {
+                return new ApiResponse(SUCCESS, userRepo.findAllByRoleIn(roles, pageable.getSort()));
+            }
+
+            return new ApiResponse(SUCCESS, userRepo.findAllByRoleInAndNameContainsIgnoreCase(roles, name, pageable.getSort()));
+        }
+
+        if (StringUtils.isEmpty(name)) {
+            return new ApiResponse(SUCCESS, userRepo.findAllByRoleIn(roles, pageable));
+        }
+
+        return new ApiResponse(SUCCESS, userRepo.findAllByRoleInAndNameContainsIgnoreCase(roles, name, pageable));
     }
 
-    @RequestMapping("/unassignable")
+    @GetMapping("/assignable/total")
     @PreAuthorize("hasRole('ROLE_REVIEWER')")
-    public ApiResponse allUnassignableUsers() {
-        List<User> assignable = new ArrayList<User>();
-        assignable.addAll(userRepo.findAllByRole(Role.ROLE_STUDENT));
-        assignable.addAll(userRepo.findAllByRole(Role.ROLE_ANONYMOUS));
-        return new ApiResponse(SUCCESS, assignable);
+    public ApiResponse countAssignableUsers(@RequestParam(defaultValue = "", name = "name") String name) {
+        List<IRole> roles = Arrays.asList(new IRole[] {
+            Role.ROLE_ADMIN,
+            Role.ROLE_MANAGER,
+            Role.ROLE_REVIEWER
+        });
+
+        if (StringUtils.isEmpty(name)) {
+            return new ApiResponse(SUCCESS, userRepo.countByRoleIn(roles));
+        }
+
+        return new ApiResponse(SUCCESS, userRepo.countByRoleInAndNameContainsIgnoreCase(roles, name));
+    }
+
+    @GetMapping("/unassignable")
+    @PreAuthorize("hasRole('ROLE_REVIEWER')")
+    public ApiResponse allUnassignableUsers(@RequestParam(defaultValue = "0", name = "size") Integer size, @RequestParam(defaultValue = "", name = "name") String name, @PageableDefault(direction = Direction.ASC, sort = { "firstName", "LastName" }) Pageable pageable) {
+        List<IRole> roles = Arrays.asList(new IRole[] {
+            Role.ROLE_STUDENT,
+            Role.ROLE_ANONYMOUS
+        });
+
+        // Pageable's size is not allowed to be 0, but by adding a requestParam the 0 can be intercepted and used for disabling pagination.
+        if (size == 0) {
+            if (StringUtils.isEmpty(name)) {
+                return new ApiResponse(SUCCESS, userRepo.findAllByRoleIn(roles, pageable.getSort()));
+            }
+
+            return new ApiResponse(SUCCESS, userRepo.findAllByRoleInAndNameContainsIgnoreCase(roles, name, pageable.getSort()));
+        }
+
+        if (StringUtils.isEmpty(name)) {
+            return new ApiResponse(SUCCESS, userRepo.findAllByRoleIn(roles, pageable));
+        }
+
+        return new ApiResponse(SUCCESS, userRepo.findAllByRoleInAndNameContainsIgnoreCase(roles, name, pageable));
+    }
+
+    @GetMapping("/unassignable/total")
+    @PreAuthorize("hasRole('ROLE_REVIEWER')")
+    public ApiResponse countUnassignableUsers(@RequestParam(defaultValue = "", name = "name") String name) {
+        List<IRole> roles = Arrays.asList(new IRole[] {
+            Role.ROLE_STUDENT,
+            Role.ROLE_ANONYMOUS
+        });
+
+        if (StringUtils.isEmpty(name)) {
+            return new ApiResponse(SUCCESS, userRepo.countByRoleIn(roles));
+        }
+
+        return new ApiResponse(SUCCESS, userRepo.countByRoleInAndNameContainsIgnoreCase(roles, name));
     }
 
     @PreAuthorize("hasRole('ROLE_MANAGER')")

--- a/src/main/java/org/tdl/vireo/model/User.java
+++ b/src/main/java/org/tdl/vireo/model/User.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.Formula;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.tdl.vireo.model.response.Views;
@@ -59,16 +60,19 @@ public class User extends HibernateWorkaroundAbstractWeaverUserDetails {
     private String password;
 
     @JsonView(Views.SubmissionList.class)
-    @Column(nullable = false)
+    @Column(nullable = false, name = "first_name")
     private String firstName;
 
     @JsonView(Views.SubmissionList.class)
-    @Column(nullable = false)
+    @Column(nullable = false, name = "last_name")
     private String lastName;
 
     @JsonView(Views.Partial.class)
-    @Column
+    @Column(name = "middle_name")
     private String middleName;
+
+    @Formula("CONCAT(first_name, ' ', last_name)")
+    private String name;
 
     @ElementCollection(fetch = EAGER)
     @MapKeyColumn(name = "setting")
@@ -238,6 +242,14 @@ public class User extends HibernateWorkaroundAbstractWeaverUserDetails {
      */
     public void setMiddleName(String middleName) {
         this.middleName = middleName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     /**

--- a/src/main/java/org/tdl/vireo/model/repo/UserRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/UserRepo.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.UserRepoCustom;
@@ -15,8 +16,18 @@ public interface UserRepo extends AbstractWeaverUserRepo<User>, UserRepoCustom {
 
     public User findByEmail(String email);
 
-    public List<User> findAllByRole(IRole role);
+    public List<User> findAllByRoleIn(List<IRole> role, Sort sort);
+
+    public List<User> findAllByRoleIn(List<IRole> role, Pageable pageable);
+
+    public List<User> findAllByRoleInAndNameContainsIgnoreCase(List<IRole> role, String name, Sort sort);
+
+    public List<User> findAllByRoleInAndNameContainsIgnoreCase(List<IRole> role, String name, Pageable pageable);
 
     public Page<User> findAll(Specification<User> specification, Pageable pageable);
+
+    public Long countByRoleIn(List<IRole> role);
+
+    public Long countByRoleInAndNameContainsIgnoreCase(List<IRole> role, String name);
 
 }

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -928,10 +928,20 @@ var apiMapping = {
             'controller': 'user',
             'method': 'assignable'
         },
+        assignableTotal: {
+            'endpoint': '/private/queue',
+            'controller': 'user',
+            'method': 'assignable/total'
+        },
         unassignable: {
             'endpoint': '/private/queue',
             'controller': 'user',
             'method': 'unassignable'
+        },
+        unassignableTotal: {
+            'endpoint': '/private/queue',
+            'controller': 'user',
+            'method': 'unassignable/total'
         },
         update: {
             'endpoint': '/private/queue',

--- a/src/main/webapp/app/controllers/settings/whoHasAccessController.js
+++ b/src/main/webapp/app/controllers/settings/whoHasAccessController.js
@@ -1,13 +1,126 @@
-vireo.controller('WhoHasAccessController', function ($controller, $location, $scope, $timeout, User, UserRepo, UserService) {
+vireo.controller('WhoHasAccessController', function ($controller, $location, $scope, $timeout, NgTableParams, User, UserRepo, UserService) {
 
-    angular.extend(this, $controller('UserRepoController', { $scope: $scope, $location: $location, $timeout: $timeout, User: User, UserRepo: UserRepo, UserService: UserService }));
+    angular.extend(this, $controller('AbstractController', {$scope: $scope}));
 
-    $scope.assignableUsers = $scope.userRepo.getAssignableUsers();
-    $scope.unassignableUsers = [];
+    $scope.userRepo = UserRepo;
+
+    $scope.roles = [];
+
+    $scope.allowableRoles = function(role) {
+        if (sessionStorage.role === 'ROLE_ADMIN') {
+            return ['ROLE_ADMIN','ROLE_MANAGER', 'ROLE_REVIEWER', 'ROLE_STUDENT', 'ROLE_ANONYMOUS'];
+        }
+        else if (sessionStorage.role === 'ROLE_MANAGER') {
+            if (role === 'ROLE_ADMIN') {
+                return ['ROLE_ADMIN'];
+            }
+            return ['ROLE_MANAGER', 'ROLE_REVIEWER', 'ROLE_STUDENT', 'ROLE_ANONYMOUS'];
+        }
+        else if (sessionStorage.role === 'ROLE_REVIEWER') {
+            if (role === 'ROLE_ADMIN') {
+                return ['ROLE_ADMIN'];
+            }
+            return ['ROLE_REVIEWER', 'ROLE_STUDENT', 'ROLE_ANONYMOUS'];
+        }
+        else {
+            return [role];
+        }
+    };
+
+    $scope.updateRole = function(user, role) {
+        if (role !== undefined) {
+            user.role = role;
+        }
+        user.dirty(true);
+        user.save();
+    };
+
+    $scope.setRole = function(user) {
+        $scope.roles[user.email] = $scope.allowableRoles(user.role);
+    };
 
     $scope.openAddMemberModal = function () {
         $scope.unassignableUsers = $scope.userRepo.getUnassignableUsers();
         $scope.openModal('#addMemberModal');
     };
+
+    $scope.setAssignableTable = function () {
+        $scope.assignableUsersTable = new NgTableParams({
+            page: 1,
+            count: 5,
+            sorting: { name: 'asc' }
+        }, {
+            counts: [ 5, 10, 25, 50, 100 ],
+            getData: function (params) {
+                var name = "";
+                if (angular.isDefined(params._params.filter.name)) {
+                    name = params._params.filter.name;
+                }
+
+                return $scope.userRepo.getAssignableUsersTotal(name).then(function(response) {
+                    var total = 0;
+                    var resObj = angular.fromJson(response.body);
+                    if (resObj.meta.status === 'SUCCESS') {
+                        total = resObj.payload.Long;
+                    }
+
+                    params.total(total);
+
+                    var list = [];
+                    if (total) {
+                        list = $scope.userRepo.getAssignableUsers(params.page() - 1, params.count(), name);
+                    }
+
+                    return list;
+                });
+            },
+        });
+    };
+
+    $scope.setUnassignableTable = function () {
+        $scope.unassignableUsersTable = new NgTableParams({
+            page: 1,
+            count: 5,
+            sorting: { name: 'asc' }
+        }, {
+            counts: [ 5, 10, 25, 50, 100 ],
+            getData: function (params) {
+                var name = "";
+                if (angular.isDefined(params._params.filter.name)) {
+                    name = params._params.filter.name;
+                }
+
+                return $scope.userRepo.getUnassignableUsersTotal(name).then(function(response) {
+                    var total = 0;
+                    var resObj = angular.fromJson(response.body);
+                    if (resObj.meta.status === 'SUCCESS') {
+                        total = resObj.payload.Long;
+                    }
+
+                    params.total(total);
+
+                    var list = [];
+                    if (total) {
+                        list = $scope.userRepo.getUnassignableUsers(params.page() - 1, params.count(), name);
+                    }
+
+                    return list;
+                });
+            },
+        });
+    };
+
+    UserService.userReady().then(function (event) {
+        $scope.user = UserService.getCurrentUser();
+
+        $scope.setAssignableTable();
+        $scope.setUnassignableTable();
+
+        UserRepo.listen(function() {
+            $scope.closeModal();
+
+            $scope.user = new User();
+        });
+    });
 
 });

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -74,7 +74,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
     $scope.dropZoneText = "Drop a file or click arrow";
 
     SubmissionRepo.fetchSubmissionById($routeParams.id).then(function(submission) {
-      
+
         $scope.submission = submission;
 
         WsApi.listen("/channel/submission/" + $scope.submission.id).then(null, null, function(res) {
@@ -100,7 +100,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
         $scope.resetCommentModal = function (addCommentModal) {
           $scope.closeModal();
-          
+
           addCommentModal.adding = false;
           addCommentModal.commentVisibility = userSettings.notes_mark_comment_as_private_by_default ? "private" : "public";
           addCommentModal.recipientEmail = '';
@@ -145,24 +145,24 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
           if ($scope.addCommentModal.commentVisibility == 'public') {
               if ($scope.addCommentModal.sendEmailToRecipient) {
                   if ($scope.addCommentModal.sendEmailToCCRecipient) {
-                      disable = $scope.addCommentModal.recipientEmails.length === 0 || 
-                                $scope.addCommentModal.ccRecipientEmails.length === 0 || 
-                                $scope.addCommentModal.subject === undefined || 
-                                $scope.addCommentModal.subject === "" || 
+                      disable = $scope.addCommentModal.recipientEmails.length === 0 ||
+                                $scope.addCommentModal.ccRecipientEmails.length === 0 ||
+                                $scope.addCommentModal.subject === undefined ||
+                                $scope.addCommentModal.subject === "" ||
                                 $scope.addCommentModal.message === undefined ||
                                 $scope.addCommentModal.message === "";
                   } else {
-                      disable = $scope.addCommentModal.recipientEmails.length === 0 || 
-                                $scope.addCommentModal.subject === undefined || 
-                                $scope.addCommentModal.subject === "" || 
+                      disable = $scope.addCommentModal.recipientEmails.length === 0 ||
+                                $scope.addCommentModal.subject === undefined ||
+                                $scope.addCommentModal.subject === "" ||
                                 $scope.addCommentModal.message === undefined ||
                                 $scope.addCommentModal.message === "";
                   }
               }
           } else {
               if ($scope.addCommentModal.commentVisibility == 'private') {
-                  disable = $scope.addCommentModal.subject === undefined || 
-                          $scope.addCommentModal.subject === "" || 
+                  disable = $scope.addCommentModal.subject === undefined ||
+                          $scope.addCommentModal.subject === "" ||
                           $scope.addCommentModal.message === undefined ||
                           $scope.addCommentModal.message === "";
               }
@@ -175,10 +175,10 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         var recipient = formField.$$rawModelValue;
 
         if (recipient) {
-          
-          if(typeof recipient === 'string') {
 
-            if(!$scope.validateEmailAddressee(formField)) return;            
+          if (typeof recipient === 'string') {
+
+            if (!$scope.validateEmailAddressee(formField)) return;
 
             recipient = new EmailRecipient({
               name: recipient,
@@ -186,7 +186,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
               data: recipient
             });
           }
-          
+
           emails.push(recipient);
 
           //This is not ideal, as it assumes the attr name and attr ngModel are the same.
@@ -207,7 +207,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
               break;
             }
           }
-        }        
+        }
         $scope[formField.$$attr.name+"Invalid"] = formField.$invalid && !valueIsContact;
         return  !$scope[formField.$$attr.name+"Invalid"];
       };
@@ -378,7 +378,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             $scope.closeModal();
             $scope.errorMessage = "";
             $scope.removeFiles();
-            
+
             $scope.addFileData.uploading = false;
             $scope.addFileData.recipientEmail = '';
             $scope.addFileData.recipientEmails = userSettings.attachment_email_student_by_default === "true" ? [new EmailRecipient({
@@ -406,7 +406,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         };
 
         $scope.resetFileData();
-        
+
         $scope.submitAddFile = function () {
 
             $scope.addFileData.uploading = true;
@@ -611,7 +611,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
             "SubmissionStatusRepo": SubmissionStatusRepo,
             "submissionStatuses": submissionStatuses,
             "advanced": true,
-            "assignableUsers": UserRepo.getAssignableUsers(),
+            "assignableUsers": UserRepo.getAssignableUsers(0, 0),
             "user": UserService.getCurrentUser(),
             "sending": false,
             "sendAdvisorEmail": function () {

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -119,7 +119,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
 
         update();
 
-        var assignableUsers = UserRepo.getAssignableUsers();
+        var assignableUsers = UserRepo.getAssignableUsers(0, 0);
         var savedFilters = SavedFilterRepo.getAll();
         var emailTemplates = EmailTemplateRepo.getAll();
         var emailValidationPattern = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";

--- a/src/main/webapp/app/repo/userRepo.js
+++ b/src/main/webapp/app/repo/userRepo.js
@@ -26,22 +26,58 @@ vireo.repo("UserRepo", function UserRepo($timeout, TableFactory, User, WsApi) {
         repo: userRepo
     });
 
-    userRepo.getAssignableUsers = function() {
+    userRepo.getAssignableUsers = function(page, size, name) {
         var assignable = [];
+
+        if (size > 0) {
+            angular.extend(userRepo.mapping.assignable, {
+                query: {
+                  page: page,
+                  size: size,
+                  name: name
+                }
+            });
+        }
+
         WsApi.fetch(userRepo.mapping.assignable).then(function(response) {
             var resObj = angular.fromJson(response.body);
             if (resObj.meta.status === 'SUCCESS') {
                 var users = resObj.payload['ArrayList<User>'];
-                for(var i in users) {
+                for (var i in users) {
                     assignable.push(new User(users[i]));
                 }
             }
         });
+
         return assignable;
     };
 
-    userRepo.getUnassignableUsers = function() {
+    userRepo.getAssignableUsersTotal = function(name) {
+        var total = 0;
+
+        if (angular.isDefined(name)) {
+            angular.extend(userRepo.mapping.assignableTotal, {
+                query: {
+                  name: name
+                }
+            });
+        }
+
+        return WsApi.fetch(userRepo.mapping.assignableTotal);
+    };
+
+    userRepo.getUnassignableUsers = function(page, size, name) {
         var unassignable = [];
+
+        if (size > 0) {
+            angular.extend(userRepo.mapping.unassignable, {
+                query: {
+                  page: page,
+                  size: size,
+                  name: name
+                }
+            });
+        }
 
         WsApi.fetch(userRepo.mapping.unassignable).then(function(response) {
             var resObj = angular.fromJson(response.body);
@@ -56,6 +92,20 @@ vireo.repo("UserRepo", function UserRepo($timeout, TableFactory, User, WsApi) {
         });
 
         return unassignable;
+    };
+
+    userRepo.getUnassignableUsersTotal = function(name) {
+        var total = 0;
+
+        if (angular.isDefined(name)) {
+            angular.extend(userRepo.mapping.unassignableTotal, {
+                query: {
+                  name: name
+                }
+            });
+        }
+
+        return WsApi.fetch(userRepo.mapping.unassignableTotal);
     };
 
     WsApi.listen(userRepo.mapping.createListen).then(null, null, function (response) {

--- a/src/main/webapp/app/views/admin/settings/application/whoHasAccess.html
+++ b/src/main/webapp/app/views/admin/settings/application/whoHasAccess.html
@@ -7,19 +7,12 @@
 
             <div class="glyphicon glyphicon-info-sign opaque glyiphicon-span-adjust" tooltip="Dialog in which allows to elevate users access."></div>
 
-            <table  class="table">
-                <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th>Email</th>
-                        <th>Role</th>
-                    </tr>
-                </thead>
+            <table ng-table="assignableUsersTable" class="table table-hover table-striped">
                 <tbody>
-                    <tr ng-repeat="u in assignableUsers" ng-init="setRole(u)">
-                        <td>{{u.firstName}} {{u.lastName}}</td>
-                        <td>{{u.email}}</td>
-                        <td>
+                    <tr ng-repeat="u in $data" ng-init="setRole(u)">
+                        <td data-title="'Name'">{{u.name}}</td>
+                        <td data-title="'E-mail'">{{u.email}}</td>
+                        <td data-title="'Role'">
                             <select class="form-control" ng-model="u.role" ng-change="updateRole(u)" ng-disabled="disableUpdateRole(u)">
                                 <option ng-repeat="role in roles[u.email]" ng-selected="role === u.role">{{role}}</option>
                             </select>

--- a/src/main/webapp/app/views/modals/addMemberModal.html
+++ b/src/main/webapp/app/views/modals/addMemberModal.html
@@ -10,33 +10,17 @@
         <form action="/admin/settings/members/search">
             <div class="row">
                 <div class="col-sm-12">
-
-                <form>
-                    <div class="form-group">
-                        <div class="input-group">
-                            <div class="input-group-addon"><i class="search"></i></div>
-                            <input type="text" class="form-control" placeholder="Filter" ng-model="search">
-                        </div>
-                    </div>
-                </form>
-
-                <table class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Email</th>
-                            <th>Add</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr class="clickable" ng-repeat="u in unassignableUsers | filter:search" ng-click="selectUser(u)">
-                            <td>{{u.firstName}} {{u.lastName}}</td>
-                            <td>{{u.email}}</td>
-                            <td><button ng-click="updateRole(u, 'ROLE_REVIEWER')" type="button" class="btn btn-primary">Add</button></td>
-                        </tr>
-                    </tbody>
-                </table>
-
+                    <table ng-table="unassignableUsersTable" class="table table-hover table-striped" show-filter="true">
+                        <tbody>
+                            <tr class="clickable" ng-repeat="u in $data" ng-click="selectUser(u)">
+                                <td data-title="'Name'" filter="{ 'name': 'text' }">{{u.name}}</td>
+                                <td data-title="'E-mail'">{{u.email}}</td>
+                                <td data-title="'Role'">
+                                    <button ng-click="updateRole(u, 'ROLE_REVIEWER')" type="button" class="btn btn-primary">Add</button>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
 


### PR DESCRIPTION
resolves #1549 

Change existing endpoints and add new endpoints.
- /assignable
- /assignable/total
- /unassignable
- /unassignable/total

These new endpoints now support pagination.

Rather than changing the UI internal design, I opted to just create a new endpoint for getting the totals.
These are needed for proper pagination support.

There is a work-around (see code comments) that allows for Pageable to have a default value of 0.
This means load all results without pagination.
In such a case, filtering is still supported.

In order to achive the filter, a synthetic DB column "name" is generated and is including at the DB level.
This is achieved by utilizing `@Formula` annotation.
This annotationr equired that I explicitly set the name annotation property for the firstName and lastName User properties.

Several JPA functions are added to accomplish all of the necessary tasks.

The UI loads the totals first and if the total is non-zero, then loads the actual data.

The existing filter from Add Member is removed in favor of the ng-table filter.

There is a lot more cleanup that could be done but for brevity and time-limits these potential improvements are ignored.

Problems that are not resolved:
- There is a flicker on filter changes or pagination that is annoying.
- Changes to either form still require full page refreshes.