### PR TITLE
Issue 1795: Redesign filter broadcasting logic.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.tdl.vireo.model.FilterAction;
 import org.tdl.vireo.model.FilterCriterion;
 import org.tdl.vireo.model.NamedSearchFilter;
 import org.tdl.vireo.model.NamedSearchFilterGroup;
@@ -144,7 +145,7 @@ public class SubmissionListController {
 
         activeFilter = namedSearchFilterGroupRepo.update(activeFilter);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.SORT, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS, activeFilter);
     }
@@ -163,7 +164,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.SET, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -195,8 +196,8 @@ public class SubmissionListController {
 
         namedSearchFilterGroupRepo.delete(filterGroup.get());
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
-        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, user.getSavedFilters()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS, user.getActiveFilter());
     }
@@ -235,7 +236,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -272,7 +273,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -283,7 +284,7 @@ public class SubmissionListController {
         user = userRepo.clearActiveFilter(user);
 
         simpMessagingTemplate.convertAndSend("/channel/user/update", new ApiResponse(SUCCESS, user));
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.CLEAR, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -329,8 +330,8 @@ public class SubmissionListController {
 
         userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
-        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, user.getSavedFilters()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS);
     }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -145,7 +145,7 @@ public class SubmissionListController {
 
         activeFilter = namedSearchFilterGroupRepo.update(activeFilter);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.SORT, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.SORT, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS, activeFilter);
     }
@@ -164,7 +164,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.SET, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.SET, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -196,8 +196,8 @@ public class SubmissionListController {
 
         namedSearchFilterGroupRepo.delete(filterGroup.get());
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
-        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS, user.getActiveFilter());
     }
@@ -236,7 +236,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -273,7 +273,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -284,7 +284,7 @@ public class SubmissionListController {
         user = userRepo.clearActiveFilter(user);
 
         simpMessagingTemplate.convertAndSend("/channel/user/update", new ApiResponse(SUCCESS, user));
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.CLEAR, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.CLEAR, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -330,8 +330,8 @@ public class SubmissionListController {
 
         userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
-        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.REFRESH, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS);
     }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -144,6 +144,8 @@ public class SubmissionListController {
 
         activeFilter = namedSearchFilterGroupRepo.update(activeFilter);
 
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+
         return new ApiResponse(SUCCESS, activeFilter);
     }
 
@@ -161,7 +163,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters/" + user.getActiveFilter().getId(), new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -192,6 +194,9 @@ public class SubmissionListController {
         }
 
         namedSearchFilterGroupRepo.delete(filterGroup.get());
+
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS, user.getActiveFilter());
     }
@@ -230,7 +235,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters/" + user.getActiveFilter().getId(), new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -267,7 +272,7 @@ public class SubmissionListController {
 
         user = userRepo.update(user);
 
