### PR TITLE
Issue 1264: Take alternate approach for fetching saved filters.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -281,7 +281,10 @@ public class SubmissionListController {
     @RequestMapping("/all-saved-filter-criteria")
     @PreAuthorize("hasRole('REVIEWER')")
     public ApiResponse getAllSaveFilterCriteria(@WeaverUser User user) {
-        return new ApiResponse(SUCCESS, namedSearchFilterGroupRepo.findByUserOrPublicFlagTrue(user));
+        List<NamedSearchFilterGroup> all = namedSearchFilterGroupRepo.findByUserIsNotAndPublicFlagTrue(user);
+        all.addAll(user.getSavedFilters());
+
+        return new ApiResponse(SUCCESS, all);
     }
 
     @RequestMapping(value = "/save-filter-criteria", method = POST)

--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -10,7 +10,7 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilterGroup>, NamedSearchFilterGroupRepoCustom {
 
-    public List<NamedSearchFilterGroup> findByUserOrPublicFlagTrue(User user);
+    public List<NamedSearchFilterGroup> findByUserIsNotAndPublicFlagTrue(User user);
 
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 


### PR DESCRIPTION
resolves #1264 

The previous commit (cf2673eae621ea8e0c59f6b0a89872e75b39c7fc) is designed around selecting all filters for user or all public. There are apparently filters that are not saved filters (which relates to a likely separate bug). Avoid using these by partially reverting the changes in the referenced commit.

Select all public filters that are not associated with the requested user. Then join the array from the already loaded saved filters from the User entity.