### PR TITLE
Issue 1757: Sort Graduation Semester (Month Year Format Dates) as a date type.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -1031,7 +1031,7 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
         if (sort == Sort.ASC || sort == Sort.DESC) {
             sqlSelectBuilder
                 .append(table).append(".value,")
-                .append(" cast(replace(").append(table).append(".value, ' ', ' 1, ') as date) as").append(table).append("_date,");
+                .append(" CAST(REPLACE(").append(table).append(".value, ' ', ' 1, ') AS DATE) AS").append(table).append("_date,");
 
             sqlOrderBysBuilder.append(table).append("_date ").append(sort.name()).append(",");
         }


### PR DESCRIPTION
Resolves #1757 

When sorting as a string, the sort produces unwanted results as described by the issue. Given the current design, it should have been simple to add a CAST to the ORDER BY for the appropriate date field.

Several problems make this more complicated than otherwise would be hoped for:
1. The column needed to be changed is a field predicate associated with field_values rather than being a date on submission.
2. Postgresql doesn't cast "Month Year" format to a date.
3. Postgresql doesn't support the specific case of casting on a column in the SELECT clause when DISTINCT is in use.

A separate function with documentation is added to explain the situation.

When sorting by the Graduation Semester (which is also called "Degree Date"), a new column is added to the SELECT clause to provide the Graduation Semester casted to a date type. The ORDER BY then select his special date column for sorting rather than the original value column.