### PR TITLE
Issue 1666: Remove hard-coded Advisor from organization e-mail list.

### DIFF
--- a/src/main/webapp/app/filters/withoutAdvisor.js
+++ b/src/main/webapp/app/filters/withoutAdvisor.js
@@ -1,0 +1,17 @@
+vireo.filter('withoutAdvisor', function() {
+    return function(recipients) {
+        if (typeof recipients != 'object') {
+            return recipients;
+        }
+
+        var reduced = [];
+
+        for (var i = 0; i < recipients.length; i++) {
+            if (recipients[i].type != 'ADVISOR') {
+                reduced.push(recipients[i]);
+            }
+        }
+
+        return reduced;
+    };
+});

--- a/src/main/webapp/app/views/modals/organization/emailWorkflowRuleCreate.html
+++ b/src/main/webapp/app/views/modals/organization/emailWorkflowRuleCreate.html
@@ -1,63 +1,63 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-	<button type="button" class="close" ng-click="resetEmailWorkflowRule()" data-dismiss="modal" aria-label="Close">
-		<span class="modal-close" aria-hidden="true">&times;</span>
-	</button>
-	<h3 class="modal-title">Add Email Workflow Rule to {{status.name}}</h3>
+    <button type="button" class="close" ng-click="resetEmailWorkflowRule()" data-dismiss="modal" aria-label="Close">
+        <span class="modal-close" aria-hidden="true">&times;</span>
+    </button>
+    <h3 class="modal-title">Add Email Workflow Rule to {{status.name}}</h3>
 </div>
 
 <form ng-submit="addEmailWorkflowRule(newTemplate,newRecipient,status)" name="forms.add" novalidate>
 
-	<div class="addRecipientModal modal-body">
-		<div class="row">
-			<div class="col-xs-6">
-				<div class="form-group">
-					<label>Email Template</label>
-					 <select
-	                	class="form-control"
-	                	name="newTemplate"
-	                	ng-model="newTemplate"
-	                	ng-options="t.name for t in emailTemplates">
-	                </select>
-				</div>
-			</div>
-			<div class="col-xs-6">
-				<div class="form-group">
-					<label>Recipient</label>
-					<select
-	                	class="form-control"
-	                	name="newRecipient"
-	                	ng-model="newRecipient"
-	                	ng-options="r as r.name for r in recipients">
-	                </select>
-				</div>
-			</div>
-		</div>
-		<div class="row email-workflow-rule-section" ng-class="{'email-workflow-rule-open': newRecipient.type==emailRecipientType.ORGANIZATION, 'email-workflow-rule-closed': newRecipient.type!=emailRecipientType.ORGANIZATION}">
-			<div class="col-xs-12">
-				<label for="organizationName">Organization Name</label>
-				<input 	id="organizationName"
-						class="form-control"
-						ng-model="newRecipient.data"
-						typeahead-append-to="'.addRecipientModal .typeahead-dropdown-container'"
-						uib-typeahead="o as o.name for o in organizations | filter:{name:$viewValue} | limitTo:8"
-				/>
-				<div class="typeahead-dropdown-container"></div>
-			</div>
-		</div>
-	</div>
+    <div class="addRecipientModal modal-body">
+        <div class="row">
+            <div class="col-xs-6">
+                <div class="form-group">
+                    <label>Email Template</label>
+                     <select
+                        class="form-control"
+                        name="newTemplate"
+                        ng-model="newTemplate"
+                        ng-options="t.name for t in emailTemplates">
+                    </select>
+                </div>
+            </div>
+            <div class="col-xs-6">
+                <div class="form-group">
+                    <label>Recipient</label>
+                    <select
+                        class="form-control"
+                        name="newRecipient"
+                        ng-model="newRecipient"
+                        ng-options="r as r.name for r in recipients | withoutAdvisor">
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="row email-workflow-rule-section" ng-class="{'email-workflow-rule-open': newRecipient.type==emailRecipientType.ORGANIZATION, 'email-workflow-rule-closed': newRecipient.type!=emailRecipientType.ORGANIZATION}">
+            <div class="col-xs-12">
+                <label for="organizationName">Organization Name</label>
+                <input  id="organizationName"
+                        class="form-control"
+                        ng-model="newRecipient.data"
+                        typeahead-append-to="'.addRecipientModal .typeahead-dropdown-container'"
+                        uib-typeahead="o as o.name for o in organizations | filter:{name:$viewValue} | limitTo:8"
+                />
+                <div class="typeahead-dropdown-container"></div>
+            </div>
+        </div>
+    </div>
 
