### PR TITLE
Issue 1667: Place the AND in the correct location.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -947,11 +947,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                         sqlCountSelectBuilder
                             .append("\n(fv.field_predicate_id = ").append(id)
-                            .append(" AND (").append(filter).append("))");
+                            .append(" AND (").append(filter).append(")) AND");
                     }
                 });
-
-                sqlCountSelectBuilder.append(" AND");
             } else {
                 sqlCountSelectBuilder.append("\nWHERE");
             }


### PR DESCRIPTION
resolves: #1667

An over sight resulted in having the AND in the wrong location. This causes a regression where having multiple filters could produce an SQL exception.