### PR TITLE
Issue 1608: Add new end points for action log and re-design code depending on new end points.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -4,6 +4,16 @@ import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.INVALID;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.weaver.auth.annotation.WeaverCredentials;
+import edu.tamu.weaver.auth.annotation.WeaverUser;
+import edu.tamu.weaver.auth.model.Credentials;
+import edu.tamu.weaver.data.model.ApiPage;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.results.ValidationResults;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -23,10 +33,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.poi.hssf.usermodel.HSSFRow;
@@ -38,11 +46,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -88,18 +100,6 @@ import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
-
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import edu.tamu.weaver.auth.annotation.WeaverCredentials;
-import edu.tamu.weaver.auth.annotation.WeaverUser;
-import edu.tamu.weaver.auth.model.Credentials;
-import edu.tamu.weaver.data.model.ApiPage;
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.validation.results.ValidationResults;
 
 @RestController
 @RequestMapping("/submission")
@@ -188,7 +188,7 @@ public class SubmissionController {
     return new ApiResponse(SUCCESS, submissionRepo.findAllBySubmitterId(user.getId()));
   }
 
-  @JsonView(Views.SubmissionIndividual.class)
+  @JsonView(Views.SubmissionIndividualActionLogs.class)
   @RequestMapping("/get-one/{submissionId}")
   @PreAuthorize("hasRole('STUDENT')")
   public ApiResponse getOne(@WeaverUser User user, @PathVariable Long submissionId) {
@@ -204,12 +204,22 @@ public class SubmissionController {
     return new ApiResponse(SUCCESS, submission);
   }
 
-  @JsonView(Views.SubmissionIndividual.class)
-  @RequestMapping("/advisor-review/{submissionHash}")
-  public ApiResponse getOne(@PathVariable String submissionHash) {
-    Submission submission = submissionRepo.findOneByAdvisorAccessHash(submissionHash);
-    return new ApiResponse(SUCCESS, submission);
-  }
+    @GetMapping("/get-one/{submissionId}/action-logs")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ApiResponse getActionLogs(@WeaverUser User user, @PathVariable Long submissionId, @PageableDefault(direction = Direction.DESC, sort = { "action_date" }) Pageable pageable) {
+        return new ApiResponse(SUCCESS, actionLogRepo.getAllActionLogs(submissionId, false, pageable));
+    }
+
+    @JsonView(Views.SubmissionIndividual.class)
+    @RequestMapping("/advisor-review/{advisorAccessHash}")
+    public ApiResponse getOne(@PathVariable String advisorAccessHash) {
+        return new ApiResponse(SUCCESS, submissionRepo.findOneByAdvisorAccessHash(advisorAccessHash));
+    }
+
+    @GetMapping("/advisor-review/{advisorAccessHash}/action-logs")
+    public ApiResponse getActionLogsForAdvisement(@PathVariable String advisorAccessHash, @PageableDefault(direction = Direction.DESC, sort = { "action_date" }) Pageable pageable) {
+        return new ApiResponse(SUCCESS, actionLogRepo.getAllActionLogs(advisorAccessHash, false, pageable));
+    }
 
   @RequestMapping(value = "/create", method = RequestMethod.POST)
   @PreAuthorize("hasRole('STUDENT')")

--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -214,7 +214,7 @@ public class Submission extends ValidatingBaseEntity {
     @Fetch(FetchMode.SELECT)
     private Set<CustomActionValue> customActionValues;
 
-    @JsonView(Views.SubmissionIndividual.class)
+    @JsonView(Views.SubmissionIndividualActionLogs.class)
     @OneToMany(cascade = ALL, fetch = LAZY, orphanRemoval = true)
     @Fetch(FetchMode.SELECT)
     @JoinColumn

--- a/src/main/java/org/tdl/vireo/model/repo/ActionLogRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/ActionLogRepo.java
@@ -1,7 +1,7 @@
 package org.tdl.vireo.model.repo;
 
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
 import java.util.Calendar;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
@@ -11,8 +11,6 @@ import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.ActionLogRepoCustom;
 
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
-
 public interface ActionLogRepo extends WeaverRepo<ActionLog>, ActionLogRepoCustom {
 
     public ActionLog findByUserAndSubmissionStatus(User user, SubmissionStatus submissionStatus);
@@ -21,9 +19,38 @@ public interface ActionLogRepo extends WeaverRepo<ActionLog>, ActionLogRepoCusto
      * Returns the action log for a given file upload based on file name and nearest action date from file creation date.
      *
      * Column action_logs_id is join column representing submission id.
-     * Returning Page as JPQL does not support LIMIT.
+     *
+     * @return Page as JPQL does not support LIMIT.
      */
     @Query("SELECT al FROM ActionLog al WHERE action_logs_id = :submission_id and al.entry LIKE %:file_identifier% AND al.actionDate >= :creation_date ORDER BY al.actionDate ASC")
     public Page<ActionLog> findBySubmissionIdAndEntryLikeAndBeforeActionDate(@Param("submission_id") Long submissionId, @Param("file_identifier") String fileIdentifier, @Param("creation_date") Calendar creationDate, Pageable pageable);
+
+    /**
+     * Returns the action logs that are not private and are associated with a given submission.
+     *
+     * A native query is used to work-around JPQL+Pageable problems that result in errors like:
+     * - "QueryException: could not resolve property: action_date of: org.tdl.vireo.model.ActionLog"
+     *
+     * @param submissionId ID representing the submission.
+     * @param privateFlag The value of the private flag to filter by.
+     *
+     * @return Page of all action logs fulfilling the given parameters.
+     */
+    @Query(value = "SELECT al.* FROM action_log AS al WHERE al.action_logs_id = :submission_id AND al.private_flag = :private_flag", nativeQuery = true)
+    public Page<ActionLog> getAllActionLogs(@Param("submission_id") Long submissionId, @Param("private_flag") Boolean privateFlag, Pageable pageable);
+
+    /**
+     * Returns the action logs that are not private and are associated with a given advisor access hash.
+     *
+     * A native query is used to work-around JPQL+Pageable problems that result in errors like:
+     * - "QueryException: could not resolve property: action_date of: org.tdl.vireo.model.ActionLog"
+     *
+     * @param advisorAccessHash ID representing the submission.
+     * @param privateFlag The value of the private flag to filter by.
+     *
+     * @return Page of all action logs fulfilling the given parameters.
+     */
+    @Query(value = "SELECT al.* FROM action_log AS al INNER JOIN submission AS s ON al.action_logs_id = s.id WHERE s.advisor_access_hash = :advisor_access_hash AND al.private_flag = :private_flag", nativeQuery = true)
+    public Page<ActionLog> getAllActionLogs(@Param("advisor_access_hash") String advisorAccessHash, @Param("private_flag") Boolean privateFlag, Pageable pageable);
 
 }

--- a/src/main/java/org/tdl/vireo/model/response/Views.java
+++ b/src/main/java/org/tdl/vireo/model/response/Views.java
@@ -4,6 +4,10 @@ import edu.tamu.weaver.response.ApiView;
 
 public class Views {
 
+    public static class SubmissionIndividualActionLogs extends SubmissionIndividual {
+
+    }
+
     public static class SubmissionIndividual extends Partial {
 
     }

--- a/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
+++ b/src/main/webapp/app/controllers/submission/advisorSubmissionReviewController.js
@@ -103,4 +103,8 @@ vireo.controller("AdvisorSubmissionReviewController", function ($controller, $sc
         return result;
     };
 
+    $scope.getPaginatedActionLog = function (orderBy, page, count) {
+        return AdvisorSubmissionRepo.findPaginatedActionLogsByHash($routeParams.advisorAccessHash, orderBy, page, count);
+    };
+
 });

--- a/src/main/webapp/app/controllers/submission/submissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/submissionViewController.js
@@ -60,7 +60,11 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $scope, 
         };
 
         $scope.updateActionLogLimit = function () {
-            $scope.actionLogCurrentLimit = $scope.actionLogCurrentLimit === $scope.actionLogLimit ? $scope.submission.actionLogs.length : $scope.actionLogLimit;
+            if (angular.isDefined($scope.submission.actionLogs)) {
+                $scope.actionLogCurrentLimit = $scope.actionLogCurrentLimit === $scope.actionLogLimit ? $scope.submission.actionLogs.length : $scope.actionLogLimit;
+            } else {
+                $scope.actionLogCurrentLimit = 0;
+            }
         };
 
         $scope.queueRemove = function (fieldValue) {
@@ -171,6 +175,10 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $scope, 
                 });
             }
         });
