### PR TITLE
Issue 1596: Add "expansive" option to CLI.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -8,12 +8,10 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
-
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.Organization;
@@ -81,6 +79,10 @@ public class Cli implements CommandLineRunner {
 
             Scanner reader = new Scanner(System.in); // Reading from System.in
             boolean expansive = false;
+            Random random = new Random();
+
+            SimpleDateFormat format = new SimpleDateFormat("MM/dd/yyyy");
+            SimpleDateFormat emailDate = new SimpleDateFormat("_yyyy_MM_dd_HH_mm_ss_");
 
             System.out.print(PROMPT);
 
@@ -112,10 +114,6 @@ public class Cli implements CommandLineRunner {
                     System.out.println("\nGoodbye.");
                     running = false;
                     break;
-                case "expansive":
-                    expansive = !expansive;
-                    System.out.println("\nSet expansive = " + (expansive ? "true" : "false") + ".");
-                    break;
 
                 case "accounts":
                     int acct = 0;
@@ -141,6 +139,7 @@ public class Cli implements CommandLineRunner {
                     break;
 
                 case "admin_accounts":
+                {
                     int admin_acct = 0;
                     if (commandArgs.size() > 0) {
                         try {
@@ -156,8 +155,15 @@ public class Cli implements CommandLineRunner {
                         userRepo.saveAndFlush(testacct);
                     }
                     break;
+                }
+
+                case "expansive":
+                    expansive = !expansive;
+                    System.out.println("\nSet expansive = " + (expansive ? "true" : "false") + ".");
+                    break;
 
                 case "generate":
+                {
                     if (commandArgs.size() > 0) {
                         try {
                             num = Integer.parseInt(commandArgs.get(0));
@@ -166,16 +172,13 @@ public class Cli implements CommandLineRunner {
                         }
                     }
 
-                    SimpleDateFormat format = new SimpleDateFormat("MM/dd/yyyy");
-                    SimpleDateFormat emailDate = new SimpleDateFormat("_yyyy_MM_dd_HH_mm_ss_");
-
                     Organization org = organizationRepo.findAll().get(0);
 
                     int idOffset = userRepo.findAll().toArray().length;
                     User helpfulHarry = null;
 
                     if (expansive) {
-                        helpfulHarry = userRepo.create("harry" + emailDate.format(Calendar.getInstance().getTime()) + (idOffset++) + "@help.ful", "Harry", "Helpful " + idOffset, Role.ROLE_STUDENT);
+                        helpfulHarry = createHelpfulHarry(idOffset++, emailDate);
                     }
 
                     if (!org.getAcceptsSubmissions()) {
@@ -184,7 +187,6 @@ public class Cli implements CommandLineRunner {
                     }
 
                     List<SubmissionStatus> statuses = submissionStatusRepo.findAll();
-                    Random random = new Random();
 
                     for (int i = itemsGenerated; i < num + itemsGenerated; i++) {
                         Calendar now = Calendar.getInstance();
@@ -256,6 +258,7 @@ public class Cli implements CommandLineRunner {
                     System.out.println("\rGenerated " + num + " submissions.");
                     itemsGenerated += num;
                     break;
+                }
 
                 case "":
                     break;
@@ -284,6 +287,11 @@ public class Cli implements CommandLineRunner {
         date.add(Calendar.MONTH, rm);
         date.add(Calendar.DATE, random.nextInt(32 - date.get(Calendar.DAY_OF_MONTH)));
         return date;
+    }
+
+    private User createHelpfulHarry(int offset, SimpleDateFormat formatter) {
+        String dateString = formatter.format(Calendar.getInstance().getTime());
+        return userRepo.create("harry" + dateString + offset + "@help.ful", "Harry", "Helpful " + offset, Role.ROLE_REVIEWER);
     }
 
     private void generateActionLogs(Submission sub, User submitter, boolean expansive) {


### PR DESCRIPTION
relates: #1596

This is intended to make performance testing easier by providing more random and more inconsistent data structures. This primarily focuses on the action log and a few other changes. There may be future changes that provide more than just the action log.

This "expansive" option, when enabled, should cause a large amount of action logs per submission (randomly). This is intended to create more inconsistency in the generated data to better help identify performance problems due to large disparate data sets.

The action log now properly sets the submitter id on the log.

The reviewer "Helpful Harry" is now created and randomly assigned to generated submissions.
The Review State is now randomly assigned from the available set.

The users created now have a number appended to their last name.

The generated submitter name now has a date and time stamp in the name to make it easier to more uniqely identify.

To test this, pass `-Drun.arguments="console"` when manually starting, such as this example:
```shell
mvn clean spring-boot:run -Drun.arguments="console" -Dprofile=development
```

Wait for the console to appear.
This may take some time.

Once there, type this command:
```
expansive
```
A message should be printed to the screen displaying that expansive is set to true.

Now give a generate command, such as this one that generates 10 submissions:
```
generate 10
```