### PR TITLE
Fix action log.

### DIFF
--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -88,10 +88,12 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
             });
 
             submission.actionLogListenPromise = WsApi.listen(apiMapping.Submission.actionLogListen);
+            submission.actionLogListenReloadDefer = $q.defer();
 
             submission.actionLogListenPromise.then(null, null, function (response) {
                 var newActionLog = angular.fromJson(response.body).payload.ActionLog;
                 submission.actionLogs.push(new ActionLog(newActionLog));
+                submission.actionLogListenReloadDefer.notify(submission.actionLogs);
             });
 
             angular.extend(apiMapping.Submission.customActionValuesListen, {

--- a/src/main/webapp/app/views/directives/actionLog.html
+++ b/src/main/webapp/app/views/directives/actionLog.html
@@ -2,8 +2,8 @@
   <tbody>
     <tr ng-repeat="actionLog in $data | filter: (public || '') && {privateFlag: 'false'}" ng-class="{'danger': actionLog.privateFlag}">
       <td title="'Action By'">
-      	<span ng-if="actionLog.user">{{actionLog.user.settings.displayName}}</span>
-      	<span ng-if="!actionLog.user">Advisor</span>
+        <span ng-if="actionLog.user">{{actionLog.user.settings.displayName}}</span>
+        <span ng-if="!actionLog.user">Advisor</span>
       </td>
       <td title="'Action / Comment'" class="message-cell">{{actionLog.entry}}
         <spam class="private-flag" ng-if="actionLog.privateFlag">[private]</spam>


### PR DESCRIPTION
The action log is not consistently refreshing.
Change the design using a different approach that requires some more manual control.
Despite the manual control, this approach seems more reliable.

This adds an additional event defer that triggers only after the new action log is loaded on submission. This is done to prevent potential race conditions.