+
+        $scope.getPaginatedActionLog = function (orderBy, page, count) {
+            return StudentSubmissionRepo.findPaginatedActionLogsById($routeParams.submissionId, orderBy, page, count);
+        }
 
     });
 

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -24,14 +24,17 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
 
         //populate actionLogs with models for existing values
         var instantiateActionLogs = function () {
-            var actionLogs = angular.copy(submission.actionLogs);
-            if (submission.actionLogs) {
-                submission.actionLogs.length = 0;
+            if (angular.isDefined(submission.actionLogs)) {
+                var actionLogs = angular.copy(submission.actionLogs);
+                if (submission.actionLogs) {
+                    submission.actionLogs.length = 0;
+                }
+
+                angular.forEach(actionLogs, function (actionLog) {
+                    actionLog = new ActionLog(actionLog);
+                    submission.actionLogs.push(actionLog);
+                });
             }
-            angular.forEach(actionLogs, function (actionLog) {
-                actionLog = new ActionLog(actionLog);
-                submission.actionLogs.push(actionLog);
-            });
         };
 
         // additional model methods and variables
@@ -92,6 +95,11 @@ var submissionModel = function ($q, ActionLog, FieldValue, FileService, Organiza
 
             submission.actionLogListenPromise.then(null, null, function (response) {
                 var newActionLog = angular.fromJson(response.body).payload.ActionLog;
+
+                if (angular.isUndefined(submission.actionLogs)) {
+                    submission.actionLogs = [];
+                }
+
                 submission.actionLogs.push(new ActionLog(newActionLog));
                 submission.actionLogListenReloadDefer.notify(submission.actionLogs);
             });

--- a/src/main/webapp/app/repo/advisorSubmissionRepo.js
+++ b/src/main/webapp/app/repo/advisorSubmissionRepo.js
@@ -19,6 +19,36 @@ vireo.repo("AdvisorSubmissionRepo", function AdvisorSubmissionRepo($q, AdvisorSu
         });
     };
 
+    advisorSubmissionRepo.findPaginatedActionLogsByHash = function (hash, orderBy, page, count) {
+        return $q(function(resolve, reject) {
+            angular.extend(advisorSubmissionRepo.mapping.getByHash, {
+                'method': 'advisor-review/' + hash + '/action-logs',
+                'query': {
+                  'orderBy': orderBy,
+                  'page': page,
+                  'size': count,
+                }
+            });
+
+            var fetchPromise = WsApi.fetch(advisorSubmissionRepo.mapping.getByHash);
+
+            fetchPromise.then(function (res) {
+                if (angular.isDefined(res) && angular.isDefined(res.body)) {
+                    var apiRes = angular.fromJson(res.body);
+
+                    if (angular.isDefined(apiRes) && angular.isDefined(apiRes.meta)) {
+                        if (apiRes.meta.status === "SUCCESS" && angular.isDefined(apiRes.payload.PageImpl)) {
+                            resolve(apiRes.payload.PageImpl);
+                            return;
+                        }
+                    }
+                }
+
+                reject();
+            });
+        });
+    };
+
     return advisorSubmissionRepo;
 
 });

