### PR TITLE
Advisor review application page is always showing as rejected for generated submissions.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -214,9 +214,30 @@ public class Cli implements CommandLineRunner {
                         Submission sub = submissionRepo.create(submitter, org, state, credentials, customActionDefinitionRepo.findAll());
 
                         sub.setSubmissionDate(getRandomDate());
-                        sub.setApproveAdvisorDate(getRandomDate());
-                        sub.setApproveApplicationDate(getRandomDate());
-                        sub.setApproveEmbargoDate(getRandomDate());
+
+                        if (random.nextInt(10) < 3) {
+                            sub.setApproveAdvisorDate(getRandomDate());
+                            sub.setApproveAdvisor(random.nextInt(10) < 5);
+                        } else {
+                            sub.setApproveAdvisorDate(null);
+                            sub.setApproveAdvisor(false);
+                        }
+
+                        if (random.nextInt(10) < 3) {
+                            sub.setApproveApplicationDate(getRandomDate());
+                            sub.setApproveApplication(random.nextInt(10) < 5);
+                        } else {
+                            sub.setApproveApplicationDate(null);
+                            sub.setApproveApplication(false);
+                        }
+
+                        if (random.nextInt(10) < 3) {
+                            sub.setApproveEmbargoDate(getRandomDate());
+                            sub.setApproveEmbargo(random.nextInt(10) < 5);
+                        } else {
+                            sub.setApproveEmbargoDate(null);
+                            sub.setApproveEmbargo(false);
+                        }
 
                         // %30 chance to be assigned to helpful harry.
                         if (expansive && random.nextInt(10) < 3) {

--- a/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
+++ b/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
@@ -16,9 +16,9 @@ vireo.controller("AdvisorSubmissionReviewController", function ($controller, $sc
 
     $scope.actionLogDelay = 1000;
 
-    AdvisorSubmissionRepo.fetchSubmissionByHash($routeParams.advisorAccessHash).then(function (submissions) {
+    AdvisorSubmissionRepo.fetchSubmissionByHash($routeParams.advisorAccessHash).then(function (submission) {
         $scope.advisorSubmissionRepoReady = true;
-        $scope.submission = submissions;
+        $scope.submission = submission;
         resetApproveProxy();
         $scope.submission.fetchDocumentTypeFileInfo();
     });

--- a/src/main/webapp/app/directives/approvalBlockDirective.js
+++ b/src/main/webapp/app/directives/approvalBlockDirective.js
@@ -4,10 +4,10 @@ vireo.directive("approvalblock", function() {
             return "views/directives/approvalBlock.html";
         },
         scope: {
- 			type: "=",
-			approvalProxy: "=",
-			status: "=",
-			statusDate: "="
+            type: "=",
+            approvalProxy: "=",
+            status: "=",
+            statusDate: "="
         }
     };
 });


### PR DESCRIPTION
This is a follow up on the recent changes to the CLI for the purposes of generating more random data for performance testing.
The generated data is always setting the approvals to rejected.

This is happening because the date determines the approval boolean.
Change the design to only set approval of 30% of the submissions generated.
Of those with the approval set, have 50% be approved and 50% be rejected.

Fix relating typos and syntax problems.