-	<div class="modal-footer">
-		<button
-			type="button"
-			class="btn btn-default"
-			ng-click="resetEmailWorkflowRule()">
-			Cancel
-		</button>
-		<button
-			type="submit"
-			class="btn btn-primary"
-			ng-disabled="forms.add.$invalid || (newRecipient.type=='Organization' && !newRecipient.data.id)">
-			Add
-		</button>
-	</div>
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-default"
+            ng-click="resetEmailWorkflowRule()">
+            Cancel
+        </button>
+        <button
+            type="submit"
+            class="btn btn-primary"
+            ng-disabled="forms.add.$invalid || (newRecipient.type=='Organization' && !newRecipient.data.id)">
+            Add
+        </button>
+    </div>
 </form>

--- a/src/main/webapp/app/views/modals/organization/emailWorkflowRuleEdit.html
+++ b/src/main/webapp/app/views/modals/organization/emailWorkflowRuleEdit.html
@@ -1,64 +1,64 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-	<button type="button" class="close" ng-click="resetEditEmailWorkflowRule()" data-dismiss="modal" aria-label="Close">
-		<span class="modal-close" aria-hidden="true">&times;</span>
-	</button>
-	<h3 class="modal-title">Edit Email Workflow Rule</h3>
+    <button type="button" class="close" ng-click="resetEditEmailWorkflowRule()" data-dismiss="modal" aria-label="Close">
+        <span class="modal-close" aria-hidden="true">&times;</span>
+    </button>
+    <h3 class="modal-title">Edit Email Workflow Rule</h3>
 </div>
 
 <form ng-submit="editEmailWorkflowRule(rule)" name="forms.add" novalidate>
 
