### PR TITLE
Issue 1776: The "wysiwyg" default is missing.

### DIFF
--- a/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
+++ b/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
@@ -1,627 +1,631 @@
 <div class="look-and-feel" ng-controller="LookAndFeelController" ng-model-options="{ debounce: 1000 }">
-	<form name="look-and-feel">
-		<div class="row">
-			<div class="col-sm-6 col-lg-9">
-
-				<div class="row look-and-feel-h1">
-					<div>Text
-					   <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the default text color for the application."></span>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h2">
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Main Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','text_main_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','text_main_color')"
-						  		ng-model="settings.configurable.lookAndFeel.text_main_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.text_main_color.value}">
-									<input
-										type="color"
-										name="text_main_color"
-										ng-model="settings.configurable.lookAndFeel.text_main_color.value"
-										ng-change="updateHexValue('lookAndFeel','text_main_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h1">
-					<div>Header/Footer
-						<span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors for the header and footer. The main color (default #1B333F) fades into the highlight color (default #43606E)."></span>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h2">
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Background Main Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','background_main_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','background_main_color')"
-						  		ng-model="settings.configurable.lookAndFeel.background_main_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_main_color.value}">
-									<input
-										type="color"
-										name="background_main_color"
-										ng-model="settings.configurable.lookAndFeel.background_main_color.value"
-										ng-change="updateHexValue('lookAndFeel','background_main_color')"/>
-								</label>
-							</span>
-
-						</div>
-
-					</div>
-
-					<div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
-						<div class="row">
-							<span>Background Highlight Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','background_highlight_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','background_highlight_color')"
-						  		ng-model="settings.configurable.lookAndFeel.background_highlight_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_highlight_color.value}">
-									<input
-										type="color"
-										name="background_highlight_color"
-										ng-model="settings.configurable.lookAndFeel.background_highlight_color.value"
-										ng-change="updateHexValue('lookAndFeel','background_highlight_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Header Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','background_header_text_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','background_header_text_color')"
-						  		ng-model="settings.configurable.lookAndFeel.background_header_text_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_header_text_color.value}">
-									<input
-										type="color"
-										name="background_header_text_color"
-										ng-model="settings.configurable.lookAndFeel.background_header_text_color.value"
-										ng-change="updateHexValue('lookAndFeel','background_header_text_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>	
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Footer Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','background_footer_text_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','background_footer_text_color')"
-						  		ng-model="settings.configurable.lookAndFeel.background_footer_text_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_footer_text_color.value}">
-									<input
-										type="color"
-										name="background_footer_text_color"
-										ng-model="settings.configurable.lookAndFeel.background_footer_text_color.value"
-										ng-change="updateHexValue('lookAndFeel','background_footer_text_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-1 col-lg-5"></div>
-				</div>
-
-
-				<div class="row look-and-feel-h1">
-					<div>Submission Step Button (On)
-					   	<span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the submission step buttons for the selected step or on hover. The main color (default #1B333F) fades into the highlight color (default #43606E) and then back to the main color."></span>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h2">
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Background Main Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_main_color_on')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_main_color_on')"
-						  		ng-model="settings.configurable.lookAndFeel.button_main_color_on.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_main_color_on.value}">
-									<input
-										type="color"
-										name="button_main_color_on"
-										ng-model="settings.configurable.lookAndFeel.button_main_color_on.value"
-										ng-change="updateHexValue('lookAndFeel','button_main_color_on')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-
-					<div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
-						<div class="row">
-							<span>Background Highlight Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_highlight_color_on')">
-								</span>
-							</span>
-						</div>
-
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_highlight_color_on')"
-						  		ng-model="settings.configurable.lookAndFeel.button_highlight_color_on.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label
-									class="color-selector-swatch"
-									ng-style="{background: settings.configurable.lookAndFeel.button_highlight_color_on.value}">
-									<input
-										type="color"
-										name="button_highlight_color_on"
-										ng-model="settings.configurable.lookAndFeel.button_highlight_color_on.value"
-										ng-change="updateHexValue('lookAndFeel','button_highlight_color_on')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_text_color_on')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_text_color_on')"
-						  		ng-model="settings.configurable.lookAndFeel.button_text_color_on.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_text_color_on.value}">
-									<input
-										type="color"
-										name="button_text_color_on"
-										ng-model="settings.configurable.lookAndFeel.button_text_color_on.value"
-										ng-change="updateHexValue('lookAndFeel','button_text_color_on')"/>
-								</label>
-							</span>
-
-						</div>
-
-					</div>
-					<div class="col-md-1 col-lg-5"></div>
-				</div>
-
-
-				<div class="row look-and-feel-h1">
-					<div>Submission Step Button (Off)
-			   			<span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the submission step buttons when not selected. The main color (default #424D46) fades into the highlight color (default #697A70) and then back to the main color."></span>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h2">
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Background Main Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_main_color_off')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-							<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_main_color_off')"
-						  		ng-model="settings.configurable.lookAndFeel.button_main_color_off.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label
-									class="color-selector-swatch"
-									ng-style="{background: settings.configurable.lookAndFeel.button_main_color_off.value}">
-									<input
-										type="color"
-										name="button_main_color_off"
-										ng-model="settings.configurable.lookAndFeel.button_main_color_off.value"
-										ng-change="updateHexValue('lookAndFeel','button_main_color_off')"/>
-								</label>
-							</span>
-
-						</div>
-
-					</div>
-
-
-					<div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
-						<div class="row">
-							<span>Background Highlight Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_highlight_color_off')">
-								</span>
-							</span>
-						</div>
-
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_highlight_color_off')"
-						  		ng-model="settings.configurable.lookAndFeel.button_highlight_color_off.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label
-									class="color-selector-swatch"
-									ng-style="{background: settings.configurable.lookAndFeel.button_highlight_color_off.value}">
-									<input
-										type="color"
-										name="button_highlight_color_off"
-										ng-model="settings.configurable.lookAndFeel.button_highlight_color_off.value"
-										ng-change="updateHexValue('lookAndFeel','button_highlight_color_off')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','button_text_color_off')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','button_text_color_off')"
-						  		ng-model="settings.configurable.lookAndFeel.button_text_color_off.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_text_color_off.value}">
-									<input
-										type="color"
-										name="button_text_color_off"
-										ng-model="settings.configurable.lookAndFeel.button_text_color_off.value"
-										ng-change="updateHexValue('lookAndFeel','button_text_color_off')"/>
-								</label>
-							</span>
-						</div>
-					</div>					
-					<div class="col-md-1 col-lg-5"></div>
-				</div>
-
-				<div class="row look-and-feel-h1">
-					<div>Admin Navigation Tab
-			   			<span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the tabs in the admin interface (top of the current page). The main color (default #ADBDAA) is the background color for tabs not selected. The selected color (default #FFFFFF) is the backgound color for the selected tab."></span>
-					</div>
-				</div>
-
-				<div class="row look-and-feel-h2">
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Background Main Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','admin_tab_main_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-							<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','admin_tab_main_color')"
-						  		ng-model="settings.configurable.lookAndFeel.admin_tab_main_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label
-									class="color-selector-swatch"
-									ng-style="{background: settings.configurable.lookAndFeel.admin_tab_main_color.value}">
-									<input
-										type="color"
-										name="admin_tab_main_color"
-										ng-model="settings.configurable.lookAndFeel.admin_tab_main_color.value"
-										ng-change="updateHexValue('lookAndFeel','admin_tab_main_color')"/>
-								</label>
-							</span>
-
-						</div>
-
-					</div>
-
-
-					<div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
-						<div class="row">
-							<span>Background Selected Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','admin_tab_selected_color')">
-								</span>
-							</span>
-						</div>
-
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','admin_tab_selected_color')"
-						  		ng-model="settings.configurable.lookAndFeel.admin_tab_selected_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label
-									class="color-selector-swatch"
-									ng-style="{background: settings.configurable.lookAndFeel.admin_tab_selected_color.value}">
-									<input
-										type="color"
-										name="admin_tab_selected_color"
-										ng-model="settings.configurable.lookAndFeel.admin_tab_selected_color.value"
-										ng-change="updateHexValue('lookAndFeel','admin_tab_selected_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Main Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','admin_tab_main_text_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','admin_tab_main_text_color')"
-						  		ng-model="settings.configurable.lookAndFeel.admin_tab_main_text_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.admin_tab_main_text_color.value}">
-									<input
-										type="color"
-										name="admin_tab_main_text_color"
-										ng-model="settings.configurable.lookAndFeel.admin_tab_main_text_color.value"
-										ng-change="updateHexValue('lookAndFeel','admin_tab_main_text_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-5 col-lg-3">
-						<div class="row">
-							<span>Selected Text Color
-								<span
-									class="glyphicon glyphicon-refresh color-reset"
-									ng-click="resetConfiguration('lookAndFeel','admin_tab_selected_text_color')">
-								</span>
-							</span>
-						</div>
-
-						<div class="input-group color-selector">
-							<span class="input-group-addon">#</span>
-						  	<input
-						  		class="form-control color-input"
-						  		ng-change="updateHexValue('lookAndFeel','admin_tab_selected_text_color')"
-						  		ng-model="settings.configurable.lookAndFeel.admin_tab_selected_text_color.value"
-						  		dehashcolor>
-
-							<span class="input-group-addon">
-								<label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.admin_tab_selected_text_color.value}">
-									<input
-										type="color"
-										name="admin_tab_selected_text_color"
-										ng-model="settings.configurable.lookAndFeel.admin_tab_selected_text_color.value"
-										ng-change="updateHexValue('lookAndFeel','admin_tab_selected_text_color')"/>
-								</label>
-							</span>
-						</div>
-					</div>
-					<div class="col-md-1 col-lg-5"></div>
-				</div>
-			</div>
-
-
-			<div class="col-sm-6 col-lg-3">
-			</div>
-		</div>
-
-		<!-- LOGOS -->
-		<div class="row">
-
-			<div>Logos
-		   		<span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Change the logos located on the student side in the top left and top right corners. The recommended size is 50 x 150 pixels."></span>
-			</div>
-
-			<div class="row">
-
-				<div class="col-sm-4">
-					<div class="logo-wraper">
-						<p>
-							Left Logo
-							<span
-								class="glyphicon glyphicon-refresh color-reset"
-								ng-click="resetLogo('left_logo')">
-							</span>
-						</p>
-
-						<img ng-src="{{modalData.logoLeft}}" class="logo-preview">
-					</div>
-
-				</div>
-
-				<div class="col-sm-4">
-					<div class="logo-wraper">
-						<p>
-							Right Logo
-							<span
-								class="glyphicon glyphicon-refresh color-reset"
-								ng-click="resetLogo('right_logo')">
-							</span>
-						</p>
-						<img ng-src="{{modalData.logoRight}}" class="logo-preview">
-					</div>
-
-				</div>
-
-
-				<div class="col-sm-4">
-					<dropzone file-model="modalData.newLogo.file" id="rightLogoDrop" text="uploadDataText" patterns="uploadDataPattern" drop-method="previewLogo(files)"></dropzone>
-				</div>
-
-			</div>
-
-		</div>
-
-		<modal
-			modal-id="newLogoConfirmUploadModal"
-   		modal-view="views/modals/settings/newLogoConfirmUploadModal.html"
- 			modal-header-class="modal-header-primary"
-   		modal-data="modalData">
-		</modal>
-
-		<!-- CUSTOM CSS -->
-		<lockingtextarea
-	    label="Custom CSS"
-			hint="Customize any styling on the student side using CSS."
-			scope-value="settings.configurable.lookAndFeel.custom_css.value"
-			on-blur="updateConfiguration('lookAndFeel', 'custom_css')"
-    	key-down="confirmEdit(event, prop)"
-    	wysiwyg="false">
- 		</lockingtextarea>
-
-		<!-- FRONT PAGE INSTRUCTIONS BEFORE BUTTON -->
-		<lockingtextarea
-	    label="Front Page Instructions (before button)"
-			hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
-			scope-value="settings.configurable.lookAndFeel.front_page_instructions_before.value"
-			on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_before')"
-    	key-down="confirmEdit(event, prop)">
- 		</lockingtextarea>
-
-   		<!-- FRONT PAGE INSTRUCTIONS AFTER BUTTON -->
-		<lockingtextarea
-	    label="Front Page Instructions (after button)"
-			hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
-			scope-value="settings.configurable.lookAndFeel.front_page_instructions_after.value"
-			on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_after')"
-    	key-down="confirmEdit(event, prop)">
- 		</lockingtextarea>
-
-   		<!-- POST SUBMISSION INSTRUCTIONS -->
-		<lockingtextarea
-	    label="Post Submission Instructions"
-			hint="These instructions will be shown on the confirmation page after a student has completed their submission. New lines are converted to paragraphs automatically."
-			scope-value="settings.configurable.lookAndFeel.post_submission_instructions.value"
-			on-blur="updateConfiguration('lookAndFeel', 'post_submission_instructions')"
-    	key-down="confirmEdit(event, prop)">
- 		</lockingtextarea>
-
-		<!-- POST CORRECTION INSTRUCTIONS-->
-		<lockingtextarea
-	  	label="Post Correction Instructions"
-			hint="These instructions are shown on the confirmation page after a student has submitted corrections for their submission. New lines are converted to paragraphs automatically."
-			scope-value="settings.configurable.lookAndFeel.post_correction_instructions.value"
-			on-blur="updateConfiguration('lookAndFeel', 'post_correction_instructions')"
-    	key-down="confirmEdit(event, prop)">
- 		</lockingtextarea>
-
-	</form>
+  <form name="look-and-feel">
+    <div class="row">
+      <div class="col-sm-6 col-lg-9">
+
+        <div class="row look-and-feel-h1">
+          <div>Text
+             <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the default text color for the application."></span>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h2">
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Main Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','text_main_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','text_main_color')"
+                  ng-model="settings.configurable.lookAndFeel.text_main_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.text_main_color.value}">
+                  <input
+                    type="color"
+                    name="text_main_color"
+                    ng-model="settings.configurable.lookAndFeel.text_main_color.value"
+                    ng-change="updateHexValue('lookAndFeel','text_main_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h1">
+          <div>Header/Footer
+            <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors for the header and footer. The main color (default #1B333F) fades into the highlight color (default #43606E)."></span>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h2">
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Background Main Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','background_main_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','background_main_color')"
+                  ng-model="settings.configurable.lookAndFeel.background_main_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_main_color.value}">
+                  <input
+                    type="color"
+                    name="background_main_color"
+                    ng-model="settings.configurable.lookAndFeel.background_main_color.value"
+                    ng-change="updateHexValue('lookAndFeel','background_main_color')"/>
+                </label>
+              </span>
+
+            </div>
+
+          </div>
+
+          <div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
+            <div class="row">
+              <span>Background Highlight Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','background_highlight_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','background_highlight_color')"
+                  ng-model="settings.configurable.lookAndFeel.background_highlight_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_highlight_color.value}">
+                  <input
+                    type="color"
+                    name="background_highlight_color"
+                    ng-model="settings.configurable.lookAndFeel.background_highlight_color.value"
+                    ng-change="updateHexValue('lookAndFeel','background_highlight_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Header Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','background_header_text_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','background_header_text_color')"
+                  ng-model="settings.configurable.lookAndFeel.background_header_text_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_header_text_color.value}">
+                  <input
+                    type="color"
+                    name="background_header_text_color"
+                    ng-model="settings.configurable.lookAndFeel.background_header_text_color.value"
+                    ng-change="updateHexValue('lookAndFeel','background_header_text_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Footer Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','background_footer_text_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','background_footer_text_color')"
+                  ng-model="settings.configurable.lookAndFeel.background_footer_text_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.background_footer_text_color.value}">
+                  <input
+                    type="color"
+                    name="background_footer_text_color"
+                    ng-model="settings.configurable.lookAndFeel.background_footer_text_color.value"
+                    ng-change="updateHexValue('lookAndFeel','background_footer_text_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-1 col-lg-5"></div>
+        </div>
+
+
+        <div class="row look-and-feel-h1">
+          <div>Submission Step Button (On)
+              <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the submission step buttons for the selected step or on hover. The main color (default #1B333F) fades into the highlight color (default #43606E) and then back to the main color."></span>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h2">
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Background Main Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_main_color_on')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_main_color_on')"
+                  ng-model="settings.configurable.lookAndFeel.button_main_color_on.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_main_color_on.value}">
+                  <input
+                    type="color"
+                    name="button_main_color_on"
+                    ng-model="settings.configurable.lookAndFeel.button_main_color_on.value"
+                    ng-change="updateHexValue('lookAndFeel','button_main_color_on')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+
+          <div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
+            <div class="row">
+              <span>Background Highlight Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_highlight_color_on')">
+                </span>
+              </span>
+            </div>
+
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_highlight_color_on')"
+                  ng-model="settings.configurable.lookAndFeel.button_highlight_color_on.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label
+                  class="color-selector-swatch"
+                  ng-style="{background: settings.configurable.lookAndFeel.button_highlight_color_on.value}">
+                  <input
+                    type="color"
+                    name="button_highlight_color_on"
+                    ng-model="settings.configurable.lookAndFeel.button_highlight_color_on.value"
+                    ng-change="updateHexValue('lookAndFeel','button_highlight_color_on')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_text_color_on')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_text_color_on')"
+                  ng-model="settings.configurable.lookAndFeel.button_text_color_on.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_text_color_on.value}">
+                  <input
+                    type="color"
+                    name="button_text_color_on"
+                    ng-model="settings.configurable.lookAndFeel.button_text_color_on.value"
+                    ng-change="updateHexValue('lookAndFeel','button_text_color_on')"/>
+                </label>
+              </span>
+
+            </div>
+
+          </div>
+          <div class="col-md-1 col-lg-5"></div>
+        </div>
+
+
+        <div class="row look-and-feel-h1">
+          <div>Submission Step Button (Off)
+              <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the submission step buttons when not selected. The main color (default #424D46) fades into the highlight color (default #697A70) and then back to the main color."></span>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h2">
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Background Main Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_main_color_off')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+              <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_main_color_off')"
+                  ng-model="settings.configurable.lookAndFeel.button_main_color_off.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label
+                  class="color-selector-swatch"
+                  ng-style="{background: settings.configurable.lookAndFeel.button_main_color_off.value}">
+                  <input
+                    type="color"
+                    name="button_main_color_off"
+                    ng-model="settings.configurable.lookAndFeel.button_main_color_off.value"
+                    ng-change="updateHexValue('lookAndFeel','button_main_color_off')"/>
+                </label>
+              </span>
+
+            </div>
+
+          </div>
+
+
+          <div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
+            <div class="row">
+              <span>Background Highlight Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_highlight_color_off')">
+                </span>
+              </span>
+            </div>
+
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_highlight_color_off')"
+                  ng-model="settings.configurable.lookAndFeel.button_highlight_color_off.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label
+                  class="color-selector-swatch"
+                  ng-style="{background: settings.configurable.lookAndFeel.button_highlight_color_off.value}">
+                  <input
+                    type="color"
+                    name="button_highlight_color_off"
+                    ng-model="settings.configurable.lookAndFeel.button_highlight_color_off.value"
+                    ng-change="updateHexValue('lookAndFeel','button_highlight_color_off')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','button_text_color_off')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','button_text_color_off')"
+                  ng-model="settings.configurable.lookAndFeel.button_text_color_off.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.button_text_color_off.value}">
+                  <input
+                    type="color"
+                    name="button_text_color_off"
+                    ng-model="settings.configurable.lookAndFeel.button_text_color_off.value"
+                    ng-change="updateHexValue('lookAndFeel','button_text_color_off')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-1 col-lg-5"></div>
+        </div>
+
+        <div class="row look-and-feel-h1">
+          <div>Admin Navigation Tab
+              <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Use hex color values to change the background and text colors of the tabs in the admin interface (top of the current page). The main color (default #ADBDAA) is the background color for tabs not selected. The selected color (default #FFFFFF) is the backgound color for the selected tab."></span>
+          </div>
+        </div>
+
+        <div class="row look-and-feel-h2">
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Background Main Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','admin_tab_main_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+              <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','admin_tab_main_color')"
+                  ng-model="settings.configurable.lookAndFeel.admin_tab_main_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label
+                  class="color-selector-swatch"
+                  ng-style="{background: settings.configurable.lookAndFeel.admin_tab_main_color.value}">
+                  <input
+                    type="color"
+                    name="admin_tab_main_color"
+                    ng-model="settings.configurable.lookAndFeel.admin_tab_main_color.value"
+                    ng-change="updateHexValue('lookAndFeel','admin_tab_main_color')"/>
+                </label>
+              </span>
+
+            </div>
+
+          </div>
+
+
+          <div class="col-md-5 col-lg-3 col-md-offset-1 col-lg-offset-0">
+            <div class="row">
+              <span>Background Selected Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','admin_tab_selected_color')">
+                </span>
+              </span>
+            </div>
+
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','admin_tab_selected_color')"
+                  ng-model="settings.configurable.lookAndFeel.admin_tab_selected_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label
+                  class="color-selector-swatch"
+                  ng-style="{background: settings.configurable.lookAndFeel.admin_tab_selected_color.value}">
+                  <input
+                    type="color"
+                    name="admin_tab_selected_color"
+                    ng-model="settings.configurable.lookAndFeel.admin_tab_selected_color.value"
+                    ng-change="updateHexValue('lookAndFeel','admin_tab_selected_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Main Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','admin_tab_main_text_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','admin_tab_main_text_color')"
+                  ng-model="settings.configurable.lookAndFeel.admin_tab_main_text_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.admin_tab_main_text_color.value}">
+                  <input
+                    type="color"
+                    name="admin_tab_main_text_color"
+                    ng-model="settings.configurable.lookAndFeel.admin_tab_main_text_color.value"
+                    ng-change="updateHexValue('lookAndFeel','admin_tab_main_text_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-5 col-lg-3">
+            <div class="row">
+              <span>Selected Text Color
+                <span
+                  class="glyphicon glyphicon-refresh color-reset"
+                  ng-click="resetConfiguration('lookAndFeel','admin_tab_selected_text_color')">
+                </span>
+              </span>
+            </div>
+
+            <div class="input-group color-selector">
+              <span class="input-group-addon">#</span>
+                <input
+                  class="form-control color-input"
+                  ng-change="updateHexValue('lookAndFeel','admin_tab_selected_text_color')"
+                  ng-model="settings.configurable.lookAndFeel.admin_tab_selected_text_color.value"
+                  dehashcolor>
+
+              <span class="input-group-addon">
+                <label class="color-selector-swatch" ng-style="{background: settings.configurable.lookAndFeel.admin_tab_selected_text_color.value}">
+                  <input
+                    type="color"
+                    name="admin_tab_selected_text_color"
+                    ng-model="settings.configurable.lookAndFeel.admin_tab_selected_text_color.value"
+                    ng-change="updateHexValue('lookAndFeel','admin_tab_selected_text_color')"/>
+                </label>
+              </span>
+            </div>
+          </div>
+          <div class="col-md-1 col-lg-5"></div>
+        </div>
+      </div>
+
+
+      <div class="col-sm-6 col-lg-3">
+      </div>
+    </div>
+
+    <!-- LOGOS -->
+    <div class="row">
+
+      <div>Logos
+          <span class="glyphicon glyphicon-info-sign opaque color-reset" tooltip="Change the logos located on the student side in the top left and top right corners. The recommended size is 50 x 150 pixels."></span>
+      </div>
+
+      <div class="row">
+
+        <div class="col-sm-4">
+          <div class="logo-wraper">
+            <p>
+              Left Logo
+              <span
+                class="glyphicon glyphicon-refresh color-reset"
+                ng-click="resetLogo('left_logo')">
+              </span>
+            </p>
+
+            <img ng-src="{{modalData.logoLeft}}" class="logo-preview">
+          </div>
+
+        </div>
+
+        <div class="col-sm-4">
+          <div class="logo-wraper">
+            <p>
+              Right Logo
+              <span
+                class="glyphicon glyphicon-refresh color-reset"
+                ng-click="resetLogo('right_logo')">
+              </span>
+            </p>
+            <img ng-src="{{modalData.logoRight}}" class="logo-preview">
+          </div>
+
+        </div>
+
+
+        <div class="col-sm-4">
+          <dropzone file-model="modalData.newLogo.file" id="rightLogoDrop" text="uploadDataText" patterns="uploadDataPattern" drop-method="previewLogo(files)"></dropzone>
+        </div>
+
+      </div>
+
+    </div>
+
+    <modal
+      modal-id="newLogoConfirmUploadModal"
+      modal-view="views/modals/settings/newLogoConfirmUploadModal.html"
+      modal-header-class="modal-header-primary"
+      modal-data="modalData">
+    </modal>
+
+    <!-- CUSTOM CSS -->
+    <lockingtextarea
+      label="Custom CSS"
+      hint="Customize any styling on the student side using CSS."
+      scope-value="settings.configurable.lookAndFeel.custom_css.value"
+      on-blur="updateConfiguration('lookAndFeel', 'custom_css')"
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
+    </lockingtextarea>
+
+    <!-- FRONT PAGE INSTRUCTIONS BEFORE BUTTON -->
+    <lockingtextarea
+      label="Front Page Instructions (before button)"
+      hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
+      scope-value="settings.configurable.lookAndFeel.front_page_instructions_before.value"
+      on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_before')"
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
+    </lockingtextarea>
+
+      <!-- FRONT PAGE INSTRUCTIONS AFTER BUTTON -->
+    <lockingtextarea
+      label="Front Page Instructions (after button)"
+      hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
+      scope-value="settings.configurable.lookAndFeel.front_page_instructions_after.value"
+      on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_after')"
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
+    </lockingtextarea>
+
+      <!-- POST SUBMISSION INSTRUCTIONS -->
+    <lockingtextarea
+      label="Post Submission Instructions"
+      hint="These instructions will be shown on the confirmation page after a student has completed their submission. New lines are converted to paragraphs automatically."
+      scope-value="settings.configurable.lookAndFeel.post_submission_instructions.value"
+      on-blur="updateConfiguration('lookAndFeel', 'post_submission_instructions')"
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
+    </lockingtextarea>
+
+    <!-- POST CORRECTION INSTRUCTIONS-->
+    <lockingtextarea
+      label="Post Correction Instructions"
+      hint="These instructions are shown on the confirmation page after a student has submitted corrections for their submission. New lines are converted to paragraphs automatically."
+      scope-value="settings.configurable.lookAndFeel.post_correction_instructions.value"
+      on-blur="updateConfiguration('lookAndFeel', 'post_correction_instructions')"
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
+    </lockingtextarea>
+
+  </form>
 
 </div>


### PR DESCRIPTION
resolves #1776

When the default is missing, the `=== 'wysiwyg'` and `!== 'wysiwyg'` checks fail to work as expected.

The white space is fixed, removin tabbing.
Please use the hide white space option to see the relevant differences.