### PR TITLE
Issue 1756: Use Projection for specific Submission usage.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -100,7 +100,7 @@ import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
-import org.tdl.vireo.view.SimpleSubmissionView;
+import org.tdl.vireo.view.FieldValueSubmissionView;
 
 @RestController
 @RequestMapping("/submission")
@@ -186,7 +186,7 @@ public class SubmissionController {
   @RequestMapping("/all-by-user")
   @PreAuthorize("hasRole('STUDENT')")
   public ApiResponse getAllByUser(@WeaverUser User user) {
-    return new ApiResponse(SUCCESS, submissionRepo.findAllViewBySubmitterId(user.getId(), SimpleSubmissionView.class));
+    return new ApiResponse(SUCCESS, submissionRepo.findAllViewBySubmitterId(user.getId(), FieldValueSubmissionView.class));
   }
 
   @JsonView(Views.SubmissionIndividualActionLogs.class)

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -100,6 +100,7 @@ import org.tdl.vireo.service.SubmissionEmailService;
 import org.tdl.vireo.utility.OrcidUtility;
 import org.tdl.vireo.utility.PackagerUtility;
 import org.tdl.vireo.utility.TemplateUtility;
+import org.tdl.vireo.view.SimpleSubmissionView;
 
 @RestController
 @RequestMapping("/submission")
@@ -185,7 +186,7 @@ public class SubmissionController {
   @RequestMapping("/all-by-user")
   @PreAuthorize("hasRole('STUDENT')")
   public ApiResponse getAllByUser(@WeaverUser User user) {
-    return new ApiResponse(SUCCESS, submissionRepo.findAllBySubmitterId(user.getId()));
+    return new ApiResponse(SUCCESS, submissionRepo.findAllViewBySubmitterId(user.getId(), SimpleSubmissionView.class));
   }
 
   @JsonView(Views.SubmissionIndividualActionLogs.class)

--- a/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/SubmissionRepo.java
@@ -1,17 +1,17 @@
 package org.tdl.vireo.model.repo;
 
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
 import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.custom.SubmissionRepoCustom;
 
-import edu.tamu.weaver.data.model.repo.WeaverRepo;
-
 public interface SubmissionRepo extends WeaverRepo<Submission>, SubmissionRepoCustom {
+
+    public <T> List<T> findAllViewBySubmitterId(Long submitterId, Class<T> type);
 
     public List<Submission> findAllBySubmitterAndOrganization(User submitter, Organization organization);
 

--- a/src/main/java/org/tdl/vireo/view/FieldValueSubmissionView.java
+++ b/src/main/java/org/tdl/vireo/view/FieldValueSubmissionView.java
@@ -1,0 +1,9 @@
+package org.tdl.vireo.view;
+
+import java.util.Set;
+import org.tdl.vireo.model.FieldValue;
+
+public interface FieldValueSubmissionView extends SimpleSubmissionView {
+
+    public Set<FieldValue> getFieldValues();
+}

--- a/src/main/java/org/tdl/vireo/view/SettingsUserView.java
+++ b/src/main/java/org/tdl/vireo/view/SettingsUserView.java
@@ -1,0 +1,9 @@
+package org.tdl.vireo.view;
+
+import java.util.Map;
+
+public interface SettingsUserView extends SimpleUserView {
+
+    public Map<String, String> getSettings();
+
+}

--- a/src/main/java/org/tdl/vireo/view/SimpleOrganizationView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleOrganizationView.java
@@ -1,0 +1,9 @@
+package org.tdl.vireo.view;
+
+public interface SimpleOrganizationView {
+
+    public Long getId();
+
+    public String getName();
+
+}

--- a/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
@@ -9,7 +9,7 @@ public interface SimpleSubmissionView {
 
     public SimpleUserView getSubmitter();
 
-    public SimpleUserView getAssignee();
+    public SettingsUserView getAssignee();
 
     public SubmissionStatus getSubmissionStatus();
 

--- a/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.view;
+
+import java.util.Calendar;
+import org.tdl.vireo.model.SubmissionStatus;
+
+public interface SimpleSubmissionView {
+
+    public Long getId();
+
+    public SimpleUserView getSubmitter();
+
+    public SimpleUserView getAssignee();
+
+    public SubmissionStatus getSubmissionStatus();
+
+    public SimpleOrganizationView getOrganization();
+
+    public Calendar getSubmissionDate();
+}

--- a/src/main/java/org/tdl/vireo/view/SimpleUserView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleUserView.java
@@ -1,0 +1,25 @@
+package org.tdl.vireo.view;
+
+import edu.tamu.weaver.user.model.IRole;
+
+public interface SimpleUserView {
+
+    public Long getId();
+
+    public String getNetid();
+
+    public String getEmail();
+
+    public String getFirstName();
+
+    public String getLastName();
+
+    public String getMiddleName();
+
+    public String getName();
+
+    public IRole getRole();
+
+    public String getOrcid();
+
+}


### PR DESCRIPTION
relates #1596
relates #1756

This is affecting the **Choose Your Organization** page.

Too much unnecessary data is being loaded off of the specific Submission end point `/all-by-user`. This end point is only used for the main page that then leads to the **Choose Your Organization** page.

This reduces the loaded data to only the minimum needed on the Student Submission List View. The observed difference in performance is ~800 milliseconds prior to this change and ~200 milliseconds after this change (for vocabulary words with ~17,000 contacts). Also note that Without the code from commit a2e872a6fb37a8bf1ede8cbb8210455a62ebff27, the prior performance is ~22 seconds (for vocabulary words with ~17,000 contacts).