### PR TITLE
4.2.0 Docker update replacing deprecated base images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 /.nb-gradle/
 
 
+### VS ###
+.vs
+
 ### VS Code ###
 .vscode/
 
@@ -80,7 +83,7 @@ replay_pid*
 logs/
 target/
 
-.classpth
+.classpath
 .mvn/timing.properties
 .mvn/wrapper/maven-wrapper.jar
 .project

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apk -U upgrade && \
 # Copy files from outside docker to inside.
 COPY build/appConfig.js.template /usr/local/app/templates/appConfig.js.template
 COPY build/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod ugo+x /usr/local/bin/docker-entrypoint.sh
 
 # Login as user.
 USER $USER_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,36 @@
-# Settings.
+# Build arguments.
 ARG USER_ID=3001
 ARG USER_NAME=vireo
-ARG SOURCE_DIR=/$USER_NAME/source
+ARG HOME_DIR=/$USER_NAME
+ARG SOURCE_DIR=$HOME_DIR/source
+ARG APP_PATH=/var/vireo
 ARG NODE_ENV=production
 
 # Maven stage.
-FROM maven:3-openjdk-11-slim as maven
+FROM maven:3-eclipse-temurin-11-alpine as maven
 ARG USER_ID
 ARG USER_NAME
+ARG HOME_DIR
 ARG SOURCE_DIR
+ARG APP_PATH
 ARG NODE_ENV
 
 ENV NODE_ENV=$NODE_ENV
 
-# Create the user and group (use a high ID to attempt to avoid conflicts).
-RUN groupadd --non-unique -g $USER_ID $USER_NAME && \
-    useradd --non-unique -d /$USER_NAME -m -u $USER_ID -g $USER_ID $USER_NAME
+# Create the group (use a high ID to attempt to avoid conflits).
+RUN addgroup -g $USER_ID $USER_NAME
 
-# Install stable Nodejs and npm.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs npm iproute2 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    npm cache clean -f && \
-    npm install -g n && \
-    n stable
+# Create the user (use a high ID to attempt to avoid conflits).
+RUN adduser -h $HOME_DIR -u $USER_ID -G $USER_NAME -D $USER_NAME
 
 # Ensure source directory exists and has appropriate file permissions.
 RUN mkdir -p $SOURCE_DIR && \
     chown $USER_ID:$USER_ID $SOURCE_DIR && \
     chmod g+s $SOURCE_DIR
+
+# Upgrade the system and install dependencies.
+RUN apk -U upgrade && \
+    apk add --update --no-cache nodejs npm make g++ py3-pip
 
 # Set deployment directory.
 WORKDIR $SOURCE_DIR
@@ -43,7 +43,7 @@ COPY ./src ./src
 COPY ./build ./build
 COPY ./package.json ./package.json
 
-# Assign file permissions.
+# Change ownership of source directory.
 RUN chown -R $USER_ID:$USER_ID $SOURCE_DIR
 
 # Login as user.
@@ -52,47 +52,45 @@ USER $USER_NAME
 # Build.
 RUN mvn package -Pproduction
 
-# Switch to Normal JRE Stage.
-FROM openjdk:11-jre-slim
+# JRE Stage.
+FROM eclipse-temurin:11-alpine
 ARG USER_ID
 ARG USER_NAME
+ARG HOME_DIR
 ARG SOURCE_DIR
+ARG APP_PATH
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get -y install gettext-base && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+ENV APP_PATH=$APP_PATH
+
+# Create the group (use a high ID to attempt to avoid conflits).
+RUN addgroup -g $USER_ID $USER_NAME
+
+# Create the user (use a high ID to attempt to avoid conflits).
+RUN adduser -h $HOME_DIR -u $USER_ID -G $USER_NAME -D $USER_NAME
+
+# Ensure app path directory exists and has appropriate file permissions.
+RUN mkdir -p $APP_PATH && \
+    chown $USER_ID:$USER_ID $APP_PATH && \
+    chmod g+s $APP_PATH
+
+# Update the system and install gettext for envsubst.
+RUN apk -U upgrade && \
+    apk add --update --no-cache gettext
 
 # Copy files from outside docker to inside.
 COPY build/appConfig.js.template /usr/local/app/templates/appConfig.js.template
 COPY build/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
-# Enable execute of docker entrypoint for root user.
-RUN chmod ugo+r /usr/local/app/templates/appConfig.js.template && \
-    chmod ugo+rx /usr/local/bin/docker-entrypoint.sh
-
-# Create the user and group (use a high ID to attempt to avoid conflicts).
-RUN groupadd --non-unique -g $USER_ID $USER_NAME && \
-    useradd --non-unique -d /$USER_NAME -m -u $USER_ID -g $USER_ID $USER_NAME
-
 # Login as user.
 USER $USER_NAME
 
 # Set deployment directory.
