### PR TITLE
Issue 1667: Improved submission list view performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.7</version>
+      <version>8.13.8</version>
     </dependency>
 
     <dependency>
@@ -641,7 +641,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <execute />
+                    <execute/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -675,7 +675,7 @@
         </os>
       </activation>
       <properties>
-        <npm-extension></npm-extension>
+        <npm-extension/>
       </properties>
     </profile>
 

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -281,14 +281,7 @@ public class SubmissionListController {
     @RequestMapping("/all-saved-filter-criteria")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse getAllSaveFilterCriteria(@WeaverUser User user) {
-        List<NamedSearchFilterGroup> userSavedFilters = user.getSavedFilters();
-        List<NamedSearchFilterGroup> publicSavedFilters = namedSearchFilterGroupRepo.findByPublicFlagTrue();
-
-        List<NamedSearchFilterGroup> allSavedFilters = new ArrayList<NamedSearchFilterGroup>();
-        allSavedFilters.addAll(userSavedFilters);
-        allSavedFilters.addAll(publicSavedFilters);
-
-        return new ApiResponse(SUCCESS, userSavedFilters);
+        return new ApiResponse(SUCCESS, namedSearchFilterGroupRepo.findByUserOrPublicFlagTrue(user));
     }
 
     @RequestMapping(value = "/save-filter-criteria", method = POST)

--- a/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
+++ b/src/main/java/org/tdl/vireo/model/NamedSearchFilterGroup.java
@@ -3,6 +3,7 @@ package org.tdl.vireo.model;
 import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -63,7 +64,7 @@ public class NamedSearchFilterGroup extends ValidatingBaseEntity {
     private Sort sortDirection;
 
     @OrderColumn
-    @ManyToMany(cascade = { REFRESH, MERGE }, fetch = EAGER)
+    @ManyToMany(cascade = { REFRESH, MERGE }, fetch = LAZY)
     private List<SubmissionListColumn> savedColumns;
 
     @Fetch(FetchMode.SELECT)

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -3,13 +3,14 @@ package org.tdl.vireo.model.repo;
 import java.util.List;
 
 import org.tdl.vireo.model.NamedSearchFilterGroup;
+import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.NamedSearchFilterGroupRepoCustom;
 
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilterGroup>, NamedSearchFilterGroupRepoCustom {
 
-    public List<NamedSearchFilterGroup> findByPublicFlagTrue();
+    public List<NamedSearchFilterGroup> findByUserOrPublicFlagTrue(User user);
 
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 


### PR DESCRIPTION
Switching the `ManyToMany` join between `NamedSearchFilterGroup` and `SubmissionListColumn` to `LAZY` fetch mode improved submission list view page load time by a factor of 2 when applying filter described in [Using a Saved Filter can cause system to be unresponsive for long periods of time.#1667](https://github.com/TexasDigitalLibrary/Vireo/issues/1667) with small data.


