### PR TITLE
Fix spelling mistake where 'metod' should be 'method'.

### DIFF
--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -492,12 +492,12 @@ var apiMapping = {
         addEmailWorkflowRule: {
             'endpoint': '/private/queue',
             'controller': 'organization',
-            'metod': 'add-email-workflow-rule'
+            'method': 'add-email-workflow-rule'
         },
         editEmailWorkflowRule: {
             'endpoint': '/private/queue',
             'controller': 'organization',
-            'metod': 'edit-email-workflow-rule'
+            'method': 'edit-email-workflow-rule'
         },
         get: {
             'endpoint': '/private/queue',


### PR DESCRIPTION
I noticed this while working on another issue.

I do not know if there are any existing problems regarding this because `organization.js` is adding the 'method' explicitly.

see: https://github.com/TexasDigitalLibrary/Vireo/blob/3bf83e24cddf228dcf032e47410a2155a8d9f902/src/main/webapp/app/model/organization.js#L31

see: https://github.com/TexasDigitalLibrary/Vireo/blob/3bf83e24cddf228dcf032e47410a2155a8d9f902/src/main/webapp/app/model/organization.js#L56