### PR TITLE
Issue 1737: Add missing removeFilter method to apiMapping.js.

### DIFF
--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -1067,7 +1067,8 @@ var apiMapping = {
         },
         removeFilter: {
             'endpoint': '/private/queue',
-            'controller': 'submission-list'
+            'controller': 'submission-list',
+            'method': 'remove-filter-criterion'
         },
         clearFilters: {
             'endpoint': '/private/queue',


### PR DESCRIPTION
Resolves #1737

The `remove-saved-filter` appears to be the most correct end point despite the others using "criteria" end points. There should be additional refactoring done to fix this naming confusing but such changes are out of the scope of this issue.