### PR TITLE
Issue 1731: Improve handling when attempting to delete filters.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -4,10 +4,12 @@ import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
-import java.util.ArrayList;
+import edu.tamu.weaver.auth.annotation.WeaverUser;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,10 +34,6 @@ import org.tdl.vireo.model.repo.NamedSearchFilterRepo;
 import org.tdl.vireo.model.repo.SubmissionListColumnRepo;
 import org.tdl.vireo.model.repo.UserRepo;
 import org.tdl.vireo.service.DefaultSubmissionListColumnService;
-
-import edu.tamu.weaver.auth.annotation.WeaverUser;
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
 
 @RestController
 @RequestMapping("/submission-list")
@@ -182,9 +180,14 @@ public class SubmissionListController {
     @PreAuthorize("hasRole('REVIEWER')")
     @RequestMapping(value = "/remove-saved-filter", method = POST)
     public ApiResponse removeSavedFilter(@WeaverUser User user, @WeaverValidatedModel NamedSearchFilterGroup savedFilter) {
-        user.getSavedFilters().remove(savedFilter);
-        user = userRepo.save(user);
-        return new ApiResponse(SUCCESS, user.getActiveFilter());
+        if (user.getSavedFilters().contains(savedFilter)) {
+            user.getSavedFilters().remove(savedFilter);
+            user = userRepo.save(user);
+
+            return new ApiResponse(SUCCESS, user.getActiveFilter());
+        }
+
+        return new ApiResponse(ERROR, "Cannot not find filter.");
     }
 
     @PreAuthorize("hasRole('REVIEWER')")

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -696,7 +696,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
             updateChange(false);
         };
 
-        $scope.removeFilter = function (filter) {
+        $scope.removeSaveFilter = function (filter) {
             SavedFilterRepo.delete(filter).then(function () {
                 SavedFilterRepo.reset();
             });
@@ -888,7 +888,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
                 "resetSaveUserFilters": $scope.resetSaveFilter,
                 "applyFilter": $scope.applyFilter,
                 "resetRemoveFilters": $scope.resetRemoveFilters,
-                "removeFilter": $scope.removeFilter,
+                "removeSaveFilter": $scope.removeSaveFilter,
                 "getUserById": $scope.getUserById
             },
             $scope.furtherFilterBy,

--- a/src/main/webapp/app/views/modals/submissions/removeExistingFilters.html
+++ b/src/main/webapp/app/views/modals/submissions/removeExistingFilters.html
@@ -5,28 +5,24 @@
     <h3 class="modal-title">Manage Filters</h3>
 </div>
 <form ng-submit="box.removeFilters()" name="forms.removeFilters" novalidate>
-	<div class="modal-body">
-		 <table class="table table-bordered table-striped etd-table">
-		 	<thead class="header">
-		 		<tr>
-			      	<th ng-repeat="column in ['remove','filter name','has columns','status']">
-			          	{{column}}
-			      	</th>
-			  </tr>
-		 	</thead>
-		 	<tbody>
-				<tr ng-repeat="filter in box.savedFilters">
-					<td>
-				        <button type="button" class="btn" ng-click="box.removeFilter(filter)">Remove</button>
-					</td>
-					<td>{{filter.name}}</td>
-					<td>{{filter.columnsFlag}}</td>
-					<td>{{box.getUserById(filter.user).firstName}} {{box.getUserById(filter.user).lastName}} {{filter.publicFlag ? 'public':'private'}} filter</td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
-	<div class="modal-footer">        
+    <div class="modal-body">
+        <table class="table table-bordered table-striped etd-table">
+        <thead class="header">
+            <tr>
+                <th ng-repeat="column in ['remove','filter name','has columns','status']">{{column}}</th>
+            </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="filter in box.savedFilters">
+                    <td><button type="button" class="btn" ng-click="box.removeSaveFilter(filter)">Remove</button></td>
+                    <td>{{filter.name}}</td>
+                    <td>{{filter.columnsFlag}}</td>
+                    <td>{{box.getUserById(filter.user).firstName}} {{box.getUserById(filter.user).lastName}} {{filter.publicFlag ? 'public':'private'}} filter</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="modal-footer">
         <button type="button" class="btn btn-default" ng-click="box.resetRemoveFilters()">Close</button>
     </div>
 </form>

--- a/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionListControllerTest.js
@@ -167,9 +167,9 @@ describe("controller: SubmissionListController", function () {
             expect(scope.getUserById).toBeDefined();
             expect(typeof scope.getUserById).toEqual("function");
         });
-        it("removeFilter should be defined", function () {
-            expect(scope.removeFilter).toBeDefined();
-            expect(typeof scope.removeFilter).toEqual("function");
+        it("removeSaveFilter should be defined", function () {
+            expect(scope.removeSaveFilter).toBeDefined();
+            expect(typeof scope.removeSaveFilter).toEqual("function");
         });
         it("removeFilterValue should be defined", function () {
             expect(scope.removeFilterValue).toBeDefined();
@@ -427,7 +427,7 @@ describe("controller: SubmissionListController", function () {
 
             spyOn(SavedFilterRepo, "reset");
 
-            scope.removeFilter(filter);
+            scope.removeSaveFilter(filter);
             scope.$digest();
 
             expect(SavedFilterRepo.reset).toHaveBeenCalled();


### PR DESCRIPTION
Resolves #1731

The failure may be happening due to problems with finding the filter in the saved filters and it not being there.
Add sanity checks and then only attempt the save when the filter actually exists in the saved filter for the current user.
Otherwise, return a failure.

Rename the `removeFilter` into `removeSaveFilter` to be less confusing and more consistent with similar functions in the UI.

This depends on commit 0820fce44bf02cb8c1d8a7e47ecb27bb180654d0 and is based off of the branch for the PR #1736 that contains the referenced commit.