### PR TITLE
Restrict unused endpoint.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -177,7 +177,7 @@ public class SubmissionController {
   private String documentTypesToRename;
 
   @RequestMapping("/all")
-  @PreAuthorize("hasRole('REVIEWER')")
+  @PreAuthorize("hasRole('ADMIN')")
   public ApiResponse getAll() {
     return new ApiResponse(SUCCESS, submissionRepo.findAll());
   }


### PR DESCRIPTION
We should probably decide on whether or not to keep this endpoint.

This endpoint could be changed to be paginated et al. and be used for the list if more advanced uses of the forms are provided. Or this could be removed entirely.

This takes the approach of restring this to the ADMIN use to avoid potential abuses until such a time a decision can be made.