### PR TITLE
Check if refresh on model is a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "wvr build --clean"
   },
   "dependencies": {
-    "@wvr/core": "2.2.4",
+    "@wvr/core": "https://github.com/TAMULib/Weaver-UI-Core.git#modal-keyboard-escape-fix",
     "angular-ui-tinymce": "0.0.19",
     "file-saver": "2.0.5",
     "ng-csv": "0.3.6",

--- a/src/main/webapp/app/directives/validatedInputDirective.js
+++ b/src/main/webapp/app/directives/validatedInputDirective.js
@@ -73,7 +73,9 @@ vireo.directive("validatedinput", function ($q, $timeout) {
                 }
                 // escape(27): reset value using shadow
                 else if ($event.which == 27) {
-                    $scope.model.refresh();
+                    if ($scope.model && typeof $scope.model.refresh === 'function') {
+                        $scope.model.refresh();
+                    }
                 } else {
 
                 }


### PR DESCRIPTION
Resolves a regression introduced by https://github.com/TAMULib/Weaver-UI-Core/pull/232 where keydown escape event handler is invoked when a $scope.model.refresh method is not a function.