### PR TITLE
Hotfix: Making changes after selecting a saved filter alters the saved filter.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -160,9 +160,7 @@ public class SubmissionListController {
             return new ApiResponse(ERROR, "Failed to find filter with ID " + namedSearchFilterGroup.getId() + ".");
         }
 
-        user.setActiveFilter(desiredFilter.get());
-
-        user = userRepo.update(user);
+        user = userRepo.setActiveFilter(user, desiredFilter.get());
 
         simpMessagingTemplate.convertAndSend("/channel/active-filters/user/" + user.getId(), new ApiResponse(SUCCESS, FilterAction.SET, user.getActiveFilter()));
 

--- a/src/main/java/org/tdl/vireo/model/repo/custom/UserRepoCustom.java
+++ b/src/main/java/org/tdl/vireo/model/repo/custom/UserRepoCustom.java
@@ -1,5 +1,6 @@
 package org.tdl.vireo.model.repo.custom;
 
+import org.tdl.vireo.model.NamedSearchFilterGroup;
 import org.tdl.vireo.model.Role;
 import org.tdl.vireo.model.User;
 
@@ -10,5 +11,7 @@ public interface UserRepoCustom {
     public User create(String email, String firstName, String lastName, String password, Role role);
 
     public User clearActiveFilter(User user);
+
+    public User setActiveFilter(User user, NamedSearchFilterGroup filter);
 
 }


### PR DESCRIPTION
The saved filter should not be altered.
This hot fix takes a quick approach of just always assigning the "persisted" filter as the active filter.

When this filter gets modified, the "persisted" filter now is what gets modified rather than the saved filter.

It may be a good idea to follow up this hot fix with an issue to further investigate this. A more ideal solution may be possible than what is implemented here. This should likely include unit tests.

For future notes and investigations consider that this solution also suggests that the "active filter" concept can be thrown away and the "persisted filter" could always be the active filter.

The problem is introduced in this PR:
- https://github.com/TexasDigitalLibrary/Vireo/pull/1778

That PR remove the problematic `clone()` call:
- https://github.com/TexasDigitalLibrary/Vireo/blame/8ff079ba606173e16782f418444ab4d65a497160/src/main/java/org/tdl/vireo/controller/SubmissionListController.java#L158

The `clone()` call effectively prevented the saved filter from being modified.