### PR TITLE
Fix CLI is not running problem and add Order annotation.

### DIFF
--- a/src/main/java/org/tdl/vireo/ApplicationInitialization.java
+++ b/src/main/java/org/tdl/vireo/ApplicationInitialization.java
@@ -1,13 +1,16 @@
 package org.tdl.vireo;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.tdl.vireo.service.EntityControlledVocabularyService;
 import org.tdl.vireo.service.SystemDataLoader;
 
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @Component
 @Profile("!test")
 public class ApplicationInitialization implements CommandLineRunner {

--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -10,6 +10,8 @@ import java.util.Random;
 import java.util.Scanner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.tdl.vireo.model.FieldPredicate;
@@ -32,13 +34,14 @@ import org.tdl.vireo.model.repo.UserRepo;
 /**
  * Activate the Vireo command line interface by passing the console argument to Maven
  *
- * mvn clean spring-boot:run -Drun.arguments=console
+ * mvn clean spring-boot:run -Dspring-boot.run.arguments="console"
  * 
  * NOTE: will enable allow submissions on institution
  * 
  * @author James Creel
  * @author Jeremy Huff
  */
+@Order(value = Ordered.LOWEST_PRECEDENCE)
 @Component
 public class Cli implements CommandLineRunner {
 
@@ -67,9 +70,9 @@ public class Cli implements CommandLineRunner {
     private BCryptPasswordEncoder passwordEncoder;
 
     @Override
-    public void run(String... arg0) throws Exception {
+    public void run(String... args) throws Exception {
         boolean runConsole = false;
-        for (String s : arg0) {
+        for (String s : args) {
             if (s.equals("console")) {
                 runConsole = true;
                 break;


### PR DESCRIPTION
Spring changed their parameter from `run.arguments` to `spring-boot.run.arguments`. The CLI must now be passed arguments via maven using this: `-Dspring-boot.run.arguments="console"`.

The Order annotation allows us to guarantee that the CLI runs last.

Also `arg0` is incorrect and should be called `args` given that it is the array of all arguments rather than just the first.