### PR TITLE
Change xom dependency to address javax.xml.parsers is accessible in multiple modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,18 @@
     </dependency>
 
     <dependency>
+      <groupId>com.io7m.xom</groupId>
+      <artifactId>xom</artifactId>
+      <version>1.2.10</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.swordapp</groupId>
       <artifactId>sword-common</artifactId>
       <version>1.1</version>
@@ -186,6 +198,10 @@
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xom</groupId>
+          <artifactId>xom</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
This is the error Eclipse is showing:
```
The package "javax.xml.parsers" is accessible from more than one module: <unnamed>, java.xml
```

This is not helpful, as `unnamed` is rather useless for debugging.

Used this command to identify where the `javax.xml.parsers` is being brought in.
```
mvn dependency:copy-dependencies -DincludeScope=test -DoutputDirectory=deps
```
Did a search inside the `deps/` directory for the `javax.xml.parsers` inclusion. This showed that the `xml-apis` is bringing in a duplicate and older dependency. Excluding `xom` and manually including it allows for excluding the `xml-apis`. The mvnrepository.com shows that `xom` moved from https://mvnrepository.com/artifact/xom/xom to https://mvnrepository.com/artifact/com.io7m.xom/xom .

The `xom` dependency change happened here: 018e460b81b08c6fd35b26992cde71ab637d9d22 for issue #1772.