### PR TITLE
Issue 1264: Use a single query to fetch filters for both user or if public.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -281,14 +281,7 @@ public class SubmissionListController {
     @RequestMapping("/all-saved-filter-criteria")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse getAllSaveFilterCriteria(@WeaverUser User user) {
-        List<NamedSearchFilterGroup> userSavedFilters = user.getSavedFilters();
-        List<NamedSearchFilterGroup> publicSavedFilters = namedSearchFilterGroupRepo.findByPublicFlagTrue();
-
-        List<NamedSearchFilterGroup> allSavedFilters = new ArrayList<NamedSearchFilterGroup>();
-        allSavedFilters.addAll(userSavedFilters);
-        allSavedFilters.addAll(publicSavedFilters);
-
-        return new ApiResponse(SUCCESS, userSavedFilters);
+        return new ApiResponse(SUCCESS, namedSearchFilterGroupRepo.findByUserOrPublicFlagTrue(user));
     }
 
     @RequestMapping(value = "/save-filter-criteria", method = POST)

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -3,13 +3,14 @@ package org.tdl.vireo.model.repo;
 import java.util.List;
 
 import org.tdl.vireo.model.NamedSearchFilterGroup;
+import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.NamedSearchFilterGroupRepoCustom;
 
 import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilterGroup>, NamedSearchFilterGroupRepoCustom {
 
-    public List<NamedSearchFilterGroup> findByPublicFlagTrue();
+    public List<NamedSearchFilterGroup> findByUserOrPublicFlagTrue(User user);
 
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 


### PR DESCRIPTION
resolves #1264 

This both fixes the problem and likely improves performance.
A performance improvement is assumed due to the change to a single database call and the lack of joining two arrays.