### PR TITLE
Issue 1756: Increase batch size in ControlledVocabulary and use SUBSELECT in VocabularyWord.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
+++ b/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
@@ -1,15 +1,18 @@
 package org.tdl.vireo.model;
 
 import static javax.persistence.CascadeType.ALL;
-import static javax.persistence.FetchType.EAGER;
+import static javax.persistence.FetchType.LAZY;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonView;
+import edu.tamu.weaver.context.SpringContext;
+import edu.tamu.weaver.validation.model.ValidatingOrderedBaseEntity;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
-
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.slf4j.Logger;
@@ -18,12 +21,6 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.ControlledVocabularyValidator;
 import org.tdl.vireo.service.EntityControlledVocabularyService;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonView;
-
-import edu.tamu.weaver.context.SpringContext;
-import edu.tamu.weaver.validation.model.ValidatingOrderedBaseEntity;
 
 @Entity
 @Configurable
@@ -37,8 +34,9 @@ public class ControlledVocabulary extends ValidatingOrderedBaseEntity {
     private String name;
 
     @JsonView(Views.SubmissionIndividual.class)
-    @OneToMany(cascade = { ALL }, fetch = EAGER, mappedBy = "controlledVocabulary", orphanRemoval = true)
+    @OneToMany(cascade = { ALL }, fetch = LAZY, mappedBy = "controlledVocabulary", orphanRemoval = true)
     @Fetch(FetchMode.SELECT)
+    @BatchSize(size=1000)
     private List<VocabularyWord> dictionary;
 
     @JsonView(Views.SubmissionIndividual.class)

--- a/src/main/java/org/tdl/vireo/model/VocabularyWord.java
+++ b/src/main/java/org/tdl/vireo/model/VocabularyWord.java
@@ -2,28 +2,26 @@ package org.tdl.vireo.model;
 
 import static javax.persistence.CascadeType.DETACH;
 import static javax.persistence.CascadeType.REFRESH;
-import static javax.persistence.FetchType.EAGER;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
-
-import org.tdl.vireo.model.response.Views;
-import org.tdl.vireo.model.validation.VocabularyWordValidator;
+import static javax.persistence.FetchType.LAZY;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.tdl.vireo.model.response.Views;
+import org.tdl.vireo.model.validation.VocabularyWordValidator;
 
 @Entity
 @JsonIgnoreProperties(value = { "controlledVocabulary" }, allowGetters = true)
@@ -42,11 +40,11 @@ public class VocabularyWord extends ValidatingBaseEntity {
     @Column(nullable = true)
     private String identifier;
 
-    @JsonView(Views.SubmissionIndividual.class)
-    @ElementCollection(fetch = EAGER)
+    @ElementCollection(fetch = LAZY)
+    @Fetch(FetchMode.SUBSELECT)
     private List<String> contacts;
 
-    @ManyToOne(cascade = { DETACH, REFRESH }, fetch = EAGER, optional = false)
+    @ManyToOne(cascade = { DETACH, REFRESH }, fetch = LAZY, optional = false)
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = ControlledVocabulary.class, property = "id")
     @JsonIdentityReference(alwaysAsId = true)
     private ControlledVocabulary controlledVocabulary;

--- a/src/test/java/org/tdl/vireo/model/ControlledVocabularyTest.java
+++ b/src/test/java/org/tdl/vireo/model/ControlledVocabularyTest.java
@@ -3,15 +3,17 @@ package org.tdl.vireo.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class ControlledVocabularyTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testCreate() throws ClassNotFoundException {
         controlledVocabulary = controlledVocabularyRepo.create(TEST_CONTROLLED_VOCABULARY_NAME);
         assertEquals(1, controlledVocabularyRepo.count(), "The repository did not save the entity!");
@@ -42,6 +44,7 @@ public class ControlledVocabularyTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testDuplication() {
         controlledVocabulary = controlledVocabularyRepo.create(TEST_CONTROLLED_VOCABULARY_NAME);
         try {
@@ -57,6 +60,7 @@ public class ControlledVocabularyTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testDelete() {
         controlledVocabulary = controlledVocabularyRepo.create(TEST_CONTROLLED_VOCABULARY_NAME);
         controlledVocabularyRepo.delete(controlledVocabulary);
@@ -65,6 +69,7 @@ public class ControlledVocabularyTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testCascade() {
         controlledVocabulary = controlledVocabularyRepo.create(TEST_CONTROLLED_VOCABULARY_NAME);
 
@@ -87,17 +92,6 @@ public class ControlledVocabularyTest extends AbstractEntityTest {
         controlledVocabularyRepo.delete(controlledVocabulary);
         assertEquals(0, vocabularyWordRepo.count(), "Vocabulary word was orphaned!");
         assertEquals(0, controlledVocabularyRepo.count(), "The entity was not deleted!");
-    }
-
-    @AfterEach
-    public void cleanUp() {
-        controlledVocabularyRepo.findAll().forEach(cv -> {
-            controlledVocabularyRepo.delete(cv);
-        });
-        vocabularyWordRepo.findAll().forEach(vw -> {
-            vocabularyWordRepo.delete(vw);
-        });
-        embargoRepo.deleteAll();
     }
 
 }

--- a/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
+++ b/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
@@ -62,7 +62,7 @@ public class DocumentTypeTest extends AbstractEntityTest {
     }
 
     @Test
-    @Disabled // FIXME: This function's name suggested testing the delete, but all this does is call create.
+    @Disabled // FIXME: This no longer throws an exception and the previous DataIntegrityViolationException exception may have been a false positive due to a lack of a transaction.
     @Transactional(propagation = Propagation.NESTED)
     public void testFieldPredicateDeleteFailure() {
         DocumentType documentType = documentTypeRepo.create(TEST_DOCUMENT_TYPE_NAME);

--- a/src/test/java/org/tdl/vireo/model/VocabularyWordTest.java
+++ b/src/test/java/org/tdl/vireo/model/VocabularyWordTest.java
@@ -2,21 +2,24 @@ package org.tdl.vireo.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(propagation = Propagation.REQUIRES_NEW)
 public class VocabularyWordTest extends AbstractEntityTest {
 
     @BeforeEach
-    public void setUp() {
-        assertEquals(0, vocabularyWordRepo.count(), "VocabularyWord repo was not empty!");
+    public void setup() {
         controlledVocabulary = controlledVocabularyRepo.create(TEST_CONTROLLED_VOCABULARY_NAME);
     }
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testCreate() {
         vocabularyWord = vocabularyWordRepo.create(controlledVocabulary, TEST_CONTROLLED_VOCABULARY_WORD, TEST_CONTROLLED_VOCABULARY_DEFINITION, TEST_CONTROLLED_VOCABULARY_IDENTIFIER);
         assertEquals(1, vocabularyWordRepo.count(), "VocabularyWord Repo did not save the vocab word!");
@@ -27,16 +30,17 @@ public class VocabularyWordTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void testDuplication() {
         vocabularyWordRepo.create(controlledVocabulary, TEST_CONTROLLED_VOCABULARY_WORD, TEST_CONTROLLED_VOCABULARY_DEFINITION, TEST_CONTROLLED_VOCABULARY_IDENTIFIER);
-        try {
+        Assertions.assertThrows(DataIntegrityViolationException.class, () -> {
             vocabularyWordRepo.create(controlledVocabulary, TEST_CONTROLLED_VOCABULARY_WORD, TEST_CONTROLLED_VOCABULARY_DEFINITION, TEST_CONTROLLED_VOCABULARY_IDENTIFIER);
-        } catch (DataIntegrityViolationException e) { /* SUCCESS */ }
-        assertEquals(1, vocabularyWordRepo.count(), "The repository persisted duplicate vocabulary words with the same name and controlled vocabulary!");
+        });
     }
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testDelete() {
         vocabularyWord = vocabularyWordRepo.create(controlledVocabulary, TEST_CONTROLLED_VOCABULARY_WORD, TEST_CONTROLLED_VOCABULARY_DEFINITION, TEST_CONTROLLED_VOCABULARY_IDENTIFIER);
         vocabularyWordRepo.delete(vocabularyWord);
@@ -45,21 +49,12 @@ public class VocabularyWordTest extends AbstractEntityTest {
 
     @Override
     @Test
+    @Transactional(propagation = Propagation.REQUIRED)
     public void testCascade() {
         vocabularyWord = vocabularyWordRepo.create(controlledVocabulary, TEST_CONTROLLED_VOCABULARY_WORD, TEST_CONTROLLED_VOCABULARY_DEFINITION, TEST_CONTROLLED_VOCABULARY_IDENTIFIER);
         vocabularyWordRepo.delete(vocabularyWord);
         assertEquals(0, vocabularyWordRepo.count(), "Vocabulary word did not delete!");
         assertEquals(1, controlledVocabularyRepo.count(), "The controlled vocabulary was deleted!");
-    }
-
-    @AfterEach
-    public void cleanUp() {
-        controlledVocabularyRepo.findAll().forEach(cv -> {
-            controlledVocabularyRepo.delete(cv);
-        });
-        vocabularyWordRepo.findAll().forEach(vw -> {
-            vocabularyWordRepo.delete(vw);
-        });
     }
 
 }


### PR DESCRIPTION
resolves #1756

The `ControlledVocabulary` is switched to `LAZY` and sets the batch size to 1000 for the dictionary property.
The increased batch size should reduce the amount of queries for larger data sets.
The `LAZY` is set to not immediately load the dictionary.

A major performance problem is within the `VocabularyWord` Entity where all contacts are loaded.
There may be as many as 20,000 contacts.
Loading every single one as a fully populated Entity Object (and then one at a time) is very costly.
Reduce the impact of this by using a `SUBSELECT`.

Furthermore, use `LAZY` in more properties on the `VocabularyWord` Entity.

This approach does not solve the problem.
Instead, it reduces the impact.
For a set of maybe 17,000 contacts, the loading of a single organization may take up to 22 seconds.
After this change it may take up to 4 seconds.
This is still too long but is far better.

The problem is in how the Entity is being loaded.
Other strategies need to be developed (such as using Projection). Such strategies are not performed within this commit.

With this change, the startup time has been observed to be far more performant.

Before:
```
2023-06-08 15:11:57.644  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default organization
2023-06-08 15:12:34.708  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default controlled vocabularies
2023-06-08 15:13:04.304  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default settings
...
2023-06-08 15:13:04.454  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Proquest subject codes
2023-06-08 15:13:33.848  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Submission List Columns
2023-06-08 15:13:38.652  INFO 41951 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Submission List Columns Filters
```

after:
```
2023-06-08 15:41:28.036  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default organization
2023-06-08 15:41:28.367  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default controlled vocabularies
2023-06-08 15:41:29.231  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default settings
...
2023-06-08 15:41:29.387  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Proquest subject codes
2023-06-08 15:41:30.077  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Submission List Columns
2023-06-08 15:41:30.227  INFO 48653 --- [           main] org.tdl.vireo.service.SystemDataLoader   : Loading default Submission List Columns Filters
```