### PR TITLE
Remove nekohtml dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,12 +101,6 @@
       <artifactId>thymeleaf-extras-springsecurity5</artifactId>
     </dependency>
 
-    <!-- remove if not needed -->
-    <dependency>
-      <groupId>net.sourceforge.nekohtml</groupId>
-      <artifactId>nekohtml</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.github.steveash.hnp</groupId>
       <artifactId>human-name-parser</artifactId>


### PR DESCRIPTION
This does not appear to be used anywhere.
Unused dependencies that brings in more dependencies can be a security concern.

In fact, there are several security issues pulled in by its xerces dependencies:
- CVE-2022-23437
- CVE-2020-14338
- CVE-2013-4002
- CVE-2012-0881