### PR TITLE
1596: Move custom action definition list read outside of the transaction.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -1,5 +1,6 @@
 package org.tdl.vireo.cli;
 
+import edu.tamu.weaver.auth.model.Credentials;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -7,9 +8,9 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
 import java.util.Scanner;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.tdl.vireo.model.ActionLog;
 import org.tdl.vireo.model.FieldPredicate;
@@ -22,15 +23,12 @@ import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.SubmissionWorkflowStep;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.ActionLogRepo;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 import org.tdl.vireo.model.repo.FieldValueRepo;
 import org.tdl.vireo.model.repo.OrganizationRepo;
 import org.tdl.vireo.model.repo.SubmissionRepo;
 import org.tdl.vireo.model.repo.SubmissionStatusRepo;
 import org.tdl.vireo.model.repo.UserRepo;
-
-import edu.tamu.weaver.auth.model.Credentials;
-
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 /**
  * Activate the Vireo command line interface by passing the console argument to Maven
@@ -62,6 +60,9 @@ public class Cli implements CommandLineRunner {
 
     @Autowired
     private ActionLogRepo actionLogRepo;
+
+    @Autowired
+    private CustomActionDefinitionRepo customActionDefinitionRepo;
 
     @Autowired
     private BCryptPasswordEncoder passwordEncoder;
@@ -183,7 +184,7 @@ public class Cli implements CommandLineRunner {
                         credentials.setEmail("bob@boring.bob");
                         credentials.setRole(Role.ROLE_STUDENT.name());
 
-                        Submission sub = submissionRepo.create(submitter, org, state, credentials);
+                        Submission sub = submissionRepo.create(submitter, org, state, credentials, customActionDefinitionRepo.findAll());
 
                         sub.setSubmissionDate(getRandomDate());
                         sub.setApproveAdvisorDate(getRandomDate());

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -4,6 +4,16 @@ import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.INVALID;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.weaver.auth.annotation.WeaverCredentials;
+import edu.tamu.weaver.auth.annotation.WeaverUser;
+import edu.tamu.weaver.auth.model.Credentials;
+import edu.tamu.weaver.data.model.ApiPage;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.results.ValidationResults;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -23,10 +33,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -70,6 +78,7 @@ import org.tdl.vireo.model.export.ExportPackage;
 import org.tdl.vireo.model.packager.AbstractPackager;
 import org.tdl.vireo.model.repo.ActionLogRepo;
 import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 import org.tdl.vireo.model.repo.CustomActionValueRepo;
 import org.tdl.vireo.model.repo.DepositLocationRepo;
 import org.tdl.vireo.model.repo.FieldValueRepo;
@@ -87,18 +96,6 @@ import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
-
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import edu.tamu.weaver.auth.annotation.WeaverCredentials;
-import edu.tamu.weaver.auth.annotation.WeaverUser;
-import edu.tamu.weaver.auth.model.Credentials;
-import edu.tamu.weaver.data.model.ApiPage;
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.validation.results.ValidationResults;
 
 @RestController
 @RequestMapping("/submission")
@@ -132,6 +129,9 @@ public class SubmissionController {
 
   @Autowired
   private SubmissionStatusRepo submissionStatusRepo;
+
+  @Autowired
+  private CustomActionDefinitionRepo customActionDefinitionRepo;
 
   @Autowired
   private SubmissionEmailService submissionEmailService;
@@ -209,9 +209,15 @@ public class SubmissionController {
   @PreAuthorize("hasRole('STUDENT')")
   public ApiResponse createSubmission(@WeaverUser User user, @WeaverCredentials Credentials credentials,
       @RequestBody Map<String, String> data) throws OrganizationDoesNotAcceptSubmissionsException {
-    Submission submission = submissionRepo.create(user, organizationRepo.read(Long.valueOf(data.get("organizationId"))),
-        submissionStatusRepo.findByName(STARTING_SUBMISSION_STATUS_NAME), credentials);
-    actionLogRepo.createPublicLog(submission, user, "Submission created.");
+
+    Submission submission = submissionRepo.create(
+      user,
+      organizationRepo.read(Long.valueOf(data.get("organizationId"))),
+      submissionStatusRepo.findByName(STARTING_SUBMISSION_STATUS_NAME),
+      credentials,
+      customActionDefinitionRepo.findAll()
+    );
+
     return new ApiResponse(SUCCESS, submission);
   }
 

--- a/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
@@ -1,14 +1,12 @@
 package org.tdl.vireo.model.repo;
 
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.SubmissionRepoCustom;
-
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface SubmissionRepo extends WeaverRepo<Submission>, SubmissionRepoCustom {
 

--- a/src/main/java/org/tdl/vireo/model/repo/custom/SubmissionRepoCustom.java
+++ b/src/main/java/org/tdl/vireo/model/repo/custom/SubmissionRepoCustom.java
@@ -1,11 +1,12 @@
 package org.tdl.vireo.model.repo.custom;
 
+import edu.tamu.weaver.auth.model.Credentials;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
+import org.tdl.vireo.model.CustomActionDefinition;
 import org.tdl.vireo.model.NamedSearchFilterGroup;
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.Submission;
@@ -13,11 +14,9 @@ import org.tdl.vireo.model.SubmissionListColumn;
 import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.User;
 
-import edu.tamu.weaver.auth.model.Credentials;
-
 public interface SubmissionRepoCustom {
 
-    public Submission create(User submitter, Organization organization, SubmissionStatus submissionStatus, Credentials credentials) throws OrganizationDoesNotAcceptSubmissionsException;
+    public Submission create(User submitter, Organization organization, SubmissionStatus submissionStatus, Credentials credentials, List<CustomActionDefinition> customActions) throws OrganizationDoesNotAcceptSubmissionsException;
 
     public Submission update(Submission submission);
 

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -5,6 +5,9 @@ import static edu.tamu.weaver.response.ApiAction.DELETE;
 import static edu.tamu.weaver.response.ApiAction.UPDATE;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 
+import edu.tamu.weaver.auth.model.Credentials;
+import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
+import edu.tamu.weaver.response.ApiResponse;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -21,9 +24,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
-
 import javax.sql.DataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +53,6 @@ import org.tdl.vireo.model.SubmissionWorkflowStep;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.ActionLogRepo;
 import org.tdl.vireo.model.repo.ConfigurationRepo;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 import org.tdl.vireo.model.repo.CustomActionValueRepo;
 import org.tdl.vireo.model.repo.FieldPredicateRepo;
 import org.tdl.vireo.model.repo.FieldValueRepo;
@@ -62,10 +62,6 @@ import org.tdl.vireo.model.repo.SubmissionRepo;
 import org.tdl.vireo.model.repo.SubmissionWorkflowStepRepo;
 import org.tdl.vireo.model.repo.custom.SubmissionRepoCustom;
 import org.tdl.vireo.service.AssetService;
-
-import edu.tamu.weaver.auth.model.Credentials;
-import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
-import edu.tamu.weaver.response.ApiResponse;
 
 public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, SubmissionRepo> implements SubmissionRepoCustom {
 
@@ -93,9 +89,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
     private InputTypeRepo inputTypeRepo;
 
     @Autowired
-    private CustomActionDefinitionRepo customActionDefinitionRepo;
-
-    @Autowired
     private CustomActionValueRepo customActionValueRepo;
 
     @Autowired
@@ -119,14 +112,14 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
     @Override
     @Transactional
-    public Submission create(User submitter, Organization organization, SubmissionStatus startingStatus, Credentials credentials) throws OrganizationDoesNotAcceptSubmissionsException {
+    public Submission create(User submitter, Organization organization, SubmissionStatus startingStatus, Credentials credentials, List<CustomActionDefinition> customActions) throws OrganizationDoesNotAcceptSubmissionsException {
         if (organization.getAcceptsSubmissions().equals(false)) {
             throw new OrganizationDoesNotAcceptSubmissionsException();
         }
 
         Submission submission = submissionRepo.save(new Submission(submitter, organization, startingStatus));
 
-        for (CustomActionDefinition cad : customActionDefinitionRepo.findAll()) {
+        for (CustomActionDefinition cad : customActions) {
             customActionValueRepo.create(submission, cad, false);
         }
 

--- a/src/test/java/org/tdl/vireo/model/ActionLogTest.java
+++ b/src/test/java/org/tdl/vireo/model/ActionLogTest.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 
 public class ActionLogTest extends AbstractEntityTest {
+
+    @Autowired
+    private CustomActionDefinitionRepo customActionDefinitionRepo;
 
     @Before
     public void setUp() throws OrganizationDoesNotAcceptSubmissionsException {
@@ -21,7 +26,7 @@ public class ActionLogTest extends AbstractEntityTest {
         parentCategory = organizationCategoryRepo.create(TEST_ORGANIZATION_CATEGORY_NAME);
         organization = organizationRepo.create(TEST_ORGANIZATION_NAME, parentCategory);
 
-        testSubmission = submissionRepo.create(testUser, organization, submissionStatus, getCredentials());
+        testSubmission = submissionRepo.create(testUser, organization, submissionStatus, getCredentials(), customActionDefinitionRepo.findAll());
 
         assertEquals("The submission repository is not empty!", 1, submissionRepo.count());
     }

--- a/src/test/java/org/tdl/vireo/model/CustomActionValueTest.java
+++ b/src/test/java/org/tdl/vireo/model/CustomActionValueTest.java
@@ -5,9 +5,14 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 
 public class CustomActionValueTest extends AbstractEntityTest {
+
+    @Autowired
+    private CustomActionDefinitionRepo customActionDefinitionRepo;
 
     @Before
     public void setUp() throws Exception {
@@ -22,7 +27,7 @@ public class CustomActionValueTest extends AbstractEntityTest {
 
         Organization organization = organizationRepo.create(TEST_ORGANIZATION_NAME, organizationCategoryRepo.create(TEST_ORGANIZATION_CATEGORY_NAME));
 
-        testSubmission = submissionRepo.create(testUser, organization, submissionStatus, getCredentials());
+        testSubmission = submissionRepo.create(testUser, organization, submissionStatus, getCredentials(), customActionDefinitionRepo.findAll());
 
         assertEquals("The submission repository is not empty!", 1, submissionRepo.count());
 

--- a/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
+++ b/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 
 public class DocumentTypeTest extends AbstractEntityTest {
+
+    @Autowired
+    private CustomActionDefinitionRepo customActionDefinitionRepo;
 
     @Override
     public void testCreate() {
@@ -85,7 +90,7 @@ public class DocumentTypeTest extends AbstractEntityTest {
         assertEquals("The user does not exist!", 1, userRepo.count());
 
         // Create a Submission
-        submissionRepo.create(submitter, organization, submissionStatus, getCredentials());
+        submissionRepo.create(submitter, organization, submissionStatus, getCredentials(), customActionDefinitionRepo.findAll());
 
         documentTypeRepo.delete(documentType);
     }


### PR DESCRIPTION
Relates #1596 

Doing a select all read operation in a transaction write lock can have a performance hit.

When a student first loads a submission page and they do not have a submission, the submission gets created through this write method. This causes a large pause on the view submission page.

Removing the select all read for the custom action definition list removes one potential cause of a slow first load.