### PR TITLE
DSpace Mets Export should not show local.embargo.terms nor local.emba…

### DIFF
--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -660,7 +660,7 @@ public class SubmissionHelperUtility {
     }
 
     public String getEmbargoLiftDate() {
-        String defaultEmbargoLiftDateStr = "";
+        String defaultEmbargoLiftDateStr = null;
         Optional<String> dateIssued = getFieldValueByPredicateValue("dc.date.issued");
         if(dateIssued.isPresent()){
             String dateIssuedStr = dateIssued.get();

--- a/src/main/resources/formats/dspace_mets.xml
+++ b/src/main/resources/formats/dspace_mets.xml
@@ -138,24 +138,26 @@
                     
                     <!-- dc.description.provenance = Statement about when this package was generated. -->
                     <dim:field
-                        mdschema="dc"
-                        element="description"
-                        qualifier="provenance"
-                        th:text="${ 'DSpace METS Submission Ingestion Package generated from Vireo submission ' + SUBMISSION_ID + ' on ' + TIME }">
+                      mdschema="dc"
+                      element="description"
+                      qualifier="provenance"
+                      th:text="${ 'DSpace METS Submission Ingestion Package generated from Vireo submission ' + SUBMISSION_ID + ' on ' + TIME }">
                     </dim:field>
 
                     <!-- local.embargo.terms = Embargo Lift Date -->
                     <dim:field
-                        mdschema="local"
-                        element="embargo"
-                        qualifier="terms"
-                        th:text="${ EMBARGO_LIFT_DATE }">                         
+                      th:if="${ EMBARGO_LIFT_DATE != null }"
+                      mdschema="local"
+                      element="embargo"
+                      qualifier="terms"
+                      th:text="${ EMBARGO_LIFT_DATE }">                         
                     </dim:field>
                     <dim:field
-                        mdschema="local"
-                        element="embargo"
-                        qualifier="lift"
-                        th:text="${ EMBARGO_LIFT_DATE }">                         
+                      th:if="${ EMBARGO_LIFT_DATE != null }"
+                      mdschema="local"
+                      element="embargo"
+                      qualifier="lift"
+                      th:text="${ EMBARGO_LIFT_DATE }">                         
                     </dim:field>
 
                     <dim:field


### PR DESCRIPTION
…rgo.lift if no date available

this is not related to a specific github ticket but a minor fix needed for dspace mets exports