### PR TITLE
Issue 1772: SwordV1 requires Log4j, revert exclusion.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,10 +188,6 @@
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>xom</groupId>
           <artifactId>xom</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -187,10 +187,6 @@
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>xom</groupId>
-          <artifactId>xom</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
resolves #1772 (with concerns, see below)

The error is because of the logger.
The log4j is excluded and as a result a no class found error is returned.

**Warning: This may re-introduce security concerns.**
An alternative solution is going to be needed to safely fix this.

See CVEs listed here:
- https://mvnrepository.com/artifact/log4j/log4j/1.2.17
- https://logging.apache.org/log4j/1.2/

This should not be merged until confirmed that we must accept the security implications of this.

This should be closed if an alternative solution that does not allow for the Log4J security concerns is presented.

Possible Alternatives:
- Find a way to use Reload4J (howeverm see the CVE in 1.2.25):
  - https://mvnrepository.com/artifact/ch.qos.reload4j/reload4j
  - https://github.com/qos-ch/reload4j
  - https://mvnrepository.com/artifact/ch.qos.reload4j/reload4j/1.2.25

This also may invlove DSpace, where SwordV2 is in use and that too is outdated and unmaintained:
- https://github.com/DSpace/DSpace/issues/8188
- https://github.com/DSpace/DSpace/labels/interface%3A%20SWORD