--- a/src/main/webapp/app/repo/studentSubmissionRepo.js
+++ b/src/main/webapp/app/repo/studentSubmissionRepo.js
@@ -21,6 +21,36 @@ vireo.repo("StudentSubmissionRepo", function StudentSubmissionRepo($q, ApiRespon
         });
     };
 
+    studentSubmissionRepo.findPaginatedActionLogsById = function (id, orderBy, page, count) {
+        return $q(function(resolve, reject) {
+            angular.extend(studentSubmissionRepo.mapping.one, {
+                'method': 'get-one/' + id + '/action-logs',
+                'query': {
+                  'orderBy': orderBy,
+                  'page': page,
+                  'size': count,
+                }
+            });
+
+            var fetchPromise = WsApi.fetch(studentSubmissionRepo.mapping.one);
+
+            fetchPromise.then(function (res) {
+                if (angular.isDefined(res) && angular.isDefined(res.body)) {
+                    var apiRes = angular.fromJson(res.body);
+
+                    if (angular.isDefined(apiRes) && angular.isDefined(apiRes.meta)) {
+                        if (apiRes.meta.status === "SUCCESS" && angular.isDefined(apiRes.payload.PageImpl)) {
+                            resolve(apiRes.payload.PageImpl);
+                            return;
+                        }
+                    }
+                }
+
+                reject();
+            });
+        });
+    };
+
     studentSubmissionRepo.listenForChanges = function() {
         return defer.promise;
     };

