### PR TITLE
Initial "simple models" design.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -240,6 +240,7 @@ public class SubmissionController {
         SimpleSubmission submission = simpleSubmissionRepo.findByAdvisorAccessHash(advisorAccessHash);
         submission.setFieldValues(simpleFieldValueRepo.findAllBySubmissionId(submission.getId()));
         submission.setActionLogs(actionLogRepo.findAll(submission.getId()));
+        submission.setSubmissionWorkflowSteps(submissionWorkflowStepRepo.findBySubmissionId(submission.getId()));
 
         return new ApiResponse(SUCCESS, SimpleSubmission.toSubmission(submission));
     }

--- a/src/main/java/org/tdl/vireo/model/EmailTemplate.java
+++ b/src/main/java/org/tdl/vireo/model/EmailTemplate.java
@@ -10,7 +10,7 @@ import org.tdl.vireo.model.validation.EmailTemplateValidator;
 import edu.tamu.weaver.validation.model.ValidatingOrderedBaseEntity;
 
 @Entity
-@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "systemRequired" }) })
+@Table(name = "email_template", uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "systemRequired" }) })
 public class EmailTemplate extends ValidatingOrderedBaseEntity {
 
     @Column(nullable = false)

--- a/src/main/java/org/tdl/vireo/model/EmailWorkflowRule.java
+++ b/src/main/java/org/tdl/vireo/model/EmailWorkflowRule.java
@@ -5,21 +5,20 @@ import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.FetchType.EAGER;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-
-import org.tdl.vireo.model.validation.EmailWorkflowRuleValidator;
-
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import org.tdl.vireo.model.validation.EmailWorkflowRuleValidator;
 
 @Entity
+@Table(name = "email_workflow_rule")
 public class EmailWorkflowRule extends ValidatingBaseEntity {
 
     @Column

--- a/src/main/java/org/tdl/vireo/model/FieldPredicate.java
+++ b/src/main/java/org/tdl/vireo/model/FieldPredicate.java
@@ -1,20 +1,18 @@
 package org.tdl.vireo.model;
 
-import java.util.regex.Pattern;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Transient;
-
-import org.tdl.vireo.model.validation.FieldPredicateValidator;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonView;
-
 import edu.tamu.weaver.response.ApiView;
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
+import java.util.regex.Pattern;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.tdl.vireo.model.validation.FieldPredicateValidator;
 
 @Entity
+@Table(name = "field_predicate")
 public class FieldPredicate extends ValidatingBaseEntity {
 
     @Transient

--- a/src/main/java/org/tdl/vireo/model/FieldValue.java
+++ b/src/main/java/org/tdl/vireo/model/FieldValue.java
@@ -2,24 +2,22 @@ package org.tdl.vireo.model;
 
 import static javax.persistence.FetchType.LAZY;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonView;
-
+import javax.persistence.Table;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.tdl.vireo.model.response.Views;
 
-import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
-
 @Entity
+@Table(name = "field_value")
 public class FieldValue extends ValidatingBaseEntity {
 
     @JsonView(Views.SubmissionList.class)

--- a/src/main/java/org/tdl/vireo/model/InputType.java
+++ b/src/main/java/org/tdl/vireo/model/InputType.java
@@ -2,19 +2,18 @@ package org.tdl.vireo.model;
 
 import static javax.persistence.FetchType.EAGER;
 
+import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.MapKeyColumn;
-
+import javax.persistence.Table;
 import org.tdl.vireo.model.validation.InputTypeValidator;
 
-import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
-
 @Entity
+@Table(name = "input_type")
 public class InputType extends ValidatingBaseEntity {
 
     @Column(unique = true, nullable = false)

--- a/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
+++ b/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
@@ -4,11 +4,15 @@ import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.FetchType.EAGER;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -19,21 +23,13 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.tdl.vireo.model.validation.NamedSearchFilterValidator;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIdentityReference;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
-import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
-
 @Entity
 @JsonIgnoreProperties(value = { "user" }, allowGetters = true)
-@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "user_id", "name" }) })
+@Table(name = "named_search_filter_group", uniqueConstraints = { @UniqueConstraint(columnNames = { "user_id", "name" }) })
 public class NamedSearchFilterGroup extends ValidatingBaseEntity {
 
     @ManyToOne(optional = false)

--- a/src/main/java/org/tdl/vireo/model/Organization.java
+++ b/src/main/java/org/tdl/vireo/model/Organization.java
@@ -5,12 +5,17 @@ import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.CascadeType.REMOVE;
 import static javax.persistence.FetchType.EAGER;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -22,14 +27,6 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
-
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIdentityReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
@@ -39,7 +36,7 @@ import org.tdl.vireo.model.validation.OrganizationValidator;
 
 @Entity
 @JsonIgnoreProperties(value = { "aggregateWorkflowSteps", "childrenOrganizations" }, allowGetters = true)
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "name", "category_id", "parent_organization_id" }))
+@Table(name = "organization", uniqueConstraints = @UniqueConstraint(columnNames = { "name", "category_id", "parent_organization_id" }))
 public class Organization extends HibernateWorkaroundValidatingBaseEntity {
 
     @Transient

--- a/src/main/java/org/tdl/vireo/model/OrganizationCategory.java
+++ b/src/main/java/org/tdl/vireo/model/OrganizationCategory.java
@@ -1,19 +1,16 @@
 package org.tdl.vireo.model;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import edu.tamu.weaver.response.ApiView;
+import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
-
 import org.tdl.vireo.model.validation.OrganizationCategoryValidator;
 
-import com.fasterxml.jackson.annotation.JsonView;
-
-import edu.tamu.weaver.response.ApiView;
-import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
-
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "name" }))
+@Table(name = "organization_category", uniqueConstraints = @UniqueConstraint(columnNames = { "name" }))
 public class OrganizationCategory extends ValidatingBaseEntity {
 
     @JsonView(ApiView.Partial.class)
@@ -27,7 +24,6 @@ public class OrganizationCategory extends ValidatingBaseEntity {
     /**
      *
      * @param name
-     * @param level
      */
     public OrganizationCategory(String name) {
         this();

--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -24,6 +24,7 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.Transient;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.annotations.Fetch;
@@ -40,6 +41,7 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 @Entity
 @JsonIgnoreProperties(value = { "organization" }, allowGetters = true)
 @Table(
+    name = "submission",
     indexes = {
         @Index(columnList = "submitter_id", name = "submission_submitter_id_idx"),
         @Index(columnList = "submitter_id, organization_id", name = "submission_organization_idx")
@@ -128,6 +130,9 @@ public class Submission extends ValidatingBaseEntity {
 
     @Column(nullable = true)
     private String depositURL;
+
+    @Transient
+    private ActionLog lastAction;
 
     public Submission() {
         setModelValidator(new SubmissionValidator());
@@ -433,13 +438,18 @@ public class Submission extends ValidatingBaseEntity {
      */
     @JsonView(Views.Partial.class)
     public String getLastEvent() {
+        String lastEvent = null;
+
+        if (lastAction != null) {
+            lastEvent = lastAction.getEntry();
+        } else if (getActionLogs() != null) {
         Optional<ActionLog> actionLog = getActionLogs()
             .stream()
             .max(Comparator.comparing(al -> al.getActionDate()));
-        String lastEvent = null;
 
         if (actionLog.isPresent()) {
             lastEvent = actionLog.get().getEntry();
+        }
         }
 
         return lastEvent;
@@ -515,6 +525,16 @@ public class Submission extends ValidatingBaseEntity {
         this.depositURL = depositURL;
     }
 
+    @JsonIgnore
+    public ActionLog getLastAction() {
+        return lastAction;
+    }
+
+    @JsonIgnore
+    public void setLastAction(ActionLog lastAction) {
+        this.lastAction = lastAction;
+    }
+
     /**
      * @return the customActionValues
      */
@@ -587,22 +607,26 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public List<FieldValue> getFieldValuesByPredicateValue(String predicateValue) {
         List<FieldValue> fielsValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         getFieldValues().forEach(fieldValue -> {
             if (fieldValue.getFieldPredicate().getValue().equals(predicateValue)) {
                 fielsValues.add(fieldValue);
             }
         });
+        }
         return fielsValues;
     }
 
     @JsonIgnore
     public List<FieldValue> getFieldValuesByPredicateValueStartsWith(String predicateValue) {
         List<FieldValue> fieldValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         getFieldValues().forEach(fieldValue -> {
             if (fieldValue.getFieldPredicate().getValue().startsWith(predicateValue)) {
                 fieldValues.add(fieldValue);
             }
         });
+        }
         return fieldValues;
     }   
 
@@ -610,11 +634,13 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public FieldValue getFieldValueByValueAndPredicate(String value, FieldPredicate fieldPredicate) {
         FieldValue foundFieldValue = null;
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getValue().equals(value) && fieldValue.getFieldPredicate().equals(fieldPredicate)) {
                 foundFieldValue = fieldValue;
                 break;
             }
+        }
         }
         return foundFieldValue;
     }
@@ -624,6 +650,7 @@ public class Submission extends ValidatingBaseEntity {
 
         List<FieldValue> fieldValues = new ArrayList<FieldValue>();
 
+        if (getSubmissionWorkflowSteps() != null) {
         getSubmissionWorkflowSteps().forEach(submissionWorkflowSteps -> {
             submissionWorkflowSteps.getAggregateFieldProfiles().forEach(afp -> {
                 if (afp.getInputType().equals(inputType)) {
@@ -632,6 +659,7 @@ public class Submission extends ValidatingBaseEntity {
                 }
             });
         });
+        }
 
         return fieldValues;
     }
@@ -639,10 +667,12 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public List<FieldValue> getAllDocumentFieldValues() {
         List<FieldValue> fielsValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getFieldPredicate().getDocumentTypePredicate()) {
                 fielsValues.add(fieldValue);
             }
+        }
         }
         return fielsValues;
     }
@@ -650,11 +680,13 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public FieldValue getPrimaryDocumentFieldValue() {
         FieldValue primaryDocumentFieldValue = null;
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getFieldPredicate().getValue().equals("_doctype_primary")) {
                 primaryDocumentFieldValue = fieldValue;
                 break;
             }
+        }
         }
         return primaryDocumentFieldValue;
     }
@@ -662,10 +694,12 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public List<FieldValue> getLicenseDocumentFieldValues() {
         List<FieldValue> fielsValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getFieldPredicate().getValue().equals("_doctype_license")) {
                 fielsValues.add(fieldValue);
             }
+        }
         }
         return fielsValues;
     }
@@ -673,10 +707,12 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public List<FieldValue> getSupplementalAndSourceDocumentFieldValues() {
         List<FieldValue> fielsValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getFieldPredicate().getValue().equals("_doctype_supplemental") || fieldValue.getFieldPredicate().getValue().equals("_doctype_source")) {
                 fielsValues.add(fieldValue);
             }
+        }
         }
         return fielsValues;
     }
@@ -684,10 +720,12 @@ public class Submission extends ValidatingBaseEntity {
     @JsonIgnore
     public List<FieldValue> getSupplementalDocumentFieldValues() {
         List<FieldValue> fielsValues = new ArrayList<FieldValue>();
+        if (getFieldValues() != null) {
         for (FieldValue fieldValue : getFieldValues()) {
             if (fieldValue.getFieldPredicate().getValue().equals("_doctype_supplemental")) {
                 fielsValues.add(fieldValue);
             }
+        }
         }
         return fielsValues;
     }
@@ -697,6 +735,7 @@ public class Submission extends ValidatingBaseEntity {
 
         List<SubmissionFieldProfile> submissionFieldProfiles = new ArrayList<SubmissionFieldProfile>();
 
+        if (getSubmissionWorkflowSteps() != null) {
         getSubmissionWorkflowSteps().forEach(submissionWorkflowSteps -> {
             submissionWorkflowSteps.getAggregateFieldProfiles().forEach(afp -> {
                 if (afp.getInputType().getName().equals(inputType)) {
@@ -704,6 +743,7 @@ public class Submission extends ValidatingBaseEntity {
                 }
             });
         });
+        }
 
         return submissionFieldProfiles;
     }

--- a/src/main/java/org/tdl/vireo/model/SubmissionListColumn.java
+++ b/src/main/java/org/tdl/vireo/model/SubmissionListColumn.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "title", "predicate", "input_type_id" }))
+@Table(name = "submission_list_column", uniqueConstraints = @UniqueConstraint(columnNames = { "title", "predicate", "input_type_id" }))
 public class SubmissionListColumn extends ValidatingBaseEntity {
 
     @ManyToOne(fetch = EAGER, optional = false)
@@ -228,7 +228,7 @@ public class SubmissionListColumn extends ValidatingBaseEntity {
 
     /**
      *
-     * @return
+     * @return TRUE if visible, FALSE otherwise.
      */
     public Boolean getVisible() {
         return visible;
@@ -244,7 +244,7 @@ public class SubmissionListColumn extends ValidatingBaseEntity {
 
     /**
      *
-     * @return
+     * @return TRUE if exact match, FALSE otherwise.
      */
     public Boolean getExactMatch() {
         return exactMatch;

--- a/src/main/java/org/tdl/vireo/model/SubmissionStatus.java
+++ b/src/main/java/org/tdl/vireo/model/SubmissionStatus.java
@@ -5,23 +5,22 @@ import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.FetchType.EAGER;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.ManyToMany;
-
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.SubmissionStatusValidator;
 
 @Entity
+@Table(name = "submission_status")
 public class SubmissionStatus extends HibernateWorkaroundValidatingBaseEntity {
 
     @JsonView(Views.SubmissionList.class)
@@ -200,7 +199,7 @@ public class SubmissionStatus extends HibernateWorkaroundValidatingBaseEntity {
     }
 
     /**
-     * @param transitionSubmissionStatuses
+     * @param transitionSubmissionStates
      *            the transitionSubmissionStates to set
      */
     public void setTransitionSubmissionStatuses(List<SubmissionStatus> transitionSubmissionStates) {
@@ -209,7 +208,7 @@ public class SubmissionStatus extends HibernateWorkaroundValidatingBaseEntity {
 
     /**
      *
-     * @param transitionSubmissionStatus
+     * @param transitionSubmissionState
      */
     public void addTransitionSubmissionStatus(SubmissionStatus transitionSubmissionState) {
         getTransitionSubmissionStatuses().add(transitionSubmissionState);
@@ -217,7 +216,7 @@ public class SubmissionStatus extends HibernateWorkaroundValidatingBaseEntity {
 
     /**
      *
-     * @param transitionSubmissionStatus
+     * @param transitionSubmissionState
      */
     public void removeTransitionSubmissionStatus(SubmissionStatus transitionSubmissionState) {
         getTransitionSubmissionStatuses().remove(transitionSubmissionState);

--- a/src/main/java/org/tdl/vireo/model/User.java
+++ b/src/main/java/org/tdl/vireo/model/User.java
@@ -6,6 +6,11 @@ import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.CascadeType.REMOVE;
 import static javax.persistence.FetchType.EAGER;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import edu.tamu.weaver.user.model.IRole;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -13,7 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -26,12 +30,7 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderColumn;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
+import javax.persistence.Table;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Formula;
@@ -40,9 +39,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.UserValidator;
 
-import edu.tamu.weaver.user.model.IRole;
-
 @Entity
+@Table(name = "weaver_users")
 public class User extends HibernateWorkaroundAbstractWeaverUserDetails {
 
     private static final long serialVersionUID = -614285536644750464L;
@@ -75,8 +73,8 @@ public class User extends HibernateWorkaroundAbstractWeaverUserDetails {
     private String name;
 
     @ElementCollection(fetch = EAGER)
-    @MapKeyColumn(name = "setting")
-    @Column(name = "value")
+    @MapKeyColumn(table = "weaver_users", name = "setting")
+    @Column(table = "weaver_users", name = "value")
     private Map<String, String> settings;
 
     @JsonView(Views.Partial.class)

--- a/src/main/java/org/tdl/vireo/model/repo/ActionLogRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/ActionLogRepo.java
@@ -1,14 +1,22 @@
 package org.tdl.vireo.model.repo;
 
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tdl.vireo.model.ActionLog;
 import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.ActionLogRepoCustom;
 
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
-
 public interface ActionLogRepo extends WeaverRepo<ActionLog>, ActionLogRepoCustom {
 
     public ActionLog findByUserAndSubmissionStatus(User user, SubmissionStatus submissionStatus);
+
+    @Query(value = "SELECT * FROM action_log a WHERE a.action_logs_id = :submissionId ORDER BY a.action_date DESC", nativeQuery=true)
+    public List<ActionLog> findAll(@Param("submissionId") Long submissionId);
+
+    @Query(value = "SELECT * FROM action_log a WHERE a.action_logs_id = :submissionId ORDER BY a.action_date DESC LIMIT 1", nativeQuery=true)
+    public ActionLog findLastEvent(@Param("submissionId") Long submissionId);
 
 }

--- a/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/FieldValueRepo.java
@@ -1,10 +1,15 @@
 package org.tdl.vireo.model.repo;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.repo.custom.FieldValueRepoCustom;
 
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
+import java.util.Set;
 
 public interface FieldValueRepo extends WeaverRepo<FieldValue>, FieldValueRepoCustom {
 
+    @Query(value = "SELECT * FROM field_value f INNER JOIN submission_field_values s ON f.id = s.field_values_id  INNER JOIN field_predicate p ON f.field_predicate_id = p.id WHERE s.submission_id = :submissionId", nativeQuery = true)
+    public Set<FieldValue> findAllBySubmissionId(@Param("submissionId") Long submissionId);
 }

--- a/src/main/java/org/tdl/vireo/model/repo/SubmissionWorkflowStepRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/SubmissionWorkflowStepRepo.java
@@ -1,10 +1,15 @@
 package org.tdl.vireo.model.repo;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.tdl.vireo.model.SubmissionWorkflowStep;
 import org.tdl.vireo.model.repo.custom.SubmissionWorkflowStepRepoCustom;
 
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
+import java.util.List;
 
 public interface SubmissionWorkflowStepRepo extends WeaverRepo<SubmissionWorkflowStep>, SubmissionWorkflowStepRepoCustom {
 
+    @Query(value = "SELECT w.* FROM submission_workflow_step w INNER JOIN submission_submission_workflow_steps s ON w.id = submission_workflow_steps_id WHERE s.submission_id = :submissionId ORDER BY s.submission_workflow_steps_order DESC", nativeQuery=true)
+    public List<SubmissionWorkflowStep> findBySubmissionId(@Param("submissionId") Long submissionId);
 }

--- a/src/main/java/org/tdl/vireo/model/repo/WorkflowStepRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/WorkflowStepRepo.java
@@ -1,12 +1,10 @@
 package org.tdl.vireo.model.repo;
 
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
 import java.util.List;
-
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.WorkflowStep;
 import org.tdl.vireo.model.repo.custom.WorkflowStepRepoCustom;
-
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface WorkflowStepRepo extends WeaverRepo<WorkflowStep>, WorkflowStepRepoCustom {
 

--- a/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/FieldValueRepoImpl.java
@@ -1,12 +1,11 @@
 package org.tdl.vireo.model.repo.impl;
 
+import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.repo.FieldValueRepo;
 import org.tdl.vireo.model.repo.custom.FieldValueRepoCustom;
-
-import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
 
 public class FieldValueRepoImpl extends AbstractWeaverRepoImpl<FieldValue, FieldValueRepo> implements FieldValueRepoCustom {
 

--- a/src/main/java/org/tdl/vireo/model/repo/simple/SimpleFieldValueRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/simple/SimpleFieldValueRepo.java
@@ -1,0 +1,13 @@
+package org.tdl.vireo.model.repo.simple;
+
+import java.util.Set;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.tdl.vireo.model.simple.SimpleFieldValue;
+
+public interface SimpleFieldValueRepo extends Repository<SimpleFieldValue, Long> {
+
+    @Query(value = "SELECT * FROM field_value f INNER JOIN submission_field_values s ON f.id = s.field_values_id WHERE s.submission_id = :submissionId", nativeQuery=true)
+    public Set<SimpleFieldValue> findAllBySubmissionId(@Param("submissionId") Long submissionId);
+}

--- a/src/main/java/org/tdl/vireo/model/repo/simple/SimpleSubmissionRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/simple/SimpleSubmissionRepo.java
@@ -1,0 +1,18 @@
+package org.tdl.vireo.model.repo.simple;
+
+import java.util.List;
+import org.springframework.data.repository.Repository;
+import org.tdl.vireo.model.simple.SimpleSubmission;
+
+public interface SimpleSubmissionRepo extends Repository<SimpleSubmission, Long> {
+
+    public List<SimpleSubmission> findAll();
+
+    public List<SimpleSubmission> findAllBySubmitterId(Long submitterId);
+
+    public SimpleSubmission findById(Long id);
+
+    public SimpleSubmission findBySubmitterIdAndId(Long submitterId, Long id);
+
+    public SimpleSubmission findByAdvisorAccessHash(String advisorAccessHash);
+}

--- a/src/main/java/org/tdl/vireo/model/repo/simple/SimpleUserRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/simple/SimpleUserRepo.java
@@ -1,0 +1,14 @@
+package org.tdl.vireo.model.repo.simple;
+
+import java.util.List;
+import org.springframework.data.repository.Repository;
+import org.tdl.vireo.model.simple.SimpleUser;
+
+public interface SimpleUserRepo extends Repository<SimpleUser, Long> {
+
+    public SimpleUser findByEmail(String email);
+
+    public List<SimpleUser> findAll();
+
+    public SimpleUser findById(Long id);
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleEmailTemplate.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleEmailTemplate.java
@@ -1,0 +1,78 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Immutable
+@Table(name = "email_template")
+public class SimpleEmailTemplate implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = -989693164688451518L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private String name;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private String subject;
+
+    @Column(insertable = false, updatable = false, nullable = false, columnDefinition = "text")
+    private String message;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean systemRequired;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Boolean getSystemRequired() {
+        return systemRequired;
+    }
+
+    public void setSystemRequired(Boolean systemRequired) {
+        this.systemRequired = systemRequired;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleEmailWorkflowRule.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleEmailWorkflowRule.java
@@ -1,0 +1,108 @@
+package org.tdl.vireo.model.simple;
+
+import static javax.persistence.CascadeType.DETACH;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.REFRESH;
+import static javax.persistence.FetchType.EAGER;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.AbstractEmailRecipient;
+import org.tdl.vireo.model.EmailRecipient;
+import org.tdl.vireo.model.SubmissionStatus;
+
+@Entity
+@Immutable
+@Table(name = "email_workflow_rule")
+public class SimpleEmailWorkflowRule implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 4224051361965594236L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column
+    private Boolean isSystem;
+
+    @Column
+    private Boolean isDisabled;
+
+    @Immutable
+    @ManyToOne(targetEntity = AbstractEmailRecipient.class)
+    private EmailRecipient emailRecipient;
+
+    @Immutable
+    @ManyToOne(fetch = EAGER, optional = false)
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = SubmissionStatus.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    private SimpleSubmissionStatus submissionStatus;
+
+    @Immutable
+    @ManyToOne(cascade = { DETACH, REFRESH, MERGE }, fetch = EAGER, optional = false)
+    @JoinColumn(name = "emailTemplateId")
+    private SimpleEmailTemplate emailTemplate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Boolean getIsSystem() {
+        return isSystem;
+    }
+
+    public void setIsSystem(Boolean isSystem) {
+        this.isSystem = isSystem;
+    }
+
+    public Boolean getIsDisabled() {
+        return isDisabled;
+    }
+
+    public void setIsDisabled(Boolean isDisabled) {
+        this.isDisabled = isDisabled;
+    }
+
+    public EmailRecipient getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(EmailRecipient emailRecipient) {
+        this.emailRecipient = emailRecipient;
+    }
+
+    public SimpleSubmissionStatus getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public void setSubmissionStatus(SimpleSubmissionStatus submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    public SimpleEmailTemplate getEmailTemplate() {
+        return emailTemplate;
+    }
+
+    public void setEmailTemplate(SimpleEmailTemplate emailTemplate) {
+        this.emailTemplate = emailTemplate;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleFieldPredicate.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleFieldPredicate.java
@@ -1,0 +1,71 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.FieldPredicate;
+
+@Entity
+@Immutable
+@Table(name = "field_predicate")
+public class SimpleFieldPredicate implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 7752694484720316614L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = false, unique = true)
+    private String value;
+
+    @Column(insertable = false, updatable = false, nullable = false, unique = false)
+    private Boolean documentTypePredicate;
+
+    public static FieldPredicate toFieldPredicate(SimpleFieldPredicate simpleFieldPredicate) {
+        if (simpleFieldPredicate == null) {
+            return null;
+        }
+
+        FieldPredicate fieldPredicate = new FieldPredicate();
+
+        fieldPredicate.setId(simpleFieldPredicate.getId());
+        fieldPredicate.setValue(simpleFieldPredicate.getValue());
+        fieldPredicate.setDocumentTypePredicate(simpleFieldPredicate.getDocumentTypePredicate());
+
+        return fieldPredicate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Boolean getDocumentTypePredicate() {
+        return documentTypePredicate;
+    }
+
+    public void setDocumentTypePredicate(Boolean documentTypePredicate) {
+        this.documentTypePredicate = documentTypePredicate;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleFieldValue.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleFieldValue.java
@@ -1,0 +1,111 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.FieldValue;
+
+@Entity
+@Immutable
+@Table(name = "field_value")
+public class SimpleFieldValue implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = -6043769326274667441L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, columnDefinition = "text", nullable = true)
+    private String value;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String identifier;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String definition;
+
+    @Transient
+    private List<String> contacts;
+
+    @Immutable
+    @ManyToOne(optional = false, fetch = FetchType.EAGER)
+    private SimpleFieldPredicate fieldPredicate;
+
+    public static FieldValue toFieldValue(SimpleFieldValue simpleFieldValue) {
+        if (simpleFieldValue == null) {
+            return null;
+        }
+
+        FieldValue fieldValue = new FieldValue();
+
+        fieldValue.setId(simpleFieldValue.getId());
+        fieldValue.setContacts(simpleFieldValue.getContacts());
+        fieldValue.setDefinition(simpleFieldValue.getDefinition());
+        fieldValue.setFieldPredicate(SimpleFieldPredicate.toFieldPredicate(simpleFieldValue.getFieldPredicate()));
+        fieldValue.setIdentifier(simpleFieldValue.getIdentifier());
+        fieldValue.setValue(simpleFieldValue.getValue());
+
+        return fieldValue;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(String identifier) {
+        this.identifier = identifier;
+    }
+
+    public String getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(String definition) {
+        this.definition = definition;
+    }
+
+    public List<String> getContacts() {
+        return contacts;
+    }
+
+    public void setContacts(List<String> contacts) {
+        this.contacts = contacts;
+    }
+
+    public SimpleFieldPredicate getFieldPredicate() {
+        return fieldPredicate;
+    }
+
+    public void setFieldPredicate(SimpleFieldPredicate fieldPredicate) {
+        this.fieldPredicate = fieldPredicate;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleInputType.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleInputType.java
@@ -1,0 +1,59 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Immutable
+@Table(name = "input_type")
+public class SimpleInputType implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 8703635502639470746L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, unique = true, nullable = false)
+    private String name;
+
+    @Column(insertable = false, updatable = false)
+    private String validationPattern;
+
+    @Column(insertable = false, updatable = false)
+    private String validationMessage;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValidationPattern() {
+        return validationPattern;
+    }
+
+    public void setValidationPattern(String validationPattern) {
+        this.validationPattern = validationPattern;
+    }
+
+    public String getValidationMessage() {
+        return validationMessage;
+    }
+
+    public void setValidationMessage(String validationMessage) {
+        this.validationMessage = validationMessage;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleNamedSearchFilterGroup.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleNamedSearchFilterGroup.java
@@ -1,14 +1,21 @@
 package org.tdl.vireo.model.simple;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.NamedSearchFilter;
+import org.tdl.vireo.model.Sort;
+import org.tdl.vireo.model.SubmissionListColumn;
 
 @Entity
 @Immutable
@@ -37,6 +44,19 @@ public class SimpleNamedSearchFilterGroup implements Serializable {
 
     @Column(insertable = false, updatable = false, nullable = false)
     private Boolean umiRelease;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String sortColumnTitle;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    @Enumerated(EnumType.STRING)
+    private Sort sortDirection;
+
+    @Transient
+    private List<SubmissionListColumn> savedColumns;
+
+    @Transient
+    private Set<NamedSearchFilter> namedSearchFilters;
 
     public Long getId() {
         return id;
@@ -84,6 +104,38 @@ public class SimpleNamedSearchFilterGroup implements Serializable {
 
     public void setUmiRelease(Boolean umiRelease) {
         this.umiRelease = umiRelease;
+    }
+
+    public String getSortColumnTitle() {
+        return sortColumnTitle;
+    }
+
+    public void setSortColumnTitle(String sortColumnTitle) {
+        this.sortColumnTitle = sortColumnTitle;
+    }
+
+    public Sort getSortDirection() {
+        return sortDirection;
+    }
+
+    public void setSortDirection(Sort sortDirection) {
+        this.sortDirection = sortDirection;
+    }
+
+    public List<SubmissionListColumn> getSavedColumns() {
+        return savedColumns;
+    }
+
+    public void setSavedColumns(List<SubmissionListColumn> savedColumns) {
+        this.savedColumns = savedColumns;
+    }
+
+    public Set<NamedSearchFilter> getNamedSearchFilters() {
+        return namedSearchFilters;
+    }
+
+    public void setNamedSearchFilters(Set<NamedSearchFilter> namedSearchFilters) {
+        this.namedSearchFilters = namedSearchFilters;
     }
 
 }

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleNamedSearchFilterGroup.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleNamedSearchFilterGroup.java
@@ -1,0 +1,89 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Immutable
+@Table(name = "named_search_filter_group")
+public class SimpleNamedSearchFilterGroup implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 483874224486014344L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(name = "user_id", insertable = false, updatable = false, nullable = false)
+    private Long userId;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String name;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean publicFlag;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean columnsFlag;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean umiRelease;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getPublicFlag() {
+        return publicFlag;
+    }
+
+    public void setPublicFlag(Boolean publicFlag) {
+        this.publicFlag = publicFlag;
+    }
+
+    public Boolean getColumnsFlag() {
+        return columnsFlag;
+    }
+
+    public void setColumnsFlag(Boolean columnsFlag) {
+        this.columnsFlag = columnsFlag;
+    }
+
+    public Boolean getUmiRelease() {
+        return umiRelease;
+    }
+
+    public void setUmiRelease(Boolean umiRelease) {
+        this.umiRelease = umiRelease;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleOrganization.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleOrganization.java
@@ -1,0 +1,184 @@
+package org.tdl.vireo.model.simple;
+
+import static javax.persistence.FetchType.EAGER;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.WorkflowStep;
+
+@Entity
+@Immutable
+@Table(name = "organization")
+public class SimpleOrganization implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = -6190834548753026763L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private String name;
+
+    @Immutable
+    @ManyToOne(fetch = EAGER, optional = false)
+    private SimpleOrganizationCategory category;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean acceptsSubmissions = true;
+
+    @Transient
+    private List<WorkflowStep> originalWorkflowSteps;
+
+    @Transient
+    private List<WorkflowStep> aggregateWorkflowSteps;
+
+    @Column(name = "parent_organization_id", insertable = false, updatable = false, nullable = false)
+    private Long parentOrganizationId;
+
+    @Transient
+    private Organization parentOrganization;
+
+    @Transient
+    private Set<Organization> childrenOrganizations;
+
+    @Transient
+    private List<String> emails;
+
+    @Transient
+    private List<EmailWorkflowRule> emailWorkflowRules;
+
+    public static Organization toOrganization(SimpleOrganization simpleOrganization) {
+        if (simpleOrganization == null) {
+            return null;
+        }
+
+        Organization organization = new Organization();
+
+        organization.setId(simpleOrganization.getId());
+        organization.setName(simpleOrganization.getName());
+        organization.setCategory(SimpleOrganizationCategory.toOrganizationCategory(simpleOrganization.getCategory()));
+        organization.setAcceptsSubmissions(simpleOrganization.getAcceptsSubmissions());
+        organization.setOriginalWorkflowSteps(simpleOrganization.getOriginalWorkflowSteps());
+        organization.setAggregateWorkflowSteps(simpleOrganization.getAggregateWorkflowSteps());
+        organization.setChildrenOrganizations(simpleOrganization.getChildrenOrganizations());
+        organization.setEmails(simpleOrganization.getEmails());
+        organization.setEmailWorkflowRules(simpleOrganization.getEmailWorkflowRules());
+
+        // The @JsonIdentityReference on parentOrganization of Organization is set to alwaysAsId.
+        if (simpleOrganization.getParentOrganization() == null) {
+            if (simpleOrganization.getParentOrganizationId() != null) {
+                Organization parent = new Organization();
+                parent.setId(simpleOrganization.getParentOrganizationId());
+                organization.setParentOrganization(parent);
+            }
+        } else {
+            organization.setParentOrganization(simpleOrganization.getParentOrganization());
+        }
+
+        return organization;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SimpleOrganizationCategory getCategory() {
+        return category;
+    }
+
+    public void setCategory(SimpleOrganizationCategory category) {
+        this.category = category;
+    }
+
+    public Boolean getAcceptsSubmissions() {
+        return acceptsSubmissions;
+    }
+
+    public void setAcceptsSubmissions(Boolean acceptsSubmissions) {
+        this.acceptsSubmissions = acceptsSubmissions;
+    }
+
+    public List<WorkflowStep> getOriginalWorkflowSteps() {
+        return originalWorkflowSteps;
+    }
+
+    public void setOriginalWorkflowSteps(List<WorkflowStep> originalWorkflowSteps) {
+        this.originalWorkflowSteps = originalWorkflowSteps;
+    }
+
+    public List<WorkflowStep> getAggregateWorkflowSteps() {
+        return aggregateWorkflowSteps;
+    }
+
+    public void setAggregateWorkflowSteps(List<WorkflowStep> aggregateWorkflowSteps) {
+        this.aggregateWorkflowSteps = aggregateWorkflowSteps;
+    }
+
+    public Long getParentOrganizationId() {
+        return parentOrganizationId;
+    }
+
+    public void setParentOrganizationId(Long parentOrganizationId) {
+        this.parentOrganizationId = parentOrganizationId;
+    }
+
+    public Organization getParentOrganization() {
+        return parentOrganization;
+    }
+
+    public void setParentOrganization(Organization parentOrganization) {
+        this.parentOrganization = parentOrganization;
+    }
+
+    public Set<Organization> getChildrenOrganizations() {
+        return childrenOrganizations;
+    }
+
+    public void setChildrenOrganizations(Set<Organization> childrenOrganizations) {
+        this.childrenOrganizations = childrenOrganizations;
+    }
+
+    public List<String> getEmails() {
+        return emails;
+    }
+
+    public void setEmails(List<String> emails) {
+        this.emails = emails;
+    }
+
+    public List<EmailWorkflowRule> getEmailWorkflowRules() {
+        return emailWorkflowRules;
+    }
+
+    public void setEmailWorkflowRules(List<EmailWorkflowRule> emailWorkflowRules) {
+        this.emailWorkflowRules = emailWorkflowRules;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleOrganization.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleOrganization.java
@@ -47,7 +47,7 @@ public class SimpleOrganization implements Serializable {
     @Transient
     private List<WorkflowStep> aggregateWorkflowSteps;
 
-    @Column(name = "parent_organization_id", insertable = false, updatable = false, nullable = false)
+    @Column(name = "parent_organization_id", insertable = false, updatable = false, nullable = true)
     private Long parentOrganizationId;
 
     @Transient

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleOrganizationCategory.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleOrganizationCategory.java
@@ -1,0 +1,59 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.OrganizationCategory;
+
+@Entity
+@Immutable
+@Table(name = "organization_category")
+public class SimpleOrganizationCategory implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 6761882663334170936L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private String name;
+
+    public static OrganizationCategory toOrganizationCategory(SimpleOrganizationCategory simpleOrganizationCategory) {
+        if (simpleOrganizationCategory == null) {
+            return null;
+        }
+
+        OrganizationCategory organizationCategory = new OrganizationCategory();
+
+        organizationCategory.setId(simpleOrganizationCategory.getId());
+        organizationCategory.setName(simpleOrganizationCategory.getName());
+
+        return organizationCategory;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleSubmission.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleSubmission.java
@@ -1,0 +1,336 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.ActionLog;
+import org.tdl.vireo.model.CustomActionValue;
+import org.tdl.vireo.model.FieldValue;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.SubmissionWorkflowStep;
+
+@Entity
+@Immutable
+@Table(name = "submission")
+public class SimpleSubmission implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 9085465328046307313L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Immutable
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    private SimpleUser submitter;
+
+    @Immutable
+    @ManyToOne(fetch = FetchType.EAGER, optional = true)
+    private SimpleUser assignee;
+
+    @Immutable
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    private SimpleSubmissionStatus submissionStatus;
+
+    @Immutable
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    private SimpleOrganization organization;
+
+    @Transient
+    private Set<SimpleFieldValue> fieldValues;
+
+    @Transient
+    private List<SubmissionWorkflowStep> submissionWorkflowSteps;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    @Temporal(TemporalType.DATE)
+    private Calendar approveEmbargoDate;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    @Temporal(TemporalType.DATE)
+    private Calendar approveApplicationDate;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    @Temporal(TemporalType.DATE)
+    private Calendar submissionDate;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    @Temporal(TemporalType.DATE)
+    private Calendar approveAdvisorDate;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private boolean approveEmbargo;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private boolean approveApplication;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private boolean approveAdvisor;
+
+    @Transient
+    private Set<CustomActionValue> customActionValues;
+
+    @Transient
+    private Set<ActionLog> actionLogs;
+
+    @Column(insertable = false, updatable = false, columnDefinition = "TEXT")
+    private String reviewerNotes;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String advisorAccessHash;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String advisorReviewURL;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String depositURL;
+
+    @Transient
+    private ActionLog lastAction;
+
+    public static Submission toSubmission(SimpleSubmission simpleSubmission) {
+        if (simpleSubmission == null) {
+            return null;
+        }
+
+        Submission submission = new Submission();
+
+        submission.setId(simpleSubmission.getId());
+        submission.setSubmitter(SimpleUser.toUser(simpleSubmission.getSubmitter()));
+        submission.setAssignee(SimpleUser.toUser(simpleSubmission.getAssignee()));
+        submission.setSubmissionStatus(SimpleSubmissionStatus.toSubmissionStatus(simpleSubmission.getSubmissionStatus()));
+        submission.setOrganization(SimpleOrganization.toOrganization(simpleSubmission.getOrganization()));
+        submission.setSubmissionWorkflowSteps(simpleSubmission.getSubmissionWorkflowSteps());
+        submission.setApproveEmbargoDate(simpleSubmission.getApproveEmbargoDate());
+        submission.setApproveApplicationDate(simpleSubmission.getApproveApplicationDate());
+        submission.setSubmissionDate(simpleSubmission.getSubmissionDate());
+        submission.setApproveAdvisorDate(simpleSubmission.getApproveAdvisorDate());
+        submission.setApproveEmbargo(simpleSubmission.isApproveEmbargo());
+        submission.setApproveApplication(simpleSubmission.isApproveApplication());
+        submission.setApproveAdvisor(simpleSubmission.isApproveAdvisor());
+        submission.setCustomActionValues(simpleSubmission.getCustomActionValues());
+        submission.setActionLogs(simpleSubmission.getActionLogs());
+        submission.setReviewerNotes(simpleSubmission.getReviewerNotes());
+        submission.setAdvisorAccessHash(simpleSubmission.getAdvisorAccessHash());
+        submission.setAdvisorReviewURL(simpleSubmission.getAdvisorReviewURL());
+        submission.setDepositURL(simpleSubmission.getDepositURL());
+        submission.setLastAction(simpleSubmission.getLastAction());
+
+        if (simpleSubmission.getFieldValues() == null) {
+            submission.setFieldValues(null);
+        } else {
+            Set<FieldValue> fv = new HashSet<>();
+
+            simpleSubmission.getFieldValues().forEach(fieldValue -> {
+                fv.add(SimpleFieldValue.toFieldValue(fieldValue));
+            });
+
+            submission.setFieldValues(fv);
+        }
+
+        return submission;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public SimpleUser getSubmitter() {
+        return submitter;
+    }
+
+    public void setSubmitter(SimpleUser submitter) {
+        this.submitter = submitter;
+    }
+
+    public SimpleUser getAssignee() {
+        return assignee;
+    }
+
+    public void setAssignee(SimpleUser assignee) {
+        this.assignee = assignee;
+    }
+
+    public SimpleSubmissionStatus getSubmissionStatus() {
+        return submissionStatus;
+    }
+
+    public void setSubmissionStatus(SimpleSubmissionStatus submissionStatus) {
+        this.submissionStatus = submissionStatus;
+    }
+
+    public SimpleOrganization getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(SimpleOrganization organization) {
+        this.organization = organization;
+    }
+
+    public Set<SimpleFieldValue> getFieldValues() {
+        return fieldValues;
+    }
+
+    public void setFieldValues(Set<SimpleFieldValue> fieldValues) {
+        this.fieldValues = fieldValues;
+    }
+
+    public List<SubmissionWorkflowStep> getSubmissionWorkflowSteps() {
+        return submissionWorkflowSteps;
+    }
+
+    public void setSubmissionWorkflowSteps(List<SubmissionWorkflowStep> submissionWorkflowSteps) {
+        this.submissionWorkflowSteps = submissionWorkflowSteps;
+    }
+
+    public Calendar getApproveEmbargoDate() {
+        return approveEmbargoDate;
+    }
+
+    public void setApproveEmbargoDate(Calendar approveEmbargoDate) {
+        this.approveEmbargoDate = approveEmbargoDate;
+    }
+
+    public Calendar getApproveApplicationDate() {
+        return approveApplicationDate;
+    }
+
+    public void setApproveApplicationDate(Calendar approveApplicationDate) {
+        this.approveApplicationDate = approveApplicationDate;
+    }
+
+    public Calendar getSubmissionDate() {
+        return submissionDate;
+    }
+
+    public void setSubmissionDate(Calendar submissionDate) {
+        this.submissionDate = submissionDate;
+    }
+
+    public Calendar getApproveAdvisorDate() {
+        return approveAdvisorDate;
+    }
+
+    public void setApproveAdvisorDate(Calendar approveAdvisorDate) {
+        this.approveAdvisorDate = approveAdvisorDate;
+    }
+
+    public boolean isApproveEmbargo() {
+        return approveEmbargo;
+    }
+
+    public void setApproveEmbargo(boolean approveEmbargo) {
+        this.approveEmbargo = approveEmbargo;
+    }
+
+    public boolean isApproveApplication() {
+        return approveApplication;
+    }
+
+    public void setApproveApplication(boolean approveApplication) {
+        this.approveApplication = approveApplication;
+    }
+
+    public boolean isApproveAdvisor() {
+        return approveAdvisor;
+    }
+
+    public void setApproveAdvisor(boolean approveAdvisor) {
+        this.approveAdvisor = approveAdvisor;
+    }
+
+    public Set<CustomActionValue> getCustomActionValues() {
+        return customActionValues;
+    }
+
+    public void setCustomActionValues(Set<CustomActionValue> customActionValues) {
+        this.customActionValues = customActionValues;
+    }
+
+    public Set<ActionLog> getActionLogs() {
+        return actionLogs;
+    }
+
+    public void setActionLogs(Set<ActionLog> actionLogs) {
+        this.actionLogs = actionLogs;
+    }
+
+    /**
+     * Given a list, set (or unset) both the logs and the last action.
+     * 
+     * The last action is populated from the first index under the assumption
+     * that the order is descending.
+     *
+     * @param actionLogs The array of action logs.
+     */
+    public void setActionLogs(List<ActionLog> actionLogs) {
+        if (actionLogs == null) {
+            this.actionLogs = null;
+            this.lastAction = null;
+        } else {
+            this.actionLogs = new HashSet<>(actionLogs);
+            this.lastAction = actionLogs.get(0);
+        }
+    }
+
+    public String getReviewerNotes() {
+        return reviewerNotes;
+    }
+
+    public void setReviewerNotes(String reviewerNotes) {
+        this.reviewerNotes = reviewerNotes;
+    }
+
+    public String getAdvisorAccessHash() {
+        return advisorAccessHash;
+    }
+
+    public void setAdvisorAccessHash(String advisorAccessHash) {
+        this.advisorAccessHash = advisorAccessHash;
+    }
+
+    public String getAdvisorReviewURL() {
+        return advisorReviewURL;
+    }
+
+    public void setAdvisorReviewURL(String advisorReviewURL) {
+        this.advisorReviewURL = advisorReviewURL;
+    }
+
+    public String getDepositURL() {
+        return depositURL;
+    }
+
+    public void setDepositURL(String depositURL) {
+        this.depositURL = depositURL;
+    }
+
+    public ActionLog getLastAction() {
+        return lastAction;
+    }
+
+    public void setLastAction(ActionLog lastAction) {
+        this.lastAction = lastAction;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleSubmissionListColumn.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleSubmissionListColumn.java
@@ -1,0 +1,127 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import java.util.Set;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.Sort;
+
+@Entity
+@Immutable
+@Table(name = "submission_list_column")
+public class SimpleSubmissionListColumn implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 2596784770905951073L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Immutable
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    private SimpleInputType inputType;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private String title;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String predicate;
+
+    @Transient
+    private Set<String> filters;
+
+    @Transient
+    private Integer sortOrder;
+
+    @Transient
+    private Boolean visible;
+
+    @Transient
+    private Boolean exactMatch;
+
+    @Transient
+    private Sort sort;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public SimpleInputType getInputType() {
+        return inputType;
+    }
+
+    public void setInputType(SimpleInputType inputType) {
+        this.inputType = inputType;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getPredicate() {
+        return predicate;
+    }
+
+    public void setPredicate(String predicate) {
+        this.predicate = predicate;
+    }
+
+    public Set<String> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(Set<String> filters) {
+        this.filters = filters;
+    }
+
+    public Integer getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public Boolean getVisible() {
+        return visible;
+    }
+
+    public void setVisible(Boolean visible) {
+        this.visible = visible;
+    }
+
+    public Boolean getExactMatch() {
+        return exactMatch;
+    }
+
+    public void setExactMatch(Boolean exactMatch) {
+        this.exactMatch = exactMatch;
+    }
+
+    public Sort getSort() {
+        return sort;
+    }
+
+    public void setSort(Sort sort) {
+        this.sort = sort;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleSubmissionStatus.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleSubmissionStatus.java
@@ -1,0 +1,157 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.SubmissionState;
+import org.tdl.vireo.model.SubmissionStatus;
+
+@Entity
+@Immutable
+@Table(name = "submission_status")
+public class SimpleSubmissionStatus implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = 7297110154119569868L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = false, unique = true)
+    private String name;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean isArchived;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean isPublishable;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean isDeletable;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean isEditableByReviewer;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Boolean isEditableByStudent;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private Boolean isActive;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private SubmissionState submissionState;
+
+    @Transient
+    private List<SubmissionStatus> transitionSubmissionStatuses;
+
+    public static SubmissionStatus toSubmissionStatus(SimpleSubmissionStatus simpleSubmissionStatus) {
+        if (simpleSubmissionStatus == null) {
+            return null;
+        }
+
+        SubmissionStatus submission = new SubmissionStatus();
+
+        submission.setId(simpleSubmissionStatus.getId());
+        submission.setName(simpleSubmissionStatus.getName());
+        submission.isArchived(simpleSubmissionStatus.isArchived());
+        submission.isPublishable(simpleSubmissionStatus.isPublishable());
+        submission.isDeletable(simpleSubmissionStatus.isDeletable());
+        submission.isEditableByReviewer(simpleSubmissionStatus.isEditableByReviewer());
+        submission.isEditableByStudent(simpleSubmissionStatus.isEditableByStudent());
+        submission.isActive(simpleSubmissionStatus.isActive());
+        submission.setSubmissionState(simpleSubmissionStatus.getSubmissionState());
+        submission.setTransitionSubmissionStatuses(simpleSubmissionStatus.getTransitionSubmissionStatuses());
+
+        return submission;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean isArchived() {
+        return isArchived;
+    }
+
+    public void setArchived(Boolean isArchived) {
+        this.isArchived = isArchived;
+    }
+
+    public Boolean isPublishable() {
+        return isPublishable;
+    }
+
+    public void setPublishable(Boolean isPublishable) {
+        this.isPublishable = isPublishable;
+    }
+
+    public Boolean isDeletable() {
+        return isDeletable;
+    }
+
+    public void setDeletable(Boolean isDeletable) {
+        this.isDeletable = isDeletable;
+    }
+
+    public Boolean isEditableByReviewer() {
+        return isEditableByReviewer;
+    }
+
+    public void setEditableByReviewer(Boolean isEditableByReviewer) {
+        this.isEditableByReviewer = isEditableByReviewer;
+    }
+
+    public Boolean isEditableByStudent() {
+        return isEditableByStudent;
+    }
+
+    public void setEditableByStudent(Boolean isEditableByStudent) {
+        this.isEditableByStudent = isEditableByStudent;
+    }
+
+    public Boolean isActive() {
+        return isActive;
+    }
+
+    public void setActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public SubmissionState getSubmissionState() {
+        return submissionState;
+    }
+
+    public void setSubmissionState(SubmissionState submissionState) {
+        this.submissionState = submissionState;
+    }
+
+    public List<SubmissionStatus> getTransitionSubmissionStatuses() {
+        return transitionSubmissionStatuses;
+    }
+
+    public void setTransitionSubmissionStatuses(List<SubmissionStatus> transitionSubmissionStatuses) {
+        this.transitionSubmissionStatuses = transitionSubmissionStatuses;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/simple/SimpleUser.java
+++ b/src/main/java/org/tdl/vireo/model/simple/SimpleUser.java
@@ -1,0 +1,261 @@
+package org.tdl.vireo.model.simple;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.Immutable;
+import org.tdl.vireo.model.ContactInfo;
+import org.tdl.vireo.model.NamedSearchFilterGroup;
+import org.tdl.vireo.model.Role;
+import org.tdl.vireo.model.SubmissionListColumn;
+import org.tdl.vireo.model.User;
+
+@Entity
+@Immutable
+@Table(name = "weaver_users")
+public class SimpleUser implements Serializable {
+
+    @Transient
+    private static final long serialVersionUID = -5012554086359256601L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", insertable = false, updatable = false, nullable = false)
+    private Long id;
+
+    @Column(insertable = false, updatable = false, nullable = true)
+    private String netid;
+
+    @Column(insertable = false, updatable = false, nullable = false, unique = true)
+    private String email;
+
+    @Column(insertable = false, updatable = false, nullable = false, name = "first_name")
+    private String firstName;
+
+    @Column(insertable = false, updatable = false, nullable = false, name = "last_name")
+    private String lastName;
+
+    @Column(insertable = false, updatable = false, name = "middle_name")
+    private String middleName;
+
+    @Formula("CONCAT(first_name, ' ', last_name)")
+    private String name;
+
+    @Transient
+    private Map<String, String> settings;
+
+    @Column(insertable = false, updatable = false)
+    private Integer birthYear;
+
+    @Immutable
+    @OneToOne(fetch = FetchType.EAGER, optional = true)
+    private ContactInfo currentContactInfo;
+
+    @Immutable
+    @OneToOne(fetch = FetchType.EAGER, optional = true)
+    private ContactInfo permanentContactInfo;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(insertable = false, updatable = false)
+    private String orcid;
+
+    @Column(insertable = false, updatable = false, nullable = false)
+    private Integer pageSize;
+
+    @Transient
+    private List<SubmissionListColumn> submissionViewColumns;
+
+    @Transient
+    private List<SubmissionListColumn> filterColumns;
+
+    @Transient
+    private NamedSearchFilterGroup activeFilter;
+
+    @Transient
+    private List<NamedSearchFilterGroup> savedFilters;
+
+    public static User toUser(SimpleUser simpleUser) {
+        if (simpleUser == null) {
+            return null;
+        }
+
+        User user = new User(simpleUser.getEmail(), simpleUser.getFirstName(), simpleUser.getLastName(), simpleUser.getRole());
+
+        user.setId(simpleUser.getId());
+        user.setNetid(simpleUser.getNetid());
+        user.setMiddleName(simpleUser.getMiddleName());
+        user.setName(simpleUser.getName());
+        user.setSettings(simpleUser.getSettings());
+        user.setBirthYear(simpleUser.getBirthYear());
+        user.setCurrentContactInfo(simpleUser.getCurrentContactInfo());
+        user.setPermanentContactInfo(simpleUser.getPermanentContactInfo());
+        user.setOrcid(simpleUser.getOrcid());
+        user.setPageSize(simpleUser.getPageSize());
+        user.setSubmissionViewColumns(simpleUser.getSubmissionViewColumns());
+        user.setFilterColumns(simpleUser.getFilterColumns());
+        user.setActiveFilter(simpleUser.getActiveFilter());
+        user.setSavedFilters(simpleUser.getSavedFilters());
+
+        return user;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNetid() {
+        return netid;
+    }
+
+    public void setNetid(String netid) {
+        this.netid = netid;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, String> getSettings() {
+        return settings;
+    }
+
+    public void setSettings(Map<String, String> settings) {
+        this.settings = settings;
+    }
+
+    public Integer getBirthYear() {
+        return birthYear;
+    }
+
+    public void setBirthYear(Integer birthYear) {
+        this.birthYear = birthYear;
+    }
+
+    public ContactInfo getCurrentContactInfo() {
+        return currentContactInfo;
+    }
+
+    public void setCurrentContactInfo(ContactInfo currentContactInfo) {
+        this.currentContactInfo = currentContactInfo;
+    }
+
+    public ContactInfo getPermanentContactInfo() {
+        return permanentContactInfo;
+    }
+
+    public void setPermanentContactInfo(ContactInfo permanentContactInfo) {
+        this.permanentContactInfo = permanentContactInfo;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
+    public String getOrcid() {
+        return orcid;
+    }
+
+    public void setOrcid(String orcid) {
+        this.orcid = orcid;
+    }
+
+    public Integer getPageSize() {
+        return pageSize;
+    }
+
+    public void setPageSize(Integer pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public List<SubmissionListColumn> getSubmissionViewColumns() {
+        return submissionViewColumns;
+    }
+
+    public void setSubmissionViewColumns(List<SubmissionListColumn> submissionViewColumns) {
+        this.submissionViewColumns = submissionViewColumns;
+    }
+
+    public List<SubmissionListColumn> getFilterColumns() {
+        return filterColumns;
+    }
+
+    public void setFilterColumns(List<SubmissionListColumn> filterColumns) {
+        this.filterColumns = filterColumns;
+    }
+
+    public NamedSearchFilterGroup getActiveFilter() {
+        return activeFilter;
+    }
+
+    public void setActiveFilter(NamedSearchFilterGroup activeFilter) {
+        this.activeFilter = activeFilter;
+    }
+
+    public List<NamedSearchFilterGroup> getSavedFilters() {
+        return savedFilters;
+    }
+
+    public void setSavedFilters(List<NamedSearchFilterGroup> savedFilters) {
+        this.savedFilters = savedFilters;
+    }
+
+}

--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -80,7 +80,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
         WsApi.listen("/channel/submission/" + $scope.submission.id).then(null, null, function(res) {
             var apiRes = angular.fromJson(res.body);
-            surgicalFieldValueUpdate(apiRes.payload.Submission);
+            surgicalFieldValueUpdate(angular.isDefined(apiRes.payload.SimpleSubmission) ? apiRes.payload.SimpleSubmission : apiRes.payload.Submission);
         });
 
         $scope.title = $scope.submission.submitter.lastName + ', ' + $scope.submission.submitter.firstName + ' (' + $scope.submission.organization.name + ')';
@@ -346,7 +346,7 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
             if (fieldPredicate !== undefined) {
                 var fieldProfile = $scope.submission.getFieldProfileByPredicate(fieldPredicate);
-                if (angular.isDefined(fieldProfile.controlledVocabulary)) {
+                if (fieldProfile !== null && angular.isDefined(fieldProfile.controlledVocabulary)) {
                     var cv = fieldProfile.controlledVocabulary;
                     pattern = "";
                     for (i in cv.dictionary) {
@@ -585,11 +585,15 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         };
 
         var getLastActionDate = function() {
+            if ($scope.submission.actionLogs === null) return null;
+
             var index = $scope.submission.actionLogs.length - 1;
             return $scope.submission.actionLogs[index].actionDate;
         };
 
         var getLastActionEntry = function() {
+          if ($scope.submission.actionLogs === null) return null;
+
             var index = $scope.submission.actionLogs.length - 1;
             return $scope.submission.actionLogs[index].entry;
         };

--- a/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
+++ b/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
@@ -50,16 +50,17 @@ vireo.controller("AdvisorSubmissionReviewController", function ($controller, $sc
     $scope.addComment = function () {
         $scope.approval.updating = true;
         $scope.submission.updateAdvisorApproval($scope.approval).then(function (res) {
-        var responseSubmission = angular.fromJson(res.body).payload.Submission;
+            var payload = angular.fromJson(res.body).payload;
+            var responseSubmission = angular.isDefined(payload.SimpleSubmission) ? payload.SimpleSubmission : payload.Submission;
 
-        // This should be done through a broadcast and not explicitly like this.
-        $scope.submission.approveAdvisorDate = responseSubmission.approveAdvisorDate;
-        $scope.submission.approveEmbargoDate = responseSubmission.approveEmbargoDate;
-        $scope.submission.approveAdvisor = responseSubmission.approveAdvisor;
-        $scope.submission.approveEmbargo = responseSubmission.approveEmbargo;
+            // This should be done through a broadcast and not explicitly like this.
+            $scope.submission.approveAdvisorDate = responseSubmission.approveAdvisorDate;
+            $scope.submission.approveEmbargoDate = responseSubmission.approveEmbargoDate;
+            $scope.submission.approveAdvisor = responseSubmission.approveAdvisor;
+            $scope.submission.approveEmbargo = responseSubmission.approveEmbargo;
 
-        resetApproveProxy();
-        $scope.messages.push(message);
+            resetApproveProxy();
+            $scope.messages.push(message);
         });
     };
 

--- a/src/main/webapp/app/controllers/submission/newSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/newSubmissionController.js
@@ -57,7 +57,7 @@ vireo.controller('NewSubmissionController', function ($controller, $location, $q
                 $scope.creatingSubmission = false;
                 var apiRes = angular.fromJson(response.body);
                 if (apiRes.meta.status === 'SUCCESS') {
-                    var submission = apiRes.payload.Submission;
+                    var submission = angular.isDefined(apiRes.payload.SimpleSubmission) ? apiRes.payload.SimpleSubmission : apiRes.payload.Submission;
                     StudentSubmissionRepo.add(submission);
                     $location.path("/submission/" + submission.id);
                 }

--- a/src/main/webapp/app/controllers/submission/studentSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/studentSubmissionController.js
@@ -23,9 +23,11 @@ vireo.controller("StudentSubmissionController", function ($controller, $scope, $
             return currentStepIndex === -1;
         };
 
-        var currentStep = $routeParams.stepNum ? $scope.submission.submissionWorkflowSteps[$routeParams.stepNum - 1] : $scope.submission.submissionWorkflowSteps[0];
+        if (angular.isDefined($scope.submission.submissionWorkflowSteps) && $scope.submission.submissionWorkflowSteps !== null) {
+            var currentStep = $routeParams.stepNum ? $scope.submission.submissionWorkflowSteps[$routeParams.stepNum - 1] : $scope.submission.submissionWorkflowSteps[0];
 
-        $scope.setActiveStep(currentStep);
+            $scope.setActiveStep(currentStep);
+        }
     });
 
     $scope.setActiveStep = function (step, hash) {

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -75,7 +75,7 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
             angular.forEach(submission.submissionWorkflowSteps, function (submissionWorkflowStep) {
                 angular.forEach(submissionWorkflowStep.aggregateFieldProfiles, function (fp) {
                     var fieldValuesByFieldPredicate = submission.getFieldValuesByFieldPredicate(fp.fieldPredicate);
-                    if (!fieldValuesByFieldPredicate.length) {
+                    if (!fieldValuesByFieldPredicate.length && submission.fieldValues) {
                         submission.fieldValues.push(createEmptyFieldValue(fp.fieldPredicate));
                     }
                 });

--- a/src/main/webapp/app/repo/submissionRepo.js
+++ b/src/main/webapp/app/repo/submissionRepo.js
@@ -13,7 +13,8 @@ vireo.repo("SubmissionRepo", function SubmissionRepo($q, FileService, Submission
             fetchPromise.then(function (res) {
                 var apiRes = angular.fromJson(res.body);
                 if (apiRes.meta.status === "SUCCESS") {
-                    resolve(new Submission(apiRes.payload.Submission));
+                    resolve(new Submission(angular.isDefined(apiRes.payload.SimpleSubmission) ? apiRes.payload.SimpleSubmission : apiRes.payload.Submission
+                    ));
                 } else {
                     reject("A submission with the ID " + id + " does not exist.");
                 }


### PR DESCRIPTION
Attempts have been made to use EntityGraphs and Projections. Strange problems have been encountered.
Rather than trying to investigate those, I opted for this alternative approach.

This utilizes immutable entities that act similar to an SQL view. These immutable entities have expensive columsn removed or otherwase made to not load (even lazy load). Consider this the concept of a non-existent third FetchType called "NEVER" (compared to FetchType.EAGER and FetchType.LAZY).

There have been problems observed with Spring or JPA not being able to handle certain column stuctures with the immutabille design approach. These have been made Transient to prevent the problems. The downside is that these now Transient columns must be fetched. This performs those extra manual fetches in circumstances where they will be needed. Such fetches are done on the backend to limit the amount of changes to the UI.

In many cases, these simple models are being cast to the normal model before sending them to the frontend/UI. This required some additional tweaks.
The UI is still modified to handle the simple submission model in case that comes down rather than the normal submission model.

The simple models, being immutable, somehow interefered with the normal models. The table name has been explicitly added in these cases. The table names are named after how they have been observed to be created.

To keep these unusual changes isolated, I created directories called "simple". Inside these are the simple models and the respective simple repositories. The simple repositories have been created on an as-required basis. These simple repositories are made as simple as possible and only contain an interface file.

The last event is now handled during processing of the simple submission model handling. This avoids an extra db check and avoids extra logic beyond the initial handling.

This does not address the big custom crafted select all submissions. Additional work is needed to potentially take advantage of the changes here for that big query.

NULL checks and NULL values are added to handle cases where the data is not loaded (and is not FetchType.LAZY).

NULL checks are added to the UI to handle cases where the data is not available now that everything is not loaded.

This has only been tested against postgresql so far. The other DBs need to be tested.