### PR TITLE
Remove xom dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,13 +205,6 @@
       </exclusions>
     </dependency>
 
-    <!-- remove if not needed -->
-    <dependency>
-      <groupId>xom</groupId>
-      <artifactId>xom</artifactId>
-      <version>1.3.8</version>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
This does not appear to be directly used.
There are a lot of projects excluding this already. Eclipse detects a bug where there are dependency conflicts, such as:
```
The package javax.xml.parsers is accessible from more than one module: <unnamed>, java.xml	OrcidUtility.java	/vireo/src/main/java/org/tdl/vireo/utility	line 7	Java Problem
```

There are several security issues associated with this projects dependencies:
- CVE-2022-34169
- CVE-2022-23437
- CVE-2020-14338
- CVE-2013-4002
- CVE-2012-0881
- CVE-2009-2625