--- a/src/main/webapp/app/views/directives/actionLog.html
+++ b/src/main/webapp/app/views/directives/actionLog.html
@@ -1,6 +1,6 @@
 <table  ng-table="tableParams" show-filter="false" class="table table-bordered table-striped table-hover action-log-table">
   <tbody>
-    <tr ng-repeat="actionLog in $data | filter: (public || '') && {privateFlag: 'false'}" ng-class="{'danger': actionLog.privateFlag}">
+    <tr ng-repeat="actionLog in $data" ng-class="{'danger': actionLog.privateFlag}">
       <td title="'Action By'">
         <span ng-if="actionLog.user">{{actionLog.user.settings.displayName}}</span>
         <span ng-if="!actionLog.user">Advisor</span>

--- a/src/main/webapp/app/views/submission/advisorReview.html
+++ b/src/main/webapp/app/views/submission/advisorReview.html
@@ -13,7 +13,7 @@
         <h3>Application Activity</h3>
         <hr/>
         <div class="col-md-10 col-md-offset-1">
-          <actionlog ng-if="submission" submission="submission" public="'true'" delay="{{::actionLogDelay}}"></actionlog>
+          <actionlog ng-if="submission" submission="submission" method="getPaginatedActionLog" delay="{{::actionLogDelay}}"></actionlog>
         </div>
       </div>
 

--- a/src/main/webapp/app/views/submission/submissionView.html
+++ b/src/main/webapp/app/views/submission/submissionView.html
@@ -112,7 +112,7 @@
         </div>
         <hr/>
         <div class="col-md-10 col-md-offset-1">
-          <actionlog ng-if="submission" submission="submission" public="'true'" delay="{{::actionLogDelay}}"></actionlog>
+          <actionlog ng-if="submission" submission="submission" method="getPaginatedActionLog" delay="{{::actionLogDelay}}"></actionlog>
         </div>
       </div>
 

--- a/src/main/webapp/tests/mocks/repos/mockAdvisorSubmissionRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockAdvisorSubmissionRepo.js
@@ -43,5 +43,15 @@ angular.module("mock.advisorSubmissionRepo", []).service("AdvisorSubmissionRepo"
         return valuePromise($q.defer(), repo.mockModel(payload));
     };
 
+    repo.findPaginatedActionLogsByHash = function (hash, order, page, count) {
+        var payload = {
+            PageImpl: {}
+        };
+
+        // TODO
+
+        return payloadPromise($q.defer(), repo.mockModel(payload));
+    };
+
     return repo;
 });

--- a/src/main/webapp/tests/mocks/repos/mockStudentSubmissionRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockStudentSubmissionRepo.js
@@ -42,6 +42,16 @@ angular.module("mock.studentSubmissionRepo", []).service("StudentSubmissionRepo"
         return valuePromise($q.defer(), repo.mockModel(payload));
     };
 
+    repo.findPaginatedActionLogsById = function (id, order, page, count) {
+        var payload = {
+            PageImpl: {}
+        };
+
+        // TODO
+
+        return payloadPromise($q.defer(), repo.mockModel(payload));
+    };
+
     repo.listenForChanges = function () {
         return payloadPromise($q.defer());
     };

--- a/src/main/webapp/tests/unit/repos/advisorSubmissionRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/advisorSubmissionRepoTest.js
@@ -47,11 +47,30 @@ describe("service: advisorSubmissionRepo", function () {
             expect(repo.fetchSubmissionByHash).toBeDefined();
             expect(typeof repo.fetchSubmissionByHash).toEqual("function");
         });