-	<div class="addRecipientModal modal-body">
-		<div class="row">
-			<div class="col-xs-6">
-				<div class="form-group">
-					<label>Email Template</label>
-					 <select 
-	                	class="form-control" 
-	                	name="editTemplate"
-	                	ng-model="emailWorkflowRuleToEdit.emailTemplate" 
-	                	ng-options="t.name for t in emailTemplates">
-	                	<option>Select new template</option>
-	                </select>
-				</div>
-			</div>
-			<div class="col-xs-6">
-				<div class="form-group">
-					<label>Recipient</label>
-					<select 
-	                	class="form-control" 
-	                	name="editRecipient"
-	                	ng-model="emailWorkflowRuleToEdit.emailRecipient"
-	                	ng-options="r as r.name for r in recipients">
-	                </select>
-				</div>
-			</div>
-		</div>
-		<div class="row email-workflow-rule-section" ng-class="{'email-workflow-rule-open': emailWorkflowRuleToEdit.emailRecipient.type==emailRecipientType.ORGANIZATION, 'email-workflow-rule-closed': emailWorkflowRuleToEdit.emailRecipient.type!=emailRecipientType.ORGANIZATION}">
-			<div class="col-xs-12">
-				<label for="organizationName">Organization Name</label>
-				<input 	id="organizationName"
-						class="form-control" 
-						ng-model="emailWorkflowRuleToEdit.emailRecipient.data"
-						typeahead-append-to="'.addRecipientModal .typeahead-dropdown-container'"
-						uib-typeahead="o as o.name for o in organizations | filter:{name:$viewValue} | limitTo:8"
-				/>
-				<div class="typeahead-dropdown-container"></div>
-			</div>
-		</div>
-	</div>
+    <div class="addRecipientModal modal-body">
+        <div class="row">
+            <div class="col-xs-6">
+                <div class="form-group">
+                    <label>Email Template</label>
+                     <select
+                        class="form-control"
+                        name="editTemplate"
+                        ng-model="emailWorkflowRuleToEdit.emailTemplate"
+                        ng-options="t.name for t in emailTemplates">
+                        <option>Select new template</option>
+                    </select>
+                </div>
+            </div>
+            <div class="col-xs-6">
+                <div class="form-group">
+                    <label>Recipient</label>
+                    <select
+                        class="form-control"
+                        name="editRecipient"
+                        ng-model="emailWorkflowRuleToEdit.emailRecipient"
+                        ng-options="r as r.name for r in recipients | withoutAdvisor">
+                    </select>
+                </div>
+            </div>
+        </div>
+        <div class="row email-workflow-rule-section" ng-class="{'email-workflow-rule-open': emailWorkflowRuleToEdit.emailRecipient.type==emailRecipientType.ORGANIZATION, 'email-workflow-rule-closed': emailWorkflowRuleToEdit.emailRecipient.type!=emailRecipientType.ORGANIZATION}">
+            <div class="col-xs-12">
+                <label for="organizationName">Organization Name</label>
+                <input  id="organizationName"
+                        class="form-control"
+                        ng-model="emailWorkflowRuleToEdit.emailRecipient.data"
+                        typeahead-append-to="'.addRecipientModal .typeahead-dropdown-container'"
+                        uib-typeahead="o as o.name for o in organizations | filter:{name:$viewValue} | limitTo:8"
+                />
+                <div class="typeahead-dropdown-container"></div>
+            </div>
+        </div>
+    </div>
 
-	<div class="modal-footer">
-		<button 
-			type="button" 
-			class="btn btn-default" 
-			ng-click="resetEmailWorkflowRule()">
-			Cancel
-		</button>
-		<button 
-			type="submit" 
-			class="btn btn-primary" 
-			ng-disabled="forms.add.$invalid || (editRecipient.type=='Organization' && !editRecipient.data.id)">
-			Confirm
-		</button>
-	</div>	
+    <div class="modal-footer">
+        <button
+            type="button"
+            class="btn btn-default"
+            ng-click="resetEmailWorkflowRule()">
+            Cancel
+        </button>
+        <button
+            type="submit"
+            class="btn btn-primary"
+            ng-disabled="forms.add.$invalid || (editRecipient.type=='Organization' && !editRecipient.data.id)">
+            Confirm
+        </button>
+    </div>
 </form>


### PR DESCRIPTION
resolves #1666

This takes a simple approach by just hiding the `ADVISOR` type from the create/edit modal for e-mails.
This has a side-effect of causing the built-in "SYSTEM Initial Submission" from displaying the selection ~as that appears to select `ADVISOR` by default~ (edit: It looks like "SYSTEM Initial Submission" is always empty by default and does not use `ADVISOR`).
The "SYSTEM Advisor Review Request" is unaffected because it assigns `Committee Chair` by default.

The previous commit ab8238dbc5131e5b44ccee9299c4881e69725cb0 revealed that simply removing `ADVISOR` exposes a large amount of hard-coded behavior.
This approach is abandoned given the amount of hard-coded references and uses of `ADVISOR` and the specific fix strategy being requested. The mentioned commit reveals some of the problems such as the system templates, like "SYSTEM Initial Submission", stop appearing.

There are numerous concerns about the hard-coded behavior around `ADVISOR`.
The following are two major areas to pay attention to:
- https://github.com/TexasDigitalLibrary/Vireo/blob/3bf83e24cddf228dcf032e47410a2155a8d9f902/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js#L121
- https://github.com/TexasDigitalLibrary/Vireo/blob/3bf83e24cddf228dcf032e47410a2155a8d9f902/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js#L405