### PR TITLE
Issue 1709: Add type checks to prevent errors when handling invalid dates.

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -599,9 +599,11 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         };
 
         $scope.displaySubmissionProperty = function (row, col) {
-            var value = $scope.getSubmissionProperty(row, col);
+            if (angular.isDefined(col) && col !== null) {
+                return $filter('displayFieldValue')($scope.getSubmissionProperty(row, col), col.inputType);
+            }
 
-            return angular.isDefined(col) ? $filter('displayFieldValue')(value, col.inputType) : value;
+            return value;
         };
 
         $scope.getCustomActionLabelById = function (id) {

--- a/src/main/webapp/app/filters/displayFieldValue.js
+++ b/src/main/webapp/app/filters/displayFieldValue.js
@@ -1,7 +1,7 @@
 vireo.filter('displayFieldValue', function($filter, InputTypes) {
     return function(value, inputType) {
         if (angular.isUndefined(inputType)) {
-          return value;
+            return value;
         }
 
         var dateColumn = null;
@@ -15,7 +15,7 @@ vireo.filter('displayFieldValue', function($filter, InputTypes) {
 
         if (type != null) {
             if (inputType.name == InputTypes.INPUT_LICENSE || inputType.name == InputTypes.INPUT_PROQUEST) {
-              return value == 'true' ? 'yes' : 'no';
+                return value == 'true' ? 'yes' : 'no';
             }
 
             if (angular.isDefined(appConfig.dateColumns) && angular.isDefined(inputType.name)) {
@@ -35,17 +35,28 @@ vireo.filter('displayFieldValue', function($filter, InputTypes) {
             }
         }
 
-        if (dateColumn == null || angular.isUndefined(value) || value == null) {
-          return value;
+        if (dateColumn === null || angular.isUndefined(value) || value === null) {
+            return value;
         }
 
         // Some browsers, like Firefox, do not support 'MMMM yyyy' formats for Date.parse().
         var stamp = Date.parse(value);
         if (isNaN(stamp) && dateColumn.format == 'MMMM yyyy') {
             var split = value.match(/^(\S+) (\d+)$/);
+
+            if (split === null || split.length < 3) {
+                return value;
+            }
+
             return $filter('date')(new Date(split[1] + ' 01, ' + split[2]).toISOString(), dateColumn.format, 'utc');
         }
 
-        return $filter('date')(new Date(value).toISOString(), dateColumn.format, 'utc');
+        var date = new Date(value);
+
+        if (isNaN(date)) {
+            return value;
+        }
+
+        return $filter('date')(date.toISOString(), dateColumn.format, 'utc');
     };
 });


### PR DESCRIPTION
Resolves #1709

The Javascript date function is very sensitive to values. The regex match function does not always return an array.

While it would be preferred that a Javascript regex match returns an empty array it does not. Handle the error case for when the regex match fails (such as on an empty string). This fixes the display problem on the admin list view.

The `date()` function may return the string 'invalid date' or something similar. This then causes the `date.toISOString()` to fail. Oddly enough, the `isNaN()` will succeed for when `date()` is a valid response (which is an Object). Using the `isNaN()` check fixes the display problem with using the submission view confirmation page (step 5 of the submission view for "Confirm & Submit").

Re-organize and add a NULL check to `$scope.displaySubmissionProperty()` just in case.

Clean up some white space in related areas of code.