### PR TITLE
Issue 1738: Address most of the Stale/Bad data in the database regarding filters.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/NamedSearchFilterGroupRepo.java
@@ -12,6 +12,8 @@ public interface NamedSearchFilterGroupRepo extends WeaverRepo<NamedSearchFilter
 
     public List<NamedSearchFilterGroup> findByUserIsNotAndPublicFlagTrue(User user);
 
+    public List<NamedSearchFilterGroup> findByUserAndNameIsNull(User user);
+
     public NamedSearchFilterGroup findByNameAndPublicFlagTrue(String name);
 
 }


### PR DESCRIPTION
resolves #1738

Issue #1738 is about the stale/bad data getting hidden and not about removing the filters themselves. There is some cross-over between the two issues that can make this confusing. The goal of this change is to remove the stale/bad data and not to fix the proper removal of valid filter data.

### Considerations

1. Problems Solved: There are several problems that are aspects of the same issue.
2. Problems Exposed: There are several problems that are further exposed by fixing the stale/bad data.
3. Other Problems: There are several problems that might go away as a result of some of these changes.

For point (2), this does not address the additional problems and notes them below. For point (1), this address the problems described on the issue and that are directly related (this is also described below). For point (3), parts of other issues will not seem as problematic after this but those issues may still not be resolved (such as issue #1724).

Further note that issue #1724 is not a duplicate of issue #1738 and #1724 should instead be resolved in #1739.

### Problems Solved

This commit takes the approach of not altering the database schema and as a result cannot solve all of the problems within its scope.

The `set-active-filter` end point is calling `namedSearchFilterGroupRepo.clone()`. This clone call results in a duplicate named search group being created every time a saved filter is selected. This is addressed by changing the logic as follows:
1. Attempt to load the desired filter by the given ID.
2. If none exist, then throw an error.
3. Set the active filter.

The `clear-filter-criteria` end point, as described in the issue, is causing bad data. When the filter is cleared, the actual data is never removed and remains. The Named Search Filter data (table `named_search_filter`) and the Submission List Column data (table `submission_list_column`) end up with stale data and often redundant data. This is addressed by changing the logic as follows:
1. Find the first not "saved" (aka "persisted") filter and set that as the active filter (because the current database design requires that a filter always exist or be used lest one suffer NULL pointer exceptions).
2. If the currently active filter is a not "saved" filter (aka: "persisted" filter), then all of the existing Named Search Filter data and Submission List Column data must be deleted because that is now stale/bad data. Collect all of the IDs of these so that they can be deleted.
3. Set the active filter for the current user and save.
4. Now that the active filter is saved, the stale data, whose IDs have been saved, can now be deleted without constraint violations caused by the currently set active filter.

The stale/bad data caused by the filter itself not being deleted is a separate issue. As per practice, this does not address the deletion issue because that is a different bug regarding proper deletion of valid/not-stale data. That problem is also a database design problem concern and this commit strives to avoid all database schema redesign strategies.

### Problems Exposed

There are several problems that are not regressions but are instead existing problems that are now exposed. As per practice, these are not to be solved within the scope of this issue and may need to be solved in another issue (referenced above).

1. Now filtering by does not clear on changes.
2. Adding/Removing/Saving a filter saves the current filter, even if it is a saved filter and owned by somebody else.
3. Saving a filter with the same name as another filter, such as a public filter, will replace the existing named filter even if owned by a different user.
  1. This is because the uniqueness is on the (user_id, name), allowing for another user to overwrite a public filter.
  2. In theory, this could also allow anyone to delete a public filter (once delete functionality is fixed) even if the user does not own the filter.
  3. If User A deletes Public Filter A that they own while User B is using Public Filter A, then consider:
    1. Public Filter A is still visible to User B.
    2. User B can save Public Filter A, causing changes. 3. User B can save Public Filter A as not public and it will re-appear in User A's list.
      1. When this happens, User B will have a messed up "Now Filtering By" and so will User A, when User A selects Public Filter A. 1. This is because when User B saves User A's filter, new filters owned by User B get created. 1. The filter will show two of each filters, one set owned by User A and the other set owned by User B. 2. Attempting to delete the now defunct (and currently private) Public Filter A requires two delete operations. 1. The first delete deletes only one set, such as User A's parts but not User B's parts. 2. The second delete deletes the set owned by the remaining user, such as User B's parts.

### Other Problems

With most (but not all) of the stale/bad data is removed by this change the issue #1731 will be effectively resolved. This is because the problems observed and described in issue #1731 are not actually an issue in regards to the filter being properly deleted (which is in fact a problem). Instead, the problem described in #1731 is manifested by the `clone` call and the behavior in the clear filter end point.

The proper solution to #1731 might be to fix the database schema structure. Such a change is out of scope for this commit.

### Additional Notes

Example script used to observe relevant database structure where the users being test have an ID 4 and an ID 9:
```sql
select * from named_search_filter_group where user_id in (4, 9); select * from named_search_filter_filter_criteria ; select * from named_search_filter; select id, username, active_filter_id from weaver_users where id in (4, 9); select * from named_search_filter_group_saved_columns ;
```