### PR TITLE
Issue 1596: Add Action Log Debounce.

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -12,6 +12,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
     $scope.embargoes = EmbargoRepo.getAll();
 
+    $scope.actionLogDelay = 2000;
     var userSettings = new UserSettings();
 
     var submissionStatuses = SubmissionStatusRepo.getAll();

--- a/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
+++ b/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
@@ -14,6 +14,8 @@ vireo.controller("AdvisorSubmissionReviewController", function ($controller, $sc
 
     $scope.advisorSubmissionRepoReady = false;
 
+    $scope.actionLogDelay = 1000;
+
     AdvisorSubmissionRepo.fetchSubmissionByHash($routeParams.advisorAccessHash).then(function (submissions) {
         $scope.advisorSubmissionRepoReady = true;
         $scope.submission = submissions;

--- a/src/main/webapp/app/controllers/submission/submissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/submissionViewController.js
@@ -10,6 +10,8 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $scope, 
 
     $scope.embargoes = EmbargoRepo.getAll();
 
+    $scope.actionLogDelay = 2000;
+
     FieldPredicateRepo.ready().then(function() {
 
         var deleteFile = function (fieldValue) {

--- a/src/main/webapp/app/directives/actionLogDirective.js
+++ b/src/main/webapp/app/directives/actionLogDirective.js
@@ -1,10 +1,11 @@
-vireo.directive("actionlog", function(NgTableParams) {
+vireo.directive("actionlog", function($timeout, NgTableParams) {
     return {
         templateUrl: "views/directives/actionLog.html",
         restrict: 'E',
         scope: {
             'submission': '=',
-            'public': '='
+            'public': '=',
+            'delay': '@'
         },
         link: function($scope) {
 
@@ -17,9 +18,20 @@ vireo.directive("actionlog", function(NgTableParams) {
                 dataset: $scope.submission.actionLogs
             });
 
-            $scope.submission.actionLogListenPromise.then(null, null, function() {
-                $scope.tableParams.reload();
-            });
+            if (angular.isDefined($scope.submission.actionLogListenPromise)) {
+                $scope.submission.actionLogListenPromise.then(null, null, function() {
+                    if (angular.isUndefined($scope.debounce)) {
+                        $scope.debounce = function() {
+                            $scope.tableParams.reload();
+
+                            // Do not use "null" because isUndefined() does not trigger for null.
+                            $scope.debounce = undefined;
+                        };
+
+                        $timeout($scope.debounce, $scope.delay);
+                    }
+                });
+            }
         }
     };
 });

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -67,10 +67,8 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
         });
 
         submission.before(function() {
-          submission.organization = new Organization(submission.organization);
-        });
+            submission.organization = new Organization(submission.organization);
 
-        submission.before(function () {
             instantiateFieldValues();
 
             // populate fieldValues with models for empty values
@@ -82,25 +80,20 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
                     }
                 });
             });
-        });
 
-        submission.before(function () {
+            instantiateActionLogs();
 
-          instantiateActionLogs();
+            angular.extend(apiMapping.Submission.actionLogListen, {
+              'method': submission.id + '/action-logs'
+            });
 
-          angular.extend(apiMapping.Submission.actionLogListen, {
-            'method': submission.id + '/action-logs'
-          });
+            submission.actionLogListenPromise = WsApi.listen(apiMapping.Submission.actionLogListen);
 
-          submission.actionLogListenPromise = WsApi.listen(apiMapping.Submission.actionLogListen);
+            submission.actionLogListenPromise.then(null, null, function (response) {
+                var newActionLog = angular.fromJson(response.body).payload.ActionLog;
+                submission.actionLogs.push(new ActionLog(newActionLog));
+            });
 
-          submission.actionLogListenPromise.then(null, null, function (response) {
-            var newActionLog = angular.fromJson(response.body).payload.ActionLog;
-            submission.actionLogs.push(new ActionLog(newActionLog));
-          });
-        });
-
-        submission.before(function () {
             angular.extend(apiMapping.Submission.customActionValuesListen, {
                 'method': submission.id + '/custom-action-values'
             });
@@ -119,9 +112,7 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
                     submission.customActionValues.push(cav);
                 }
             });
-        });
 
-        submission.before(function () {
             angular.extend(apiMapping.Submission.fieldValuesListen, {
                 'method': submission.id + '/field-values'
             });
@@ -158,9 +149,7 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
                     enrichDocumentTypeFieldValue(fieldValue);
                 }
             });
-        });
 
-        submission.before(function () {
             angular.extend(apiMapping.Submission.fieldValueRemovedListen, {
                 'method': submission.id + '/removed-field-value'
             });

--- a/src/main/webapp/app/views/admin/view.html
+++ b/src/main/webapp/app/views/admin/view.html
@@ -52,7 +52,7 @@
 
     <modal modal-id="addCommentModal" modal-view="views/modals/view/addCommentModal.html" modal-header-class="modal-header-primary" wvr-modal-backdrop="static"></modal>
 
-    <actionlog ng-if="submission" submission="submission" ready="submisisonReady"></actionlog>
+    <actionlog ng-if="submission" submission="submission" ready="submisisonReady" delay="{{::actionLogDelay}}"></actionlog>
 
   </div>
 

--- a/src/main/webapp/app/views/submission/advisorReview.html
+++ b/src/main/webapp/app/views/submission/advisorReview.html
@@ -13,7 +13,7 @@
         <h3>Application Activity</h3>
         <hr/>
         <div class="col-md-10 col-md-offset-1">
-          <actionlog  ng-if="submission" submission="submission" public="'true'"></actionlog>
+          <actionlog ng-if="submission" submission="submission" public="'true'" delay="{{::actionLogDelay}}"></actionlog>
         </div>
       </div>
 

--- a/src/main/webapp/app/views/submission/submissionView.html
+++ b/src/main/webapp/app/views/submission/submissionView.html
@@ -112,7 +112,7 @@
         </div>
         <hr/>
         <div class="col-md-10 col-md-offset-1">
-          <actionlog ng-if="submission" submission="submission" public="'true'"></actionlog>
+          <actionlog ng-if="submission" submission="submission" public="'true'" delay="{{::actionLogDelay}}"></actionlog>
         </div>
       </div>
 


### PR DESCRIPTION
relates #1596

When multiple requests come in quickly, the action log is constantly re-loading the data.
Perhaps, too fast.
Slow down this rate by implementing a debouncer to avoid causing performance problems of constantly re-loading data.

Set the debounce timeout to 2000 milliseconds, which is 2 seconds.
For the Reviewer Application page, set the timeout to 1000 milliseconds as this is expected to be directly used most often.
    
This utilizes the `::` (one time binding) AngularJs notation to ensure that the delay is processed exactly once.
There should be no reason for the delay to change after the view is generated and renderred with the current design.

Fix some structurable problems with multiple ` submission.before(function () {`.
Instead, use a single call.
This is a simpler and cleaner design and may also ensure execution order.