+
+        it("findPaginatedActionLogsByHash should be defined", function () {
+            expect(repo.fetchSubmissionByHash).toBeDefined();
+            expect(typeof repo.fetchSubmissionByHash).toEqual("function");
+        });
     });
 
     describe("Do the repo methods work as expected", function () {
         it("fetchSubmissionByHash should return a submission", function () {
             repo.fetchSubmissionByHash("mock hash");
+            scope.$digest();
+
+            // TODO
+        });
+
+        it("findPaginatedActionLogsByHash should return action logs", function () {
+            var mockOrderBy = { order: 'id' };
+            var mockPayload = {
+                PageImpl: {}
+            };
+
+            WsApi.mockFetchResponse({ type: "payload", payload: mockPayload });
+
+            repo.findPaginatedActionLogsByHash("mock hash", mockOrderBy, 0, 10);
             scope.$digest();
 
             // TODO

--- a/src/main/webapp/tests/unit/repos/studentSubmissionRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/studentSubmissionRepoTest.js
@@ -49,6 +49,12 @@ describe("service: studentSubmissionRepo", function () {
             expect(repo.fetchSubmissionById).toBeDefined();
             expect(typeof repo.fetchSubmissionById).toEqual("function");
         });
+
+        it("findPaginatedActionLogsById should be defined", function () {
+            expect(repo.findPaginatedActionLogsById).toBeDefined();
+            expect(typeof repo.findPaginatedActionLogsById).toEqual("function");
+        });
+
         it("listenForChanges should be defined", function () {
             expect(repo.listenForChanges).toBeDefined();
             expect(typeof repo.listenForChanges).toEqual("function");
@@ -58,6 +64,20 @@ describe("service: studentSubmissionRepo", function () {
     describe("Do the repo methods work as expected", function () {
         it("fetchSubmissionById should return a submission", function () {
             repo.fetchSubmissionById(1);
+            scope.$digest();
+
+            // TODO
+        });
+
+        it("findPaginatedActionLogsById should return action logs", function () {
+            var mockOrderBy = { order: 'id' };
+            var mockPayload = {
+                PageImpl: {}
+            };
+
+            WsApi.mockFetchResponse({ type: "payload", payload: mockPayload });
+
+            repo.findPaginatedActionLogsById(1, mockOrderBy, 0, 10);
             scope.$digest();
 
             // TODO

--- a/src/test/java/org/tdl/vireo/controller/SubmissionControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/SubmissionControllerTest.java
@@ -1,0 +1,96 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.tdl.vireo.model.ActionLog;
+import org.tdl.vireo.model.Role;
+import org.tdl.vireo.model.SubmissionState;
+import org.tdl.vireo.model.SubmissionStatus;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.repo.ActionLogRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
+public class SubmissionControllerTest {
+
+    private static final String TEST_USER_1_EMAIL = "User 1 email";
+    private static final String TEST_USER_1_FIRST_NAME = "User 1 first name";
+    private static final String TEST_USER_1_LAST_NAME = "User 1 last name";
+    private static final String TEST_HASH = "97a74588d324c59d8d8fbdd5187292d7";
+    private static final Role TEST_USER_1_ROLE = Role.ROLE_ADMIN;
+
+    private static final User TEST_USER_1 = new User(TEST_USER_1_EMAIL, TEST_USER_1_FIRST_NAME, TEST_USER_1_LAST_NAME, TEST_USER_1_ROLE);
+
+    private static final Calendar TEST_CALENDAR_1 = GregorianCalendar.getInstance();
+    private static final Calendar TEST_CALENDAR_2 = GregorianCalendar.getInstance();
+    private static final Calendar TEST_CALENDAR_3 = GregorianCalendar.getInstance();
+
+    private static final SubmissionStatus TEST_SUBMISSION_STATUS_1 = new SubmissionStatus("In Progress", false, false, false, true, true, true, SubmissionState.IN_PROGRESS);
+    private static final SubmissionStatus TEST_SUBMISSION_STATUS_2 = new SubmissionStatus("Needs Corrections", false, false, false, true, true, true, SubmissionState.NEEDS_CORRECTIONS);
+    private static final SubmissionStatus TEST_SUBMISSION_STATUS_3 = new SubmissionStatus("Approved", false, false, false, true, true, true, SubmissionState.APPROVED);
+
+    private static final ActionLog TEST_ACTION_LOG_1 = new ActionLog(TEST_SUBMISSION_STATUS_1, TEST_CALENDAR_1, "Action log entrty 1", false);
+    private static final ActionLog TEST_ACTION_LOG_2 = new ActionLog(TEST_SUBMISSION_STATUS_2, TEST_CALENDAR_2, "Action log entrty 2", true);
+    private static final ActionLog TEST_ACTION_LOG_3 = new ActionLog(TEST_SUBMISSION_STATUS_3, TEST_CALENDAR_3, "Action log entrty 3", false);
+
+    private static final List<ActionLog> TEST_ACTION_LOG_LIST = new ArrayList<>(Arrays.asList(TEST_ACTION_LOG_1, TEST_ACTION_LOG_2, TEST_ACTION_LOG_3));
+    private static final List<ActionLog> TEST_ACTION_LOG_LIST_PAGE_ASSIGNED = new ArrayList<>(Arrays.asList(TEST_ACTION_LOG_1));
+
+    private static final Page<ActionLog> TEST_ACTION_LOG_PAGE = new PageImpl<>(TEST_ACTION_LOG_LIST);
+
+    @Mock
+    private ActionLogRepo actionLogRepo;
+
+    @InjectMocks
+    private SubmissionController submissionController;
+
+    @BeforeEach
+    public void setup() {
+
+    }
+
+    @Test
+    public void testGetActionLogs() {
+        when(actionLogRepo.getAllActionLogs(any(Long.class), any(), any(Pageable.class))).thenReturn(TEST_ACTION_LOG_PAGE);
+
+        Pageable pageable = PageRequest.of(0, TEST_ACTION_LOG_LIST_PAGE_ASSIGNED.size());
+        ApiResponse response = submissionController.getActionLogs(TEST_USER_1, 1L, pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        assertEquals(pageable.getPageSize(), response.getPayload().size());
+    }
+
+    @Test
+    public void testGetActionLogsForAdvisement() {
+        when(actionLogRepo.getAllActionLogs(any(String.class), any(), any(Pageable.class))).thenReturn(TEST_ACTION_LOG_PAGE);
+
+        Pageable pageable = PageRequest.of(0, TEST_ACTION_LOG_LIST_PAGE_ASSIGNED.size());
+        ApiResponse response = submissionController.getActionLogsForAdvisement(TEST_HASH, pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        assertEquals(pageable.getPageSize(), response.getPayload().size());
+    }
+
+}


### PR DESCRIPTION
Resolves #1608

Add two new end points:
1) `/submission/get-one/{submissionId}/action-logs`
2) `/submission/advisor-review/{advisorAccessHash}/action-logs`

These are placed within the submission controller as there is no action log controller and the path structure is within the submission path. Two end points are created because the fetching by hash is not the only situation where the action logs are fetched for some submission. The student submission view also has the same exact problem as with the advisor page. The student submission view uses the submission ID as requires a logged in account whereas the advisor end point uses a hash and does not require a logged in user.

Two new matching repo methods are created to handle this behavior. The by hash fetching is more advanced in that it needs to join submission table to properly match the hash. I made several attempts to use the JPQL for `@Query` and I constantly ran into problems starting up. I decided not to pursue this problem further for time-constraint reasons and move on. I used native queries as a work-around, which is undesirable.

The UI action log table directive is updated to optionally use a callback rather than data straight off of the submission. The pagination logic is passed directly through to the callback and the response is handled appropriately. If the callback is not provided then the default behavior of processing the action logs off the submission is preserved.

Now that action logs are not always being loaded, in certain cases, additional undefined/NULL checks are required in the UI.

Unit tests are partially written.
There are no Submission Controller unit tests and so a completely new file is created and only the functions added here have tests written for them. The repo methods are using `@Query` and so there is nothing to test for those methods. The UI unit tests are written but are incomplete.
I see no existing pattern that has similar code fully working in a unit test and so a bare minimal test is written.

Implement a new JsonView called `SubmissionIndividualActionLogs`. This allows for having a `SubmissionIndividual` without the action logs being lazily loaded. The original behavior is preserved where needed by calling the newly minted `SubmissionIndividualActionLogs` instead of `SubmissionIndividual`.