-WORKDIR /$USER_NAME
+WORKDIR $HOME_DIR
+
 
 # Copy over the built artifact and library from the maven image.
 COPY --from=maven $SOURCE_DIR/target/vireo-*.war ./vireo.war
 COPY --from=maven $SOURCE_DIR/target/libs ./libs
-
-ENV AUTH_STRATEGY=weaverAuth
-
-ENV STOMP_DEBUG=false
-
-ENV AUTH_SERVICE_URL=http://localhost:9001/auth
-
-ENV APP_CONFIG_PATH=file:/$USER_NAME/appConfig.js
 
 EXPOSE 9000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 
 volumes:
   pgdata:
-  vireo:
+  assets:
 
 services:
 
@@ -41,7 +41,7 @@ services:
     env_file:
        - .env
     volumes:
-      - vireo:${APP_PATH}
+      - assets:${APP_PATH}
     ports:
       - 9000:9000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,50 @@
-version: '3.7'
+version: '3.8'
 
 networks:
-  weaver:
+  net:
+
+volumes:
+  pgdata:
+  vireo:
 
 services:
 
-  vireo_db:
-    container_name: vireo_db
-    hostname: vireo_db
+  db:
     image: postgres
     environment:
-      POSTGRES_DB: vireo
-      POSTGRES_USER: vireo
-      POSTGRES_PASSWORD: vireo
+       - POSTGRES_DB=vireo
+       - POSTGRES_USER=vireo
+       - POSTGRES_PASSWORD=vireo
     volumes:
-      - ${LOCAL_VIREO_PGDATA}:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
     networks:
-      weaver:
+      - net
+
+  adminer:
+    image: adminer
+    ports:
+      - 8080:8080
+    depends_on:
+      - db
+    networks:
+      - net
 
   vireo:
     container_name: vireo
     hostname: vireo
+    image: ${IMAGE_HOST}/${SERVICE_PROJECT}/${SERVICE_PATH}:${IMAGE_VERSION}
     build:
       dockerfile: Dockerfile
       context: './'
-    image: ${IMAGE_HOST}/${SERVICE_PROJECT}${SERVICE_PATH}:${IMAGE_VERSION}
+    env_file:
+       - .env
+    volumes:
+      - vireo:${APP_PATH}
     ports:
       - 9000:9000
-    env_file:
-      - .env
-    volumes:
-      - ${LOCAL_VIREO_PATH}:${APP_PATH}
     depends_on:
-      - vireo_db
+      - db
     networks:
-      weaver:
+      - net

--- a/example.env
+++ b/example.env
@@ -4,32 +4,35 @@
 ##############################
 
 IMAGE_HOST=127.0.0.1
-
-IMAGE_VERSION=0.0.1
-
-SERVICE_PROJECT=vireo
-
-# Must have leading slash.
-SERVICE_PATH=/vireo
-
-LOCAL_VIREO_PATH=/var/vireo/
-LOCAL_VIREO_PGDATA=/var/vireo/pgdata/
+IMAGE_VERSION=4.2.0
+SERVICE_PROJECT=tdl
+SERVICE_PATH=vireo
 
 NODE_ENV=production
 
 STOMP_DEBUG=false
 
+AUTH_STRATEGY=weaverAuth
+
 AUTH_SERVICE_URL="window.location.protocol + '//' + window.location.host + window.location.base + '/mock/auth'"
 
-SPRING_DATASOURCE_URL=jdbc:h2:mem:AZ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-SPRING_DATASOURCE_DRIVERCLASSNAME=org.h2.Driver
-SPRING_DATASOURCE_USERNAME=vireo
-SPRING_DATASOURCE_PASSWORD=vireo
-SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.H2Dialect
+
+#SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.H2Dialect
+SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.PostgreSQLDialect
+
 SPRING_JPA_HIBERNATE_DDL_AUTO=update
 
+#SPRING_DATASOURCE_URL=jdbc:h2:mem:AZ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+#SPRING_DATASOURCE_DRIVERCLASSNAME=org.h2.Driver
+SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/vireo
+SPRING_DATASOURCE_DRIVERCLASSNAME=org.postgresql.Driver
+
+SPRING_DATASOURCE_USERNAME=vireo
+SPRING_DATASOURCE_PASSWORD=vireo
+
+
 # location to place templated appConfig.js
-APP_PATH=/var/vireo/
+APP_PATH=/var/vireo
 # must match directory of APP_PATH
 APP_CONFIG_URI=file:/var/vireo/appConfig.js
 APP_ASSETS_URI=file:/var/vireo/


### PR DESCRIPTION
- Replace base image `maven:3-openjdk-11-slim` with `maven:3-eclipse-temurin-11-alpine`.
- Replace base image `openjdk:11-jre-slim` with `eclipse-temurin:11-alpine`.
- Add [Adminer ](https://www.adminer.org/) to docker compose.
- Use named volumes with docker compose.
- Minor cleanup of example env file.