### PR TITLE
Issue 1756: Should use ready() rather than getAll().

### DIFF
--- a/src/main/webapp/app/controllers/submission/newSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/newSubmissionController.js
@@ -12,7 +12,7 @@ vireo.controller('NewSubmissionController', function ($controller, $location, $q
 
     $scope.ready = false;
 
-    $q.all([OrganizationRepo.ready(), ManagedConfigurationRepo.getAll(), StudentSubmissionRepo.getAll()]).then(function () {
+    $q.all([OrganizationRepo.ready(), ManagedConfigurationRepo.ready(), StudentSubmissionRepo.ready()]).then(function () {
 
         $scope.ready = true;
 


### PR DESCRIPTION
The use of `ManagedConfigurationRepo.getAll()` and `StudentSubmissionRepo.getAll()` is incorrect here.

The `getAll()` methods are being called already a few lines up. This is likely causing a double load and is likely affecting performance.

Use `ready()` instead.