### PR TITLE
Issue 1815: Add "Archived" Submission status.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/SubmissionState.java
+++ b/src/main/java/org/tdl/vireo/model/SubmissionState.java
@@ -13,7 +13,8 @@ public enum SubmissionState {
 	PUBLISHED(9), 
 	ON_HOLD(10),
 	WITHDRAWN(11),
-	CANCELED(12);
+  CANCELED(12),
+  ARCHIVED(13);
 	
 	private int value;
 

--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -244,6 +244,8 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
             break;
         case WITHDRAWN:
             break;
+        case ARCHIVED:
+            break;
         case ON_HOLD:
         case CANCELED:
         case CORRECTIONS_RECIEVED:

--- a/src/main/resources/submission_statuses/SYSTEM_Submission_Statuses.json
+++ b/src/main/resources/submission_statuses/SYSTEM_Submission_Statuses.json
@@ -142,5 +142,17 @@
     "isActive": false,
     "submissionState": 12,
     "transitionSubmissionStatuses": []
+  },
+  {
+    "id": 13,
+    "name": "Archived",
+    "isArchived": true,
+    "isPublishable": false,
+    "isDeletable": true,
+    "isEditableByReviewer": false,
+    "isEditableByStudent": false,
+    "isActive": false,
+    "submissionState": 13,
+    "transitionSubmissionStatuses": []
   }
 ]


### PR DESCRIPTION
resolves #1815 

Without this several action logs may fail to migrate when migrating from Vireo 3 into Vireo 4.

The SQL to manually add this to the DB is:
```sql
insert into submission_status (id, is_active, is_archived, is_deletable, is_editable_by_reviewer, is_editable_by_student, is_publishable, name, submission_state) values (13, false, true, true, false, false, false, 'Archived', 13);
```