### PR TITLE
Issue 1596: Fix major (DOS-level) regression regarding listeners on user repo.

### DIFF
--- a/src/main/webapp/app/controllers/userRepoController.js
+++ b/src/main/webapp/app/controllers/userRepoController.js
@@ -1,4 +1,4 @@
-vireo.controller('UserRepoController', function ($controller, $location, $scope, $timeout, User, UserRepo, UserService) {
+vireo.controller('UserRepoController', function ($controller, $location, $scope, $timeout, TableFactory, User, UserRepo, UserService) {
 
     angular.extend(this, $controller('AbstractController', {$scope: $scope}));
 
@@ -6,9 +6,18 @@ vireo.controller('UserRepoController', function ($controller, $location, $scope,
 
     $scope.userRepo = UserRepo;
 
+    $scope.table = TableFactory.buildTable({
+        pageNumber: sessionStorage.getItem('users-page') ? sessionStorage.getItem('users-page') : 1,
+        pageSize: sessionStorage.getItem('users-size') ? sessionStorage.getItem('users-size') : 10,
+        filters: {},
+        counts: [5, 10, 25, 50, 100],
+        name: 'users',
+        repo: $scope.userRepo
+    });
+
     $scope.weaverTable = {
-        pageSettings: $scope.userRepo.getPageSettings(),
-        tableParams: $scope.userRepo.getTableParams(),
+        pageSettings: $scope.table.getPageSettings(),
+        tableParams: $scope.table.getTableParams(),
         columns: [{
             gloss: 'Email',
             property: 'email',
@@ -39,7 +48,14 @@ vireo.controller('UserRepoController', function ($controller, $location, $scope,
         }]
     };
 
-    $scope.tableParams = UserRepo.getTableParams();
+    $scope.table = TableFactory.buildTable({
+        pageNumber: sessionStorage.getItem('users-page') ? sessionStorage.getItem('users-page') : 1,
+        pageSize: sessionStorage.getItem('users-size') ? sessionStorage.getItem('users-size') : 10,
+        filters: {},
+        counts: [5, 10, 25, 50, 100],
+        name: 'users',
+        repo: $scope.userRepo
+    });
 
     $scope.roles = {};
 

--- a/src/main/webapp/app/repo/userRepo.js
+++ b/src/main/webapp/app/repo/userRepo.js
@@ -1,30 +1,12 @@
-vireo.repo("UserRepo", function UserRepo($timeout, TableFactory, User, WsApi) {
+vireo.repo("UserRepo", function UserRepo(User, WsApi) {
 
     var userRepo = this;
 
-    userRepo.getPageSettings = function () {
-        return table.getPageSettings();
-    };
-
-    userRepo.getTableParams = function () {
-        return table.getTableParams();
-    };
-
     userRepo.fetchPage = function (pageSettings) {
-        angular.extend(userRepo.mapping.page, {
-            'data': pageSettings ? pageSettings : table.getPageSettings()
-        });
-        return WsApi.fetch(userRepo.mapping.page);
-    };
+        var endpoint = angular.extend({}, userRepo.mapping.page, { data: pageSettings });
 
-    var table = TableFactory.buildTable({
-        pageNumber: sessionStorage.getItem('users-page') ? sessionStorage.getItem('users-page') : 1,
-        pageSize: sessionStorage.getItem('users-size') ? sessionStorage.getItem('users-size') : 10,
-        filters: {},
-        counts: [5, 10, 25, 50, 100],
-        name: 'users',
-        repo: userRepo
-    });
+        return WsApi.fetch(endpoint);
+    };
 
     userRepo.getAssignableUsers = function(page, size, name) {
         var assignable = [];
@@ -107,27 +89,6 @@ vireo.repo("UserRepo", function UserRepo($timeout, TableFactory, User, WsApi) {
 
         return WsApi.fetch(userRepo.mapping.unassignableTotal);
     };
-
-    WsApi.listen(userRepo.mapping.createListen).then(null, null, function (response) {
-        $timeout(function () {
-            userRepo.reset();
-            table.getTableParams().reload();
-        }, 250);
-    });
-
-    WsApi.listen(userRepo.mapping.updateListen).then(null, null, function (response) {
-        $timeout(function () {
-            userRepo.reset();
-            table.getTableParams().reload();
-        }, 250);
-    });
-
-    WsApi.listen(userRepo.mapping.deleteListen).then(null, null, function (response) {
-        $timeout(function () {
-            userRepo.reset();
-            table.getTableParams().reload();
-        }, 250);
-    });
 
     return userRepo;
 

--- a/src/main/webapp/tests/mocks/repos/mockUserRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockUserRepo.js
@@ -41,13 +41,5 @@ angular.module("mock.userRepo", []).service("UserRepo", function($q) {
         return payloadPromise($q.defer(), payload);
     };
 
-    repo.getPageSettings = function () {
-
-    };
-
-    repo.getTableParams = function () {
-
-    };
-
     return repo;
 });

--- a/src/main/webapp/tests/unit/controllers/userRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/userRepoControllerTest.js
@@ -14,7 +14,7 @@ describe("controller: UserRepoController", function () {
     };
 
     var initializeController = function(settings) {
-        inject(function ($controller, $location, $route, $rootScope, _ModalService_, _RestApi_, _StorageService_, _User_, _UserRepo_, _UserService_) {
+        inject(function ($controller, $location, $route, $rootScope, _ModalService_, _RestApi_, _StorageService_, _TableFactory_, _User_, _UserRepo_, _UserService_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -32,6 +32,7 @@ describe("controller: UserRepoController", function () {
                 ModalService: _ModalService_,
                 RestApi: _RestApi_,
                 StorageService: _StorageService_,
+                TableFactory: _TableFactory_,
                 User: _User_,
                 UserRepo: _UserRepo_,
                 UserService: _UserService_,


### PR DESCRIPTION
relates #1596

This major (DOS-level) regression was introduced here in these commits:
- dc6973b61c39276d70949e2b0499d3009bfa8129
- adeb64122cc1e80c15c9c6eb0774c696c4265ec0
- aeb7bc97c08266fed98742da2ab99fc31b7330cd
- 4c346ef624237906c048f7019d379f96ae238ab6

Specifically, this Pull Request: https://github.com/TexasDigitalLibrary/Vireo/pull/1425

When any submission is created using the CLI, any open pages will freeze up and crash the browser when at least 2 submission are created.

Investigation shows numerous problems regarding listeners and how they are handled. This specific fix focuses on problems regarding having listeners directly on the UserRepo. Everything using the UserRepo will respond to any change on the UserRepo. This then triggers re-loading the entire database (which is incredibly bad when the number of users is large). Then subsequently triggers follow up POST and GET requests (2 POST and 2 GET request, for a total of 4). Loading all users and posting data for every open browser for every tab will result in massive I/O spikes in both the service and the browser. Usually the browser crashes first.
This happens on every page that has the UserRepo on it.

Any single operation on a user can cause the system or browsers crash. Having two or more changes only exasperates the issue and makes the problem more obvious.

This change does the following:
- Strip out code that should not be on the repository model (specifically the listeners).
- Introduce the table-related functionality removed from the repository model onto the UserRepoController.
- Re-design small parts of the process to not rely on unnecessary information.
- Update the unit tests.
- Prevents this listener DOS on the browser and possibly the server and network.

This change does _not_ do the following:
- Add back the listeners logic on the controller.

This explicitly avoids adding the listeners back.
A new issue is recommended to provide a better implementation should listeners be desired on the user management page.