-        simpMessagingTemplate.convertAndSend("/channel/active-filters/" + user.getActiveFilter().getId(), new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -278,7 +283,7 @@ public class SubmissionListController {
         user = userRepo.clearActiveFilter(user);
 
         simpMessagingTemplate.convertAndSend("/channel/user/update", new ApiResponse(SUCCESS, user));
-        simpMessagingTemplate.convertAndSend("/channel/active-filters/" + user.getActiveFilter().getId(), new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
 
         return new ApiResponse(SUCCESS);
     }
@@ -323,6 +328,9 @@ public class SubmissionListController {
         }
 
         userRepo.update(user);
+
+        simpMessagingTemplate.convertAndSend("/channel/active-filters", new ApiResponse(SUCCESS, user.getActiveFilter()));
+        simpMessagingTemplate.convertAndSend("/channel/saved-filters", new ApiResponse(SUCCESS, user.getSavedFilters()));
 
         return new ApiResponse(SUCCESS);
     }

--- a/src/main/java/org/tdl/vireo/model/FilterAction.java
+++ b/src/main/java/org/tdl/vireo/model/FilterAction.java
@@ -4,6 +4,7 @@ public enum FilterAction {
     CLEAR,
     REFRESH,
     REMOVE,
+    SAVE,
     SET,
     SORT,
 }

--- a/src/main/java/org/tdl/vireo/model/FilterAction.java
+++ b/src/main/java/org/tdl/vireo/model/FilterAction.java
@@ -1,0 +1,9 @@
+package org.tdl.vireo.model;
+
+public enum FilterAction {
+    CLEAR,
+    REFRESH,
+    REMOVE,
+    SET,
+    SORT,
+}

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -1045,7 +1045,7 @@ var apiMapping = {
     },
     NamedSearchFilterGroup: {
         validations: true,
-        modelListeners: true,
+        modelListeners: false,
         instantiate: {
             'endpoint': '/private/queue',
             'controller': 'submission-list',
@@ -1056,9 +1056,13 @@ var apiMapping = {
             'controller': 'submission-list',
             'method': 'set-active-filter'
         },
-        listen: {
+        listenActive: {
             'endpoint': '/channel',
             'controller': 'active-filters'
+        },
+        listenSaved: {
+            'endpoint': '/channel',
+            'controller': 'saved-filters'
         },
         addFilter: {
             'endpoint': '/private/queue',

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -29,9 +29,11 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
 
     $scope.fieldPredicates = FieldPredicateRepo.getAll();
 
+    var userSettings = new UserSettings();
+
     var rowFilterTitle = "Exclude";
 
-    var ready = $q.all([SubmissionListColumnRepo.ready(), ManagerSubmissionListColumnRepo.ready(), EmailTemplateRepo.ready(), FieldPredicateRepo.ready()]);
+    var ready = $q.all([SubmissionListColumnRepo.ready(), ManagerSubmissionListColumnRepo.ready(), EmailTemplateRepo.ready(), FieldPredicateRepo.ready(), userSettings.ready()]);
 
     var updateChange = function(change) {
         $scope.change = change;
@@ -193,8 +195,6 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         var embargos = EmbargoRepo.getAll();
         var packagers = PackagerRepo.getAll();
         var controlledVocabularies = ControlledVocabularyRepo.getAll();
-
-        var userSettings = new UserSettings();
 
         var addBatchCommentEmail = function (message) {
             batchCommentEmail.adding = true;
@@ -968,7 +968,12 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
             sessionStorage.setItem("list-page-number", 1);
         };
 
-        WsApi.listen(apiMapping.NamedSearchFilterGroup.listenActive).then(null, null, function (res) {
+        var listenActive = apiMapping.NamedSearchFilterGroup.listenActive;
+        var listenSaved = apiMapping.NamedSearchFilterGroup.listenSaved;
+        listenActive.controller = 'active-filters/user/' + userSettings.id;
+        listenSaved.controller = 'saved-filters/user/' + userSettings.id;
+
+        WsApi.listen(listenActive).then(null, null, function (res) {
             if (res !== undefined && res.body) {
                 var apiRes = angular.fromJson(res.body);
 
@@ -990,7 +995,7 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
             }
         });
 
-        WsApi.listen(apiMapping.NamedSearchFilterGroup.listenSaved).then(null, null, function (res) {
+        WsApi.listen(listenSaved).then(null, null, function (res) {
             if (res !== undefined && res.body) {
                 var apiRes = angular.fromJson(res.body);
 

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -1,4 +1,4 @@
-vireo.controller("SubmissionListController", function (NgTableParams, $controller, $filter, $location, $q, $scope, ControlledVocabularyRepo, CustomActionDefinitionRepo, DepositLocationRepo, DocumentTypeRepo, EmailRecipient, EmailRecipientType, EmailTemplateRepo, EmbargoRepo, FieldPredicateRepo, ManagerFilterColumnRepo, ManagerSubmissionListColumnRepo, NamedSearchFilterGroup, OrganizationRepo, OrganizationCategoryRepo, PackagerRepo, SavedFilterRepo, SidebarService, SubmissionListColumnRepo, SubmissionRepo, SubmissionStatusRepo, UserRepo, UserSettings, WsApi) {
+vireo.controller("SubmissionListController", function (NgTableParams, $controller, $filter, $location, $q, $scope, ControlledVocabularyRepo, CustomActionDefinitionRepo, DepositLocationRepo, DocumentTypeRepo, EmailRecipient, EmailRecipientType, EmailTemplateRepo, EmbargoRepo, FieldPredicateRepo, ManagerFilterColumnRepo, ManagerSubmissionListColumnRepo, NamedSearchFilterGroup, OrganizationRepo, OrganizationCategoryRepo, PackagerRepo, SavedFilter, SavedFilterRepo, SidebarService, SubmissionListColumnRepo, SubmissionRepo, SubmissionStatusRepo, UserRepo, UserSettings, WsApi) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
@@ -978,6 +978,44 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
 
             sessionStorage.setItem("list-page-number", 1);
         };
+
+        WsApi.listen(apiMapping.NamedSearchFilterGroup.listenActive).then(null, null, function (res) {
+            if (res !== undefined && res.body) {
+                var apiRes = angular.fromJson(res.body);
+
+                if (apiRes.payload && apiRes.payload) {
+                    var keys = Object.keys(apiRes.payload);
+                    var regex = /^NamedSearchFilterGroup\b/;
+                    for (var i = 0; i < keys.length; i++) {
+                        if (keys[i].match(regex)) {
+                            angular.extend($scope.activeFilters, apiRes.payload[keys[i]]);
+                            query(); // FIXME: this will result in a double-load on event triggering page, but it needed for all other pages.
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        WsApi.listen(apiMapping.NamedSearchFilterGroup.listenSaved).then(null, null, function (res) {
+            if (res !== undefined && res.body) {
+                var apiRes = angular.fromJson(res.body);
+
+                if (apiRes.payload) {
+                    var keys = Object.keys(apiRes.payload);
+                    var regex = /^PersistentBag\b/;
+                    for (var i = 0; i < keys.length; i++) {
+                        if (keys[i].match(regex)) {
+                            savedFilters.length = 0;
+                            for (var j = 0; j < apiRes.payload[keys[i]].length; j++) {
+                                savedFilters.push(new SavedFilter(apiRes.payload[keys[i]][j]));
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+        });
 
     });
 

--- a/src/main/webapp/app/views/sideboxes/filterOptions.html
+++ b/src/main/webapp/app/views/sideboxes/filterOptions.html
@@ -1,45 +1,45 @@
 <div class="filter-options">
 
-	<sideboxsub>Manage Filters</sideboxsub>
-	<ul class="sidebox-list">
-		<li><a href="#" ng-click="box.clearFilters()">Clear current filter</a></li>
-		<li><a href="#" ng-click="openModal('#saveCurrentFilters')">Save current filter</a></li>
-		<li><a href="#" ng-click="openModal('#removeExistingFilters')">Remove existing filters</a></li>
-		<li><a href="#" ng-click="openModal('#customizeFilters')">Customize filters</a></li>
-	</ul>
+    <sideboxsub>Manage Filters</sideboxsub>
+    <ul class="sidebox-list">
+        <li><a href="#" ng-click="box.clearFilters()">Clear current filter</a></li>
+        <li><a href="#" ng-click="openModal('#saveCurrentFilters')">Save current filter</a></li>
+        <li><a href="#" ng-click="openModal('#removeExistingFilters')">Remove existing filters</a></li>
+        <li><a href="#" ng-click="openModal('#customizeFilters')">Customize filters</a></li>
+    </ul>
 
-	<sideboxsub>Saved Filters</sideboxsub>
-	<ul class="sidebox-list saved-filters">
-		<li ng-repeat="filterType in ['Without Columns','With Columns']" class="sideboxsub-sub">{{filterType}}
-			<ul class="list">
-				<li class="columns" ng-repeat="filter in columnFilters = (box.savedFilters | filter: {columnsFlag:($index > 0 ? true:false)})" ng-click="box.applyFilter(filter)">
-					<span ng-class="{'glyphicon-globe':filter.publicFlag,'glyphicon-user':!filter.publicFlag}" class="glyphicon"></span>
-					<a href="#" ng-click="activateFilter(filter)">{{filter.name}}</a>
-				</li>
-				<li ng-hide="columnFilters.length">None</li>
-			</ul>
-		</li>
-	</ul>
+    <sideboxsub>Saved Filters</sideboxsub>
+    <ul class="sidebox-list saved-filters">
+        <li ng-repeat="filterType in ['Without Columns','With Columns']" class="sideboxsub-sub">{{filterType}}
+            <ul class="list">
+                <li class="columns" ng-repeat="filter in columnFilters = (box.savedFilters | filter: {columnsFlag:($index > 0 ? true:false)})" ng-click="box.applyFilter(filter)">
+                    <span ng-class="{'glyphicon-globe':filter.publicFlag,'glyphicon-user':!filter.publicFlag}" class="glyphicon"></span>
+                    <a href="#">{{filter.name}}</a>
+                </li>
+                <li ng-hide="columnFilters.length">None</li>
+            </ul>
+        </li>
+    </ul>
 
 </div>
 
 <modal
-	modal-id="saveCurrentFilters"
-	modal-view="views/modals/submissions/saveCurrentFilter.html"
-	modal-header-class="modal-header-primary"
-	wvr-modal-backdrop="static">
+    modal-id="saveCurrentFilters"
+    modal-view="views/modals/submissions/saveCurrentFilter.html"
+    modal-header-class="modal-header-primary"
+    wvr-modal-backdrop="static">
 </modal>
 
 <modal
-	modal-id="removeExistingFilters"
-	modal-view="views/modals/submissions/removeExistingFilters.html"
-	modal-header-class="modal-header-primary"
-	wvr-modal-backdrop="static">
+    modal-id="removeExistingFilters"
+    modal-view="views/modals/submissions/removeExistingFilters.html"
+    modal-header-class="modal-header-primary"
+    wvr-modal-backdrop="static">
 </modal>
 
 <modal
-	modal-id="customizeFilters"
-	modal-view="views/modals/submissions/customizeFilters.html"
-	modal-header-class="modal-header-primary"
-	wvr-modal-backdrop="static">
+    modal-id="customizeFilters"
+    modal-view="views/modals/submissions/customizeFilters.html"
+    modal-header-class="modal-header-primary"
+    wvr-modal-backdrop="static">
 </modal>

--- a/src/main/webapp/tests/mocks/models/mockUserSettings.js
+++ b/src/main/webapp/tests/mocks/models/mockUserSettings.js
@@ -25,6 +25,10 @@ var dataUserSettings6 = {
 var mockUserSettings = function($q) {
     var model = mockModel("UserSettings", $q, dataUserSettings1);
 
+    model.ready = function() {
+        return true;
+    };
+
     return model;
 };
 


### PR DESCRIPTION
resolves #1795 

This does not address the columns on the table.
This does not address the Filter By Display Filter boxes (which likely should follow the same or similar solution).

The weaver model listener operates on an individual basis.
Broadcasts received are on a path such as `/channel/active-filters/1`.
This only works so long as the active filter is filter id 1 (based on the above "such as" example).
Any time this changes, the listener could be listening on a different id than what is now the active filter as far as the database is concerned.
The saved filters have the same concern as the active filters.

The problem is that the model listener is on a per individual filter basis.
The entire set for both saved filters and active filters for a given user needs to be handled as a whole.

Redesign the logic to:
1. Disable the active filter model listener.
2. Utilize a new group-level (or set-level) channels: `/channel/active-filters/user/[user id]` and `/channel/saved-filters/user/[user id]` (where `[user id]` represents some valid user id).
3. Add a new FilterAction enumeration to communicate purpose.
4. Always return the Active Filter or Saved Filter.
5. Update active filters, saved filters, and table (rows) using the response received by the channel broadcast.
6. Remove now duplicate `query()` calls, preventing double-loading.
7. Remove call to non-existent function `activateFilter()` in filterOptions.html.
8. Remove `console.warning()` as that code is now required.

The listener is updating based on the response received.
That response may entail clearing the pagination and so an enumeration called `FilterAction` is provided.
When the listener begins to update, the current page could be past the max total pages.
A listener on a page other than the one triggering the broadcast has no way of knowing what is correct until it receives a response. Therefore, once a response is received and the page number is determined to be incorrect, then update the page number. This behavior is necessary and so the console warning is now removed.
