### PR TITLE
Issue 1667: The user settings active filter is EAGER.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/User.java
+++ b/src/main/java/org/tdl/vireo/model/User.java
@@ -5,6 +5,7 @@ import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.CascadeType.REMOVE;
 import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -121,7 +122,7 @@ public class User extends AbstractWeaverUserDetails {
     @ManyToMany(cascade = { REFRESH }, fetch = EAGER)
     private List<SubmissionListColumn> filterColumns;
 
-    @ManyToOne(cascade = { REFRESH, MERGE }, fetch = EAGER, optional = true)
+    @ManyToOne(cascade = { REFRESH, MERGE }, fetch = LAZY, optional = true)
     private NamedSearchFilterGroup activeFilter;
 
     @Fetch(FetchMode.SELECT)


### PR DESCRIPTION
resolves #1667

This is believed to be the primary cause of the performance problem observed when a user has an active filter.
The performance cost can be seen ot only on the submission list but on just about any other page so long as a filter was made active of the submission list at one point in time.