### PR TITLE
Issue 1632: Allow file deletion to work even when the file on the disk is not found.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -990,9 +990,18 @@ public class SubmissionController {
             apiResponse = new ApiResponse(ERROR, "You are not allowed to delete license files!");
         } else {
             if (user.getRole().equals(Role.ROLE_ADMIN) || user.getRole().equals(Role.ROLE_MANAGER) || uri.contains(String.valueOf(hash))) {
-                JsonNode fileInfo = assetService.getAssetFileInfo(uri, submission);
+                String fileName = "";
+                String fileSize = "file not found";
+                if (assetService.assetFileExists(uri)) {
+                    JsonNode fileInfo = assetService.getAssetFileInfo(uri, submission);
+                    fileName = fileInfo.get("name").asText();
+                    fileSize = fileInfo.get("readableSize").asText();
+                } else {
+                    fileName = assetService.getAssetFileName(uri);
+                }
+
                 assetService.delete(uri);
-                actionLogRepo.createPublicLog(submission, user, documentType.substring(9).toUpperCase() + " file " + fileInfo.get("name").asText() + " (" + fileInfo.get("readableSize").asText() + ") removed");
+                actionLogRepo.createPublicLog(submission, user, documentType.substring(9).toUpperCase() + " file " + fileName + " (" + fileSize + ") removed");
             } else {
                 apiResponse = new ApiResponse(ERROR, "This is not your file to delete!");
             }


### PR DESCRIPTION
Resolves #1632 

If the file no longer exists during the delete process then do not error out. Instead, print a warning to the console.

There error actually first happens on `assetService.getAssetFileInfo()` which does not check to see if the file exists. Modifying that code appears to have larger affects and is therefore not modified. New functions are instead provided to allow for deletion without erroring on non-existent file.

Report that the file is not found in the action log where the file size would otherwise be.

![Screenshot showing the action log message](https://user-images.githubusercontent.com/35114839/230212436-6b74ed51-98a7-4d43-aa5e-a69fd3dfe63f.png)