### PR TITLE
Issue 1764: Add tabindex and aria-details to make agreements more accessible.

### DIFF
--- a/src/main/webapp/app/views/inputtype/input-license.html
+++ b/src/main/webapp/app/views/inputtype/input-license.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="well" ng-bind-html="configuration.submission.submit_license.value|trusted"></div>
+  <div class="well" tabindex="0" ng-bind-html="configuration.submission.submit_license.value|trusted"></div>
   <div class="checkbox">
     <label>
       <input type="checkbox"

--- a/src/main/webapp/app/views/inputtype/input-license.html
+++ b/src/main/webapp/app/views/inputtype/input-license.html
@@ -1,8 +1,9 @@
 <div>
-  <div class="well" tabindex="0" ng-bind-html="configuration.submission.submit_license.value|trusted"></div>
+  <div class="well" tabindex="0" ng-bind-html="configuration.submission.submit_license.value|trusted" aria-details="input_license-{{fieldValue.fieldPredicate.id}}-{{fieldValue.id}}"></div>
   <div class="checkbox">
     <label>
-      <input type="checkbox"
+      <input id="input_license-{{fieldValue.fieldPredicate.id}}-{{fieldValue.id}}"
+       type="checkbox"
         ng-model="fieldValue.value"
         ng-true-value="'true'"
         ng-false-value="'false'"

--- a/src/main/webapp/app/views/inputtype/input-proquest.html
+++ b/src/main/webapp/app/views/inputtype/input-proquest.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="well" ng-bind-html="configuration.proquest_umi_degree_code.proquest_license.value|trusted"></div>
+  <div class="well" tabindex="0" ng-bind-html="configuration.proquest_umi_degree_code.proquest_license.value|trusted"></div>
   <div class="checkbox">
     <label>
       <input type="checkbox"

--- a/src/main/webapp/app/views/inputtype/input-proquest.html
+++ b/src/main/webapp/app/views/inputtype/input-proquest.html
@@ -1,8 +1,9 @@
 <div>
-  <div class="well" tabindex="0" ng-bind-html="configuration.proquest_umi_degree_code.proquest_license.value|trusted"></div>
+  <div class="well" tabindex="0" ng-bind-html="configuration.proquest_umi_degree_code.proquest_license.value|trusted" aria-details="input_proquest-{{fieldValue.fieldPredicate.id}}-{{fieldValue.id}}"></div>
   <div class="checkbox">
     <label>
-      <input type="checkbox"
+      <input id="input_proquest-{{fieldValue.fieldPredicate.id}}-{{fieldValue.id}}"
+        type="checkbox"
         ng-model="fieldValue.value"
         ng-true-value="'true'"
         ng-false-value="'false'"


### PR DESCRIPTION
Add tabindex to the license and proquest agreements.

Use `aria-details` for the license agreement and proquest agreement.

This should improve accessibility by better associating the agreement checkbox with the agreements.
The "I agree" check boxes are not described by the agreement.
Instead, the "I agree" checkboxes is instead associated with the agreement.
The `aria-describedby` is not as semantically ideal in this case as is `aria-details`.

The `aria-describedby` should likely be avoided also because of the size of the agreements.

> Unlike aria-describedby, elements referenced by aria-details are not used in accessible descriptions and are not turned into a plain string when presented to assistive technology users. If the associated content is not too long and flattening the contents of the referenced element to a simple string of text wouldn't cause loss of information, consider using aria-describedby instead. That said, it is valid for an element to have both aria-details and a description specified with either aria-describedby or aria-description.

> Elements referenced by aria-details are intended to contain more information than would normally be provided via aria-describedby.

> The elements referenced by aria-details should be visible to all users. aria-details informs users that otherwise might not be able to scan a screen and discern quickly that the explanatory content is available.

source: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-details
