### PR TITLE
Add back creation of public log on submission create.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -218,6 +218,7 @@ public class SubmissionController {
       customActionDefinitionRepo.findAll()
     );
 
+    actionLogRepo.createPublicLog(submission, user, "Submission created.");
     return new ApiResponse(SUCCESS, submission);
   }
 


### PR DESCRIPTION
I don't see this added anywhere else.
Please double-check at runtime and confirm if this is needed or if this change is causing "Submission created" to appear twice now.