### PR TITLE
Remove exclusion for directory with .js in the name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,9 +297,6 @@
           <include>**/*.woff</include>
           <include>**/*.woff2</include>
         </includes>
-        <excludes>
-          <exclude>**/sha.js/</exclude>
-        </excludes>
       </resource>
       <resource>
         <directory>src/main/webapp/app/resources/styles</directory>
@@ -423,9 +420,6 @@
                 <include>**/*.woff</include>
                 <include>**/*.woff2</include>
               </includes>
-              <excludes>
-                <exclude>**/sha.js/</exclude>
-              </excludes>
             </webResource>
             <webResource>
               <filtering>false</filtering>


### PR DESCRIPTION
This file does not appear to be present in Vireo and the following upstream PR provides a solution at a different area.
- https://github.com/TAMULib/Weaver-UI-Core/pull/231