### PR TITLE
Issue 1757: Add support for H2 database, which does not handle normal casting to DATE.

### DIFF
--- a/src/main/java/org/tdl/vireo/config/VireoDatabaseConfig.java
+++ b/src/main/java/org/tdl/vireo/config/VireoDatabaseConfig.java
@@ -1,0 +1,20 @@
+package org.tdl.vireo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class VireoDatabaseConfig {
+
+    @Value("${spring.sql.init.platform:''}")
+    private String platform;
+
+    public String getPlatform() {
+        return platform;
+    }
+
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.config.VireoDatabaseConfig;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
 import org.tdl.vireo.model.Configuration;
 import org.tdl.vireo.model.CustomActionDefinition;
@@ -99,6 +100,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
     @Autowired
     private AssetService assetService;
+
+    @Autowired
+    private VireoDatabaseConfig vireoDatabaseConfig;
 
     private JdbcTemplate jdbcTemplate;
 
@@ -1029,9 +1033,15 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
      */
     public void setColumnOrderingForMonthYearDateFormat(Sort sort, StringBuilder sqlSelectBuilder, StringBuilder sqlOrderBysBuilder, String table) {
         if (sort == Sort.ASC || sort == Sort.DESC) {
-            sqlSelectBuilder
-                .append(table).append(".value,")
-                .append(" CAST(REPLACE(").append(table).append(".value, ' ', ' 1, ') AS DATE) AS").append(table).append("_date,");
+            sqlSelectBuilder.append(table).append(".value,");
+
+            if ("h2".equals(vireoDatabaseConfig.getPlatform())) {
+                sqlSelectBuilder.append(" PARSEDATETIME(").append(table).append(".value, 'MMM yyyy') AS");
+            } else {
+                sqlSelectBuilder.append(" CAST(REPLACE(").append(table).append(".value, ' ', ' 1, ') AS DATE) AS");
+            }
+
+            sqlSelectBuilder.append(table).append("_date,");
 
             sqlOrderBysBuilder.append(table).append("_date ").append(sort.name()).append(",");
         }


### PR DESCRIPTION
relates to #1757

H2 doesn't support the CAST for a "month year" format.
An H2-specific function is required to do this.

This then requires detecting that H2 is in use.