### PR TITLE
Issue 1662: Improve accessibility regarding footer links, providing more details.

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -153,16 +153,16 @@
           <span app-version></span>
         </li>
         <li>
-          <a href="{{webmaster}}">Webmaster</a>
+          <a href="{{webmaster}}" ng-attr-aria-label="{{webmaster_label}}" ng-attr-aria-hidden="{{webmaster_hidden}}">Webmaster</a>
         </li>
         <li>
-          <a href="{{legal}}">Legal</a>
+          <a href="{{legal}}" ng-attr-aria-label="{{legal_label}}" ng-attr-aria-hidden="{{legal_hidden}}">Legal</a>
         </li>
         <li>
-          <a href="{{comments}}">Comments</a>
+          <a href="{{comments}}" ng-attr-aria-label="{{comments_label}}" ng-attr-aria-hidden="{{comments_hidden}}">Comments</a>
         </li>
         <li>
-          <a href="{{accessibility}}">Accessibility</a>
+          <a href="{{accessibility}}" ng-attr-aria-label="{{accessibility_label}}" ng-attr-aria-hidden="{{accessibility_hidden}}">Accessibility</a>
         </li>
       </ul>
     </div>

--- a/src/main/webapp/app/controllers/footerController.js
+++ b/src/main/webapp/app/controllers/footerController.js
@@ -16,6 +16,16 @@ vireo.controller("FooterController", function ($scope, $controller, ManagedConfi
             $scope.legal = $scope.buildLink($scope.configurable.footer.link_legal);
             $scope.comments = $scope.buildLink($scope.configurable.footer.link_comments);
             $scope.accessibility = $scope.buildLink($scope.configurable.footer.link_accessibility);
+
+            $scope.webmaster_label = $scope.buildLabel($scope.configurable.footer.link_webmaster, "to the webmaster.", "contacting the webmaster.");
+            $scope.legal_label = $scope.buildLabel($scope.configurable.footer.link_legal, "regarding legal matters.", "legal matters.");
+            $scope.comments_label = $scope.buildLabel($scope.configurable.footer.link_comments, "with any comments.", "providing comments.");
+            $scope.accessibility_label = $scope.buildLabel($scope.configurable.footer.link_accessibility, "regarding accessibility.", "accessibility.");
+
+            $scope.webmaster_hidden = $scope.webmaster_label === undefined ? true : undefined;
+            $scope.legal_hidden = $scope.legal_label === undefined ? true : undefined;
+            $scope.comments_hidden = $scope.comments_label === undefined ? true : undefined;
+            $scope.accessibility_hidden = $scope.accessibility_label === undefined ? true : undefined;
         }
     });
 
@@ -32,6 +42,21 @@ vireo.controller("FooterController", function ($scope, $controller, ManagedConfi
         }
 
         return "#";
+    };
+
+    $scope.buildLabel = function (setting, email, about) {
+
+        if (setting && setting.value) {
+            var regex = /^[^@]{1,}@[^@]{1,}$/;
+
+            if (regex.test(setting.value)) {
+                return "Send an e-mail " + email;
+            }
+
+            return "View page with further information about " + about;
+        }
+
+        return undefined;
     };
 
 });

--- a/src/main/webapp/tests/unit/controllers/footerControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/footerControllerTest.js
@@ -62,6 +62,10 @@ describe("controller: FooterController", function () {
             expect(scope.buildLink).toBeDefined();
             expect(typeof scope.buildLink).toEqual("function");
         });
+        it("buildLabel should be defined", function () {
+            expect(scope.buildLabel).toBeDefined();
+            expect(typeof scope.buildLabel).toEqual("function");
+        });
     });
 
     describe("Do the scope methods work as expected", function () {
@@ -97,6 +101,35 @@ describe("controller: FooterController", function () {
 
             built = scope.buildLink({ value: "\"user name\"@example.com" });
             expect(built).toBe("mailto:\"user name\"@example.com");
+        });
+        it("buildLabel should fallback to undefined", function () {
+            var built;
+
+            built = scope.buildLabel();
+            expect(built).toBeUndefined();
+
+            built = scope.buildLabel(null);
+            expect(built).toBeUndefined();
+
+            built = scope.buildLabel({});
+            expect(built).toBeUndefined();
+
+            built = scope.buildLabel({ value: null });
+            expect(built).toBeUndefined();
+        });
+        it("buildLabel should provide e-mail related message", function () {
+            var setting = { value: 'a@b.c' };
+            var email = "to somewhere.";
+            var about = "something.";
+            var built = scope.buildLabel(setting, email, about);
+            expect(built).toBe("Send an e-mail " + email);
+        });
+        it("buildLabel should provide URL related message", function () {
+            var setting = { value: 'http://localhost' };
+            var email = "to somewhere.";
+            var about = "something.";
+            var built = scope.buildLabel(setting, email, about);
+            expect(built).toBe("View page with further information about " + about);
         });
     });
 


### PR DESCRIPTION
Resolves #1662 

The links are dynamically generated and have three possibilities:
1) A link to an e-mail.
2) A link to a URL.
3) A self-link.

The message must be accurate to the purpose so programmatically generate the text.

In the third case, the description cannot be provided because there is no link anywhere. I believe this may have been a design decision to preserve the link's presence. In this specific case, the link has no purpose and the best way to communicate this is to tell the reader to ignore this element.

Ideally, one time binding would be used here as these values should not regularly change. The one time binding does not appear to be supported for the `ng-attr` functionality.

Logic inside the html is to be avoided and so properties like `accessibility_hidden` are created to trigger the inverse case when `accessibility_label` is empty and `aria-hidden` is to be used.