### PR TITLE
Issue 1693: Return error when submission not editable by reviewer

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -213,7 +213,11 @@ public class SubmissionController {
     @JsonView(Views.SubmissionIndividual.class)
     @RequestMapping("/advisor-review/{advisorAccessHash}")
     public ApiResponse getOne(@PathVariable String advisorAccessHash) {
-        return new ApiResponse(SUCCESS, submissionRepo.findOneByAdvisorAccessHash(advisorAccessHash));
+        Submission submission = submissionRepo.findOneByAdvisorAccessHash(advisorAccessHash);
+
+        return submission.getSubmissionStatus().isEditableByReviewer()
+            ? new ApiResponse(SUCCESS, submission)
+            : new ApiResponse(ERROR, "Submission is not editable by reviewer");
     }
 
     @GetMapping("/advisor-review/{advisorAccessHash}/action-logs")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8352733/234054867-892db7b9-7811-41ac-8f03-4a2cd35cba9a.png)


Further issue may be desired to secure the API for the action log via advisor hash. `/advisor-review/{advisorAccessHash}/action-logs` returns public action log without authorization. Additional security discussion surround advisor review is warranted and already initiated.