### PR TITLE
Issue 1819: Improve error reporting with more accurate responses from Deposit Location connection attempts.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/DepositLocationController.java
+++ b/src/main/java/org/tdl/vireo/controller/DepositLocationController.java
@@ -2,13 +2,14 @@ package org.tdl.vireo.controller;
 
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
-import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 import static edu.tamu.weaver.validation.model.MethodValidationType.REORDER;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,10 +22,6 @@ import org.tdl.vireo.model.DepositLocation;
 import org.tdl.vireo.model.depositor.Depositor;
 import org.tdl.vireo.model.repo.DepositLocationRepo;
 import org.tdl.vireo.service.DepositorService;
-
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 
 @RestController
 @RequestMapping("/settings/deposit-location")

--- a/src/main/java/org/tdl/vireo/controller/DepositLocationController.java
+++ b/src/main/java/org/tdl/vireo/controller/DepositLocationController.java
@@ -63,7 +63,6 @@ public class DepositLocationController {
     // This endpoint is broken. Unable to deserialize Packager interface!!
     @PreAuthorize("hasRole('MANAGER')")
     @RequestMapping(value = "/remove", method = POST)
-    @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
     public ApiResponse removeDepositLocation(@WeaverValidatedModel DepositLocation depositLocation) {
         logger.info("Removing deposit location with name " + depositLocation.getName());
         depositLocationRepo.remove(depositLocation);

--- a/src/main/java/org/tdl/vireo/controller/advice/CustomResponseEntityExceptionHandler.java
+++ b/src/main/java/org/tdl/vireo/controller/advice/CustomResponseEntityExceptionHandler.java
@@ -2,6 +2,7 @@ package org.tdl.vireo.controller.advice;
 
 import static edu.tamu.weaver.response.ApiStatus.ERROR;
 
+import edu.tamu.weaver.response.ApiResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -12,9 +13,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.tdl.vireo.exception.SwordDepositBadRequestException;
+import org.tdl.vireo.exception.SwordDepositConflictException;
 import org.tdl.vireo.exception.SwordDepositException;
-
-import edu.tamu.weaver.response.ApiResponse;
+import org.tdl.vireo.exception.SwordDepositForbiddenException;
+import org.tdl.vireo.exception.SwordDepositInternalServerErrorException;
+import org.tdl.vireo.exception.SwordDepositNotFoundException;
+import org.tdl.vireo.exception.SwordDepositUnauthorizedException;
+import org.tdl.vireo.exception.SwordDepositUnprocessableEntityException;
 
 @RestController
 @ControllerAdvice
@@ -30,10 +36,58 @@ public class CustomResponseEntityExceptionHandler extends ResponseEntityExceptio
         return new ApiResponse(ERROR, "File size limit exceeded");
     }
 
-    @ExceptionHandler(SwordDepositException.class)
+    @ExceptionHandler(SwordDepositBadRequestException.class)
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ApiResponse handleSwordDepositBadRequestException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositConflictException.class)
     @ResponseStatus(value = HttpStatus.CONFLICT)
     @ResponseBody
-    public ApiResponse handleSwordDepositException(SwordDepositException exception) {
+    public ApiResponse handleSwordDepositConflictException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositForbiddenException.class)
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
+    @ResponseBody
+    public ApiResponse handleSwordDepositForbiddenException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositInternalServerErrorException.class)
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody
+    public ApiResponse handleSwordDepositInternalServerErrorException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositNotFoundException.class)
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ResponseBody
+    public ApiResponse handleSwordDepositNotFoundException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositUnauthorizedException.class)
+    @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+    @ResponseBody
+    public ApiResponse handleSwordDepositUnauthorizedException(SwordDepositException exception) {
+        logger.debug(exception.getMessage(), exception);
+        return new ApiResponse(ERROR, exception.getMessage());
+    }
+
+    @ExceptionHandler(SwordDepositUnprocessableEntityException.class)
+    @ResponseStatus(value = HttpStatus.UNPROCESSABLE_ENTITY)
+    @ResponseBody
+    public ApiResponse handleSwordDepositUnprocessableEntityException(SwordDepositException exception) {
         logger.debug(exception.getMessage(), exception);
         return new ApiResponse(ERROR, exception.getMessage());
     }

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositBadRequestException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositBadRequestException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositBadRequestException extends SwordDepositException {
+
+    private static final long serialVersionUID = 206711142922120313L;
+
+    public SwordDepositBadRequestException() {
+        super();
+    }
+
+    public SwordDepositBadRequestException(String message) {
+        super(message);
+    }
+
+    public SwordDepositBadRequestException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositConflictException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositConflictException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositConflictException extends SwordDepositException {
+
+    private static final long serialVersionUID = 6655042738594561428L;
+
+    public SwordDepositConflictException() {
+        super();
+    }
+
+    public SwordDepositConflictException(String message) {
+        super(message);
+    }
+
+    public SwordDepositConflictException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositForbiddenException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositForbiddenException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositForbiddenException extends SwordDepositException {
+
+    private static final long serialVersionUID = 5137876785611242339L;
+
+    public SwordDepositForbiddenException() {
+        super();
+    }
+
+    public SwordDepositForbiddenException(String message) {
+        super(message);
+    }
+
+    public SwordDepositForbiddenException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositInternalServerErrorException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositInternalServerErrorException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositInternalServerErrorException extends SwordDepositException {
+
+    private static final long serialVersionUID = -1475151059148205394L;
+
+    public SwordDepositInternalServerErrorException() {
+        super();
+    }
+
+    public SwordDepositInternalServerErrorException(String message) {
+        super(message);
+    }
+
+    public SwordDepositInternalServerErrorException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositNotFoundException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositNotFoundException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositNotFoundException extends SwordDepositException {
+
+    private static final long serialVersionUID = 7808340329570918705L;
+
+    public SwordDepositNotFoundException() {
+        super();
+    }
+
+    public SwordDepositNotFoundException(String message) {
+        super(message);
+    }
+
+    public SwordDepositNotFoundException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositUnauthorizedException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositUnauthorizedException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositUnauthorizedException extends SwordDepositException {
+
+    private static final long serialVersionUID = -3845725334845165480L;
+
+    public SwordDepositUnauthorizedException() {
+        super();
+    }
+
+    public SwordDepositUnauthorizedException(String message) {
+        super(message);
+    }
+
+    public SwordDepositUnauthorizedException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/exception/SwordDepositUnprocessableEntityException.java
+++ b/src/main/java/org/tdl/vireo/exception/SwordDepositUnprocessableEntityException.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.exception;
+
+public class SwordDepositUnprocessableEntityException extends SwordDepositException {
+
+    private static final long serialVersionUID = 816045726698304229L;
+
+    public SwordDepositUnprocessableEntityException() {
+        super();
+    }
+
+    public SwordDepositUnprocessableEntityException(String message) {
+        super(message);
+    }
+
+    public SwordDepositUnprocessableEntityException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/model/DepositLocation.java
+++ b/src/main/java/org/tdl/vireo/model/DepositLocation.java
@@ -39,7 +39,7 @@ public class DepositLocation extends ValidatingOrderedBaseEntity {
     @Column(nullable = true)
     private String onBehalfOf;
 
-    @OneToOne(targetEntity = AbstractPackager.class, orphanRemoval = true, optional = true)
+    @OneToOne(targetEntity = AbstractPackager.class, orphanRemoval = false, optional = true)
     private Packager<?> packager;
 
     @Column(nullable = false)

--- a/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
+++ b/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
@@ -102,9 +102,7 @@ vireo.controller("DepositLocationRepoController", function ($controller, $scope,
             var testData = angular.copy($scope.modalData);
             delete testData.packager;
 
-            var location = new DepositLocation(testData);
-
-            location.testConnection().then(function (response) {
+            $scope.depositLocationRepo.testConnection(testData).then(function (response) {
                 var apiRes = angular.fromJson(response.body);
 
                 if (apiRes.meta.status === 'SUCCESS') {

--- a/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
+++ b/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
@@ -37,7 +37,7 @@ vireo.controller("DepositLocationRepoController", function ($controller, $scope,
                 $scope.modalData.refresh();
             }
 
-            $scope.modalData = {
+            $scope.modalData = new DepositLocation({
                 name: '',
                 depositorName: 'SWORDv1Depositor',
                 timeout: 240,
@@ -70,7 +70,7 @@ vireo.controller("DepositLocationRepoController", function ($controller, $scope,
                 isTestable: function () {
                     return (!isTestDepositing && $scope.modalData.name && $scope.modalData.depositorName && $scope.modalData.repository && $scope.modalData.username && $scope.modalData.password);
                 }
-            };
+            });
 
             for (var key in $scope.forms) {
                 if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {

--- a/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
+++ b/src/main/webapp/app/controllers/settings/depositLocationRepoController.js
@@ -45,31 +45,6 @@ vireo.controller("DepositLocationRepoController", function ($controller, $scope,
                 repository: '',
                 username: '',
                 password: '',
-                testDepositLocation: function () {
-                    isTestDepositing = true;
-                    var testData = angular.copy($scope.modalData);
-                    delete testData.packager;
-                    var testableDepositLocation = new DepositLocation(testData);
-                    testableDepositLocation.testConnection().then(function (response) {
-                        var apiRes = angular.fromJson(response.body);
-                        if (apiRes.meta.status === 'SUCCESS') {
-                            var collections = apiRes.payload.HashMap;
-                            angular.forEach(collections, function (uri, name) {
-                                $scope.collections.push({
-                                    "name": name,
-                                    "uri": uri
-                                });
-                            });
-                        }
-                        isTestDepositing = false;
-                    });
-                },
-                isTestDepositing: function () {
-                    return isTestDepositing;
-                },
-                isTestable: function () {
-                    return (!isTestDepositing && $scope.modalData.name && $scope.modalData.depositorName && $scope.modalData.repository && $scope.modalData.username && $scope.modalData.password);
-                }
             });
 
             for (var key in $scope.forms) {
@@ -120,6 +95,38 @@ vireo.controller("DepositLocationRepoController", function ($controller, $scope,
             reorder: $scope.reorderDepositLocation,
             container: '#deposit-locations'
         });
+
+        $scope.testDepositLocation = function () {
+            isTestDepositing = true;
+
+            var testData = angular.copy($scope.modalData);
+            delete testData.packager;
+
+            var location = new DepositLocation(testData);
+
+            location.testConnection().then(function (response) {
+                var apiRes = angular.fromJson(response.body);
+
+                if (apiRes.meta.status === 'SUCCESS') {
+                    angular.forEach(apiRes.payload.HashMap, function (uri, name) {
+                        $scope.collections.push({
+                            "name": name,
+                            "uri": uri
+                        });
+                    });
+                }
+
+                isTestDepositing = false;
+            });
+        };
+
+        $scope.isTestDepositing = function () {
+            return isTestDepositing;
+        };
+
+        $scope.isTestable = function () {
+            return (!isTestDepositing && !!$scope.modalData.name && !!$scope.modalData.depositorName && !!$scope.modalData.repository && !!$scope.modalData.username && !!$scope.modalData.password);
+        };
 
         DepositLocationRepo.listen(function (data) {
             $scope.resetDepositLocation();

--- a/src/main/webapp/app/model/depositLocation.js
+++ b/src/main/webapp/app/model/depositLocation.js
@@ -4,17 +4,7 @@ vireo.model("DepositLocation", function DepositLocation(WsApi) {
 
         // additional model methods and variables
 
-        var depositLocation = this;
-
-        depositLocation.testConnection = function() {
-            angular.extend(depositLocation.getMapping().testConnection, {'data': depositLocation});
-
-            var promise = WsApi.fetch(depositLocation.getMapping().testConnection);
-
-            return promise;
-        };
-
-        return depositLocation;
+        return this;
     };
 
 });

--- a/src/main/webapp/app/repo/depositLocationRepo.js
+++ b/src/main/webapp/app/repo/depositLocationRepo.js
@@ -1,7 +1,16 @@
-vireo.repo("DepositLocationRepo", function DepositLocationRepo() {
+vireo.repo("DepositLocationRepo", function DepositLocationRepo(DepositLocation, WsApi) {
 
-	// additional repo methods and variables
+    // additional repo methods and variables
 
-	return this;
-	
+    var depositLocationRepo = this;
+
+    depositLocationRepo.testConnection = function (data) {
+        var connection = angular.copy(new DepositLocation().getMapping().testConnection);
+        connection.data = data;
+
+        return WsApi.fetch(connection);
+    };
+
+    return depositLocationRepo;
+
 });

--- a/src/main/webapp/app/views/modals/settings/depositLocationEditModal.html
+++ b/src/main/webapp/app/views/modals/settings/depositLocationEditModal.html
@@ -22,9 +22,9 @@
 
     <label for="collection">
       Collection
-      <span ng-if="modalData.isTestDepositing()">
+      <span ng-if="isTestDepositing()">
         (Getting collections)</span>
-      <span ng-if="!modalData.isTestDepositing() && collections.length==0">
+      <span ng-if="!isTestDepositing() && collections.length==0">
         (Please get collections)</span>
 
     </label>
@@ -39,9 +39,9 @@
     <validatedinput id="edit-on-behalf-of" model="modalData" property="onBehalfOf" label="On Behalf Of" form="forms.update" validations="depositLocationRepo.getValidations()" results="modalData.ValidationResults"></validatedinput>
 
     <div class="form-group">
-      <button ng-disabled="!modalData.isTestable()" ng-click="modalData.testDepositLocation()" id="depositLocation-test" type="button" class="btn btn-default">
-        <span ng-show="modalData.isTestDepositing()">Testing...</span>
-        <span ng-show="!modalData.isTestDepositing()">Test connection &amp; find available collections</span>
+      <button ng-disabled="!isTestable()" ng-click="testDepositLocation(modalData)" id="depositLocation-test" type="button" class="btn btn-default">
+        <span ng-show="isTestDepositing()">Testing...</span>
+        <span ng-show="!isTestDepositing()">Test connection &amp; find available collections</span>
       </button>
     </div>
   </div>

--- a/src/main/webapp/app/views/modals/settings/depositLocationEditModal.html
+++ b/src/main/webapp/app/views/modals/settings/depositLocationEditModal.html
@@ -39,7 +39,7 @@
     <validatedinput id="edit-on-behalf-of" model="modalData" property="onBehalfOf" label="On Behalf Of" form="forms.update" validations="depositLocationRepo.getValidations()" results="modalData.ValidationResults"></validatedinput>
 
     <div class="form-group">
-      <button ng-disabled="!isTestable()" ng-click="testDepositLocation(modalData)" id="depositLocation-test" type="button" class="btn btn-default">
+      <button ng-disabled="!isTestable()" ng-click="testDepositLocation()" id="depositLocation-test" type="button" class="btn btn-default">
         <span ng-show="isTestDepositing()">Testing...</span>
         <span ng-show="!isTestDepositing()">Test connection &amp; find available collections</span>
       </button>

--- a/src/main/webapp/app/views/modals/settings/depositLocationNewModal.html
+++ b/src/main/webapp/app/views/modals/settings/depositLocationNewModal.html
@@ -22,9 +22,9 @@
 
     <label for="collection">
       Collection
-      <span ng-if="modalData.isTestDepositing()">
+      <span ng-if="isTestDepositing()">
         (Getting collections)</span>
-      <span ng-if="!modalData.isTestDepositing() && collections.length==0">
+      <span ng-if="!isTestDepositing() && collections.length==0">
         (Please get collections)</span>
 
     </label>
@@ -39,9 +39,9 @@
     <validatedinput id="new-on-behalf-of" model="modalData" property="onBehalfOf" label="On Behalf Of" form="forms.create" validations="depositLocationRepo.getValidations()" results="modalData.ValidationResults"></validatedinput>
 
     <div class="form-group">
-      <button ng-disabled="!modalData.isTestable()" ng-click="modalData.testDepositLocation()" id="new-depositLocation-test" type="button" class="btn btn-default">
-        <span ng-show="modalData.isTestDepositing()">Testing...</span>
-        <span ng-show="!modalData.isTestDepositing()">Test connection &amp; find available collections</span>
+      <button ng-disabled="!isTestable()" ng-click="testDepositLocation()" id="new-depositLocation-test" type="button" class="btn btn-default">
+        <span ng-show="isTestDepositing()">Testing...</span>
+        <span ng-show="!isTestDepositing()">Test connection &amp; find available collections</span>
       </button>
     </div>
   </div>

--- a/src/main/webapp/tests/mocks/models/mockDepositLocation.js
+++ b/src/main/webapp/tests/mocks/models/mockDepositLocation.js
@@ -84,15 +84,6 @@ var dataDepositLocation6 = {
 
 var mockDepositLocation = function($q) {
     var model = mockModel("DepositLocation", $q, dataDepositLocation1);
-    var testConnectionPayload = { HashMap: [ ] };
-
-    model.mockTestConnectionPayload = function(dataArray) {
-        testConnectionPayload = { HashMap: dataArray };
-    };
-
-    model.testConnection = function() {
-        return payloadPromise($q.defer(), testConnectionPayload);
-    };
 
     return model;
 };

--- a/src/main/webapp/tests/mocks/models/mockDepositLocation.js
+++ b/src/main/webapp/tests/mocks/models/mockDepositLocation.js
@@ -94,17 +94,6 @@ var mockDepositLocation = function($q) {
         return payloadPromise($q.defer(), testConnectionPayload);
     };
 
-    model.testDepositLocation = function() {
-    };
-
-    model.isTestDepositing = function() {
-        return false;
-    };
-
-    model.isTestable = function() {
-        return false;
-    };
-
     return model;
 };
 

--- a/src/main/webapp/tests/mocks/models/mockDepositLocation.js
+++ b/src/main/webapp/tests/mocks/models/mockDepositLocation.js
@@ -94,6 +94,17 @@ var mockDepositLocation = function($q) {
         return payloadPromise($q.defer(), testConnectionPayload);
     };
 
+    model.testDepositLocation = function() {
+    };
+
+    model.isTestDepositing = function() {
+        return false;
+    };
+
+    model.isTestable = function() {
+        return false;
+    };
+
     return model;
 };
 

--- a/src/main/webapp/tests/mocks/repos/mockDepositLocationRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockDepositLocationRepo.js
@@ -18,6 +18,15 @@ var dataDepositLocationRepo3 = [
 
 angular.module("mock.depositLocationRepo", []).service("DepositLocationRepo", function($q) {
     var repo = mockRepo("DepositLocationRepo", $q, mockDepositLocation, dataDepositLocationRepo1);
+    var testConnectionPayload = { HashMap: [ ] };
+
+    repo.mockTestConnectionPayload = function(dataArray) {
+        testConnectionPayload = { HashMap: dataArray };
+    };
+
+    repo.testConnection = function() {
+        return payloadPromise($q.defer(), testConnectionPayload);
+    };
 
     return repo;
 });

--- a/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
@@ -14,17 +14,19 @@ describe("controller: DepositLocationRepoController", function () {
     };
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, _DragAndDropListenerFactory_, _ModalService_, _PackagerRepo_, _RestApi_, _StorageService_) {
+        inject(function ($controller, $rootScope, _DepositLocation_, _DragAndDropListenerFactory_, _ModalService_, _PackagerRepo_, _RestApi_, _StorageService_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
 
+            DepositLocation = _DepositLocation_;
+
             controller = $controller("DepositLocationRepoController", {
                 $q: q,
                 $scope: scope,
                 $window: mockWindow(),
-                DepositLocation: DepositLocation,
+                DepositLocation: _DepositLocation_,
                 DepositLocationRepo: DepositLocationRepo,
                 DragAndDropListenerFactory: _DragAndDropListenerFactory_,
                 ModalService: _ModalService_,
@@ -44,12 +46,6 @@ describe("controller: DepositLocationRepoController", function () {
     beforeEach(function() {
         module("core");
         module("vireo");
-        module("mock.depositLocation", function($provide) {
-            DepositLocation = function() {
-                return mockedDepositLocation();
-            };
-            $provide.value("DepositLocation", DepositLocation);
-        });
 
         module("mock.depositLocationRepo");
         module("mock.dragAndDropListenerFactory");
@@ -213,9 +209,6 @@ describe("controller: DepositLocationRepoController", function () {
             scope.modalData.testDepositLocation();
             scope.$digest();
 
-            scope.modalData.mockTestConnectionPayload([
-                { uri: "mockUri", name: "mockName" }
-            ]);
             scope.resetDepositLocation();
             scope.modalData.testDepositLocation();
             scope.$digest();

--- a/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
@@ -1,15 +1,12 @@
 describe("controller: DepositLocationRepoController", function () {
 
-    var controller, q, scope, DepositLocation, DepositLocationRepo, MockedDepositLocation, WsApi;
+    var controller, q, scope, mockedDepositLocation, DepositLocation, DepositLocationRepo, WsApi;
 
     var initializeVariables = function(settings) {
         inject(function ($q, _DepositLocationRepo_, _WsApi_) {
             q = $q;
 
-            MockedDepositLocation = new mockDepositLocation(q);
-            DepositLocation = function() {
-                return MockedDepositLocation;
-            };
+            mockedDepositLocation = mockParameterModel(q, mockDepositLocation);
 
             DepositLocationRepo = _DepositLocationRepo_;
             WsApi = _WsApi_;
@@ -47,7 +44,13 @@ describe("controller: DepositLocationRepoController", function () {
     beforeEach(function() {
         module("core");
         module("vireo");
-        module("mock.depositLocation");
+        module("mock.depositLocation", function($provide) {
+            DepositLocation = function() {
+                return mockedDepositLocation();
+            };
+            $provide.value("DepositLocation", DepositLocation);
+        });
+
         module("mock.depositLocationRepo");
         module("mock.dragAndDropListenerFactory");
         module("mock.modalService");
@@ -210,14 +213,14 @@ describe("controller: DepositLocationRepoController", function () {
             scope.modalData.testDepositLocation();
             scope.$digest();
 
-            MockedDepositLocation.mockTestConnectionPayload([
+            scope.modalData.mockTestConnectionPayload([
                 { uri: "mockUri", name: "mockName" }
             ]);
             scope.resetDepositLocation();
             scope.modalData.testDepositLocation();
             scope.$digest();
 
-            MockedDepositLocation.testConnection = function() {
+            scope.modalData.testConnection = function() {
                 return payloadPromise(q.defer(), {}, "OTHER");
             };
 

--- a/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/depositLocationRepoControllerTest.js
@@ -76,6 +76,14 @@ describe("controller: DepositLocationRepoController", function () {
             expect(scope.editDepositLocation).toBeDefined();
             expect(typeof scope.editDepositLocation).toEqual("function");
         });
+        it("isTestable should be defined", function () {
+            expect(scope.isTestable).toBeDefined();
+            expect(typeof scope.isTestable).toEqual("function");
+        });
+        it("isTestDepositing should be defined", function () {
+            expect(scope.isTestDepositing).toBeDefined();
+            expect(typeof scope.isTestDepositing).toEqual("function");
+        });
         it("removeDepositLocation should be defined", function () {
             expect(scope.removeDepositLocation).toBeDefined();
             expect(typeof scope.removeDepositLocation).toEqual("function");
@@ -92,24 +100,13 @@ describe("controller: DepositLocationRepoController", function () {
             expect(scope.selectDepositLocation).toBeDefined();
             expect(typeof scope.selectDepositLocation).toEqual("function");
         });
+        it("testDepositLocation should be defined", function () {
+            expect(scope.testDepositLocation).toBeDefined();
+            expect(typeof scope.testDepositLocation).toEqual("function");
+        });
         it("updateDepositLocation should be defined", function () {
             expect(scope.updateDepositLocation).toBeDefined();
             expect(typeof scope.updateDepositLocation).toEqual("function");
-        });
-    });
-
-    describe("Are the scope.modalData methods defined", function () {
-        it("testDepositLocation should be defined", function () {
-            expect(scope.modalData.testDepositLocation).toBeDefined();
-            expect(typeof scope.modalData.testDepositLocation).toEqual("function");
-        });
-        it("isTestDepositing should be defined", function () {
-            expect(scope.modalData.isTestDepositing).toBeDefined();
-            expect(typeof scope.modalData.isTestDepositing).toEqual("function");
-        });
-        it("isTestable should be defined", function () {
-            expect(scope.modalData.isTestable).toBeDefined();
-            expect(typeof scope.modalData.isTestable).toEqual("function");
         });
     });
 
@@ -206,26 +203,26 @@ describe("controller: DepositLocationRepoController", function () {
     describe("Do the scope.modalData methods work as expected", function () {
         it("testDepositLocation should test the deposit location", function () {
             scope.resetDepositLocation();
-            scope.modalData.testDepositLocation();
+            scope.testDepositLocation();
             scope.$digest();
 
             scope.resetDepositLocation();
-            scope.modalData.testDepositLocation();
+            scope.testDepositLocation();
             scope.$digest();
 
-            scope.modalData.testConnection = function() {
+            scope.testConnection = function() {
                 return payloadPromise(q.defer(), {}, "OTHER");
             };
 
             scope.resetDepositLocation();
-            scope.modalData.testDepositLocation();
+            scope.testDepositLocation();
             scope.$digest();
         });
         it("isTestDepositing should return a boolean", function () {
             var response;
 
             scope.resetDepositLocation();
-            response = scope.modalData.isTestDepositing();
+            response = scope.isTestDepositing();
 
             expect(typeof response).toBe("boolean");
         });
@@ -233,20 +230,20 @@ describe("controller: DepositLocationRepoController", function () {
             var response;
 
             scope.resetDepositLocation();
-            response = scope.modalData.isTestable();
+            response = scope.isTestable();
 
-            // FIXME: should be returning a boolean and not a string (scope.modalData.nam is actually returned).
-            //expect(typeof response).toBe("boolean");
+            expect(typeof response).toBe("boolean");
+            expect(response).toBe(false);
 
             scope.modalData.name = "mock";
             scope.modalData.depositorName = "mock";
             scope.modalData.repository = "mock";
             scope.modalData.username = "mock";
             scope.modalData.password = "mock";
-            response = scope.modalData.isTestable();
+            response = scope.isTestable();
 
-            // FIXME: should be returning a boolean and not a string (scope.modalData.nam is actually returned).
-            //expect(response).toBe(true);
+            expect(typeof response).toBe("boolean");
+            expect(response).toBe(true);
         });
     });
 

--- a/src/main/webapp/tests/unit/models/depositLocationTest.js
+++ b/src/main/webapp/tests/unit/models/depositLocationTest.js
@@ -31,22 +31,4 @@ describe('model: DepositLocation', function () {
             expect(model).toBeDefined();
         });
     });
-
-    describe('Are the model methods defined', function () {
-        it('testConnection should be defined', function () {
-            expect(model.testConnection).toBeDefined();
-            expect(typeof model.testConnection).toEqual("function");
-        });
-    });
-
-    describe('Are the model methods working as expected', function () {
-        it('testConnection should call WsApi', function () {
-            spyOn(WsApi, 'fetch');
-
-            model.testConnection();
-            scope.$digest();
-
-            expect(WsApi.fetch).toHaveBeenCalled();
-        });
-    });
 });

--- a/src/main/webapp/tests/unit/repos/depositLocationRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/depositLocationRepoTest.js
@@ -2,7 +2,7 @@ describe("service: depositLocationRepo", function () {
     var q, repo, rootScope, mockedRepo, mockedUser, scope, WsApi;
 
     var initializeVariables = function(settings) {
-        inject(function ($q, $rootScope, _WsApi_) {
+        inject(function ($q, $rootScope, _DepositLocation_, _WsApi_) {
             q = $q;
             rootScope = $rootScope;
 
@@ -39,6 +39,24 @@ describe("service: depositLocationRepo", function () {
     describe("Is the repo defined", function () {
         it("should be defined", function () {
             expect(repo).toBeDefined();
+        });
+    });
+
+    describe('Are the repo methods defined', function () {
+        it('testConnection should be defined', function () {
+            expect(repo.testConnection).toBeDefined();
+            expect(typeof repo.testConnection).toEqual("function");
+        });
+    });
+
+    describe('Are the repo methods working as expected', function () {
+        it('testConnection should call WsApi', function () {
+            spyOn(WsApi, 'fetch');
+
+            repo.testConnection();
+            scope.$digest();
+
+            expect(WsApi.fetch).toHaveBeenCalled();
         });
     });
 });

--- a/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
@@ -1,0 +1,127 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.ControlledVocabulary;
+import org.tdl.vireo.model.repo.ControlledVocabularyRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class ControlledVocabularyControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private ControlledVocabularyRepo controlledVocabularyRepo;
+
+    @InjectMocks
+    private ControlledVocabularyController controlledVocabularyController;
+
+    private ControlledVocabulary mockControlledVocabulary1;
+    private ControlledVocabulary mockControlledVocabulary2;
+
+    private static List<ControlledVocabulary> mockControlledVocabularys;
+
+    @BeforeEach
+    public void setup() {
+        mockControlledVocabulary1 = new ControlledVocabulary("ControlledVocabulary 1");
+        mockControlledVocabulary1.setId(1L);
+
+        mockControlledVocabulary2 = new ControlledVocabulary("ControlledVocabulary 2");
+        mockControlledVocabulary2.setId(2L);
+
+        mockControlledVocabularys = new ArrayList<ControlledVocabulary>(Arrays.asList(new ControlledVocabulary[] { mockControlledVocabulary1 }));
+    }
+
+    @Test
+    public void testAllControlledVocabularys() {
+        when(controlledVocabularyRepo.findAllByOrderByPositionAsc()).thenReturn(mockControlledVocabularys);
+
+        ApiResponse response = controlledVocabularyController.getAllControlledVocabulary();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<ControlledVocabulary>");
+        assertEquals(mockControlledVocabularys.size(), list.size());
+    }
+
+    @Test
+    public void testGetControlledVocabulary() {
+        when(controlledVocabularyRepo.findByName(any(String.class))).thenReturn(mockControlledVocabulary1);
+
+        ApiResponse response = controlledVocabularyController.getControlledVocabularyByName("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(mockControlledVocabulary1.getId(), controlledVocabulary.getId());
+    }
+
+    @Test
+    public void testCreateControlledVocabulary() {
+        when(controlledVocabularyRepo.create(any(String.class))).thenReturn(mockControlledVocabulary2);
+
+        ApiResponse response = controlledVocabularyController.createControlledVocabulary(mockControlledVocabulary1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(mockControlledVocabulary2.getId(), controlledVocabulary.getId());
+    }
+
+    @Test
+    public void testUpdateControlledVocabulary() {
+        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(mockControlledVocabulary2));
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(mockControlledVocabulary2);
+
+        ApiResponse response = controlledVocabularyController.updateControlledVocabulary(mockControlledVocabulary1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(mockControlledVocabulary2.getId(), controlledVocabulary.getId());
+    }
+
+    @Test
+    public void testRemoveControlledVocabulary() {
+        doNothing().when(controlledVocabularyRepo).remove(any(ControlledVocabulary.class));
+
+        ApiResponse response = controlledVocabularyController.removeControlledVocabulary(mockControlledVocabulary1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyRepo, times(1)).remove(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testReorderControlledVocabularys() {
+        doNothing().when(controlledVocabularyRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = controlledVocabularyController.reorderControlledVocabulary(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    public void testSortControlledVocabularys() {
+        doNothing().when(controlledVocabularyRepo).sort(any(String.class));
+
+        ApiResponse response = controlledVocabularyController.sortControlledVocabulary("column");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyRepo, times(1)).sort(any(String.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/CustomActionControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/CustomActionControllerTest.java
@@ -1,0 +1,104 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.CustomActionDefinition;
+import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class CustomActionControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private CustomActionDefinitionRepo customActionDefinitionRepo;
+
+    @InjectMocks
+    private CustomActionSettingsController customActionDefinitionController;
+
+    private CustomActionDefinition mockCustomActionDefinition1;
+    private CustomActionDefinition mockCustomActionDefinition2;
+
+    private static List<CustomActionDefinition> mockCustomActionDefinitions;
+
+    @BeforeEach
+    public void setup() {
+        mockCustomActionDefinition1 = new CustomActionDefinition("CustomActionDefinition 1", true);
+        mockCustomActionDefinition1.setId(1L);
+
+        mockCustomActionDefinition2 = new CustomActionDefinition("CustomActionDefinition 2", false);
+        mockCustomActionDefinition2.setId(2L);
+
+        mockCustomActionDefinitions = new ArrayList<CustomActionDefinition>(Arrays.asList(new CustomActionDefinition[] { mockCustomActionDefinition1 }));
+    }
+
+    @Test
+    public void testAllCustomActionDefinitions() {
+        when(customActionDefinitionRepo.findAllByOrderByPositionAsc()).thenReturn(mockCustomActionDefinitions);
+
+        ApiResponse response = customActionDefinitionController.getCustomActions();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<CustomActionDefinition>");
+        assertEquals(mockCustomActionDefinitions.size(), list.size());
+    }
+
+    @Test
+    public void testCreateCustomActionDefinition() {
+        when(customActionDefinitionRepo.create(any(String.class), any(Boolean.class))).thenReturn(mockCustomActionDefinition2);
+
+        ApiResponse response = customActionDefinitionController.createCustomAction(mockCustomActionDefinition1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        CustomActionDefinition customActionDefinition = (CustomActionDefinition) response.getPayload().get("CustomActionDefinition");
+        assertEquals(mockCustomActionDefinition2.getId(), customActionDefinition.getId());
+    }
+
+    @Test
+    public void testUpdateCustomActionDefinition() {
+        when(customActionDefinitionRepo.update(any(CustomActionDefinition.class))).thenReturn(mockCustomActionDefinition2);
+
+        ApiResponse response = customActionDefinitionController.updateCustomAction(mockCustomActionDefinition1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        CustomActionDefinition customActionDefinition = (CustomActionDefinition) response.getPayload().get("CustomActionDefinition");
+        assertEquals(mockCustomActionDefinition2.getId(), customActionDefinition.getId());
+    }
+
+    @Test
+    public void testRemoveCustomActionDefinition() {
+        doNothing().when(customActionDefinitionRepo).remove(any(CustomActionDefinition.class));
+
+        ApiResponse response = customActionDefinitionController.removeCustomAction(mockCustomActionDefinition1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(customActionDefinitionRepo, times(1)).remove(any(CustomActionDefinition.class));
+    }
+
+    @Test
+    public void testReorderDegrees() {
+        doNothing().when(customActionDefinitionRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = customActionDefinitionController.reorderCustomActions(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(customActionDefinitionRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/DegreeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DegreeControllerTest.java
@@ -1,0 +1,147 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.Degree;
+import org.tdl.vireo.model.DegreeLevel;
+import org.tdl.vireo.model.repo.DegreeRepo;
+import org.tdl.vireo.service.ProquestCodesService;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class DegreeControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private DegreeRepo degreeRepo;
+
+    @Mock
+    private ProquestCodesService proquestCodesService;
+
+    @InjectMocks
+    private DegreeController degreeController;
+
+    private Degree mockDegree1;
+    private Degree mockDegree2;
+
+    private DegreeLevel mockDegreeLevel1;
+    private DegreeLevel mockDegreeLevel2;
+
+    private static List<Degree> mockDegrees;
+
+    @BeforeEach
+    public void setup() {
+        mockDegreeLevel1 = new DegreeLevel("1");
+        mockDegreeLevel1.setId(1L);
+
+        mockDegreeLevel2 = new DegreeLevel("2");
+        mockDegreeLevel2.setId(2L);
+
+        mockDegree1 = new Degree("Degree 1", mockDegreeLevel1, "Proquest 1");
+        mockDegree1.setId(1L);
+        mockDegree1.setPosition(1L);
+
+        mockDegree2 = new Degree("Degree 2", mockDegreeLevel2, "Proquest 2");
+        mockDegree2.setId(2L);
+        mockDegree2.setPosition(2L);
+
+        mockDegrees = new ArrayList<Degree>(Arrays.asList(new Degree[] { mockDegree1 }));
+    }
+
+    @Test
+    public void testAllDegrees() {
+        when(degreeRepo.findAllByOrderByPositionAsc()).thenReturn(mockDegrees);
+
+        ApiResponse response = degreeController.allDegrees();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Degree>");
+        assertEquals(mockDegrees.size(), list.size());
+    }
+
+    @Test
+    public void testCreateDegree() {
+        when(degreeRepo.create(any(String.class), any(DegreeLevel.class))).thenReturn(mockDegree2);
+
+        ApiResponse response = degreeController.createDegree(mockDegree1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Degree degree = (Degree) response.getPayload().get("Degree");
+        assertEquals(mockDegree2.getId(), degree.getId());
+    }
+
+    @Test
+    public void testUpdateDegree() {
+        when(degreeRepo.update(any(Degree.class))).thenReturn(mockDegree2);
+
+        ApiResponse response = degreeController.updateDegree(mockDegree1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Degree degree = (Degree) response.getPayload().get("Degree");
+        assertEquals(mockDegree2.getId(), degree.getId());
+    }
+
+    @Test
+    public void testRemoveDegree() {
+        doNothing().when(degreeRepo).remove(any(Degree.class));
+
+        ApiResponse response = degreeController.removeDegree(mockDegree1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(degreeRepo, times(1)).remove(any(Degree.class));
+    }
+
+    @Test
+    public void testReorderDegrees() {
+        doNothing().when(degreeRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = degreeController.reorderDegrees(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(degreeRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    public void testSortDegrees() {
+        doNothing().when(degreeRepo).sort(any(String.class));
+
+        ApiResponse response = degreeController.sortDegrees("column");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(degreeRepo, times(1)).sort(any(String.class));
+    }
+
+    @Test
+    public void testGetProquestLanguageCodes() {
+        Map<String, String> map = new HashMap<>();
+        map.put("a", "b");
+
+        when(proquestCodesService.getCodes(any(String.class))).thenReturn(map);
+
+        ApiResponse response = degreeController.getProquestLanguageCodes();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> mapReturned = (HashMap<String, String>) response.getPayload().get("HashMap");
+        assertEquals(mapReturned.get("a"), map.get("a"));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/DegreeLevelControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DegreeLevelControllerTest.java
@@ -1,0 +1,55 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.DegreeLevel;
+import org.tdl.vireo.model.repo.DegreeLevelRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class DegreeLevelControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private DegreeLevelRepo degreeLevelRepo;
+
+    @InjectMocks
+    private DegreeLevelController degreeLevelController;
+
+    private DegreeLevel mockDegreeLevel1;
+
+    private static List<DegreeLevel> mockDegreeLevels;
+
+    @BeforeEach
+    public void setup() {
+        mockDegreeLevel1 = new DegreeLevel("DegreeLevel 1");
+        mockDegreeLevel1.setId(1L);
+        mockDegreeLevel1.setPosition(1L);
+
+        mockDegreeLevels = new ArrayList<DegreeLevel>(Arrays.asList(new DegreeLevel[] { mockDegreeLevel1 }));
+    }
+
+    @Test
+    public void testAllDegreeLevels() {
+        when(degreeLevelRepo.findAllByOrderByPositionAsc()).thenReturn(mockDegreeLevels);
+
+        ApiResponse response = degreeLevelController.allDegreeLevels();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<DegreeLevel>");
+        assertEquals(mockDegreeLevels.size(), list.size());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/DepositLocationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DepositLocationControllerTest.java
@@ -1,0 +1,121 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.DepositLocation;
+import org.tdl.vireo.model.repo.DepositLocationRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class DepositLocationControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private DepositLocationRepo depositLocationRepo;
+
+    @InjectMocks
+    private DepositLocationController depositLocationController;
+
+    private DepositLocation mockDepositLocation1;
+    private DepositLocation mockDepositLocation2;
+    private DepositLocation mockDepositLocation3;
+    private DepositLocation mockDepositLocation4;
+
+    private static List<DepositLocation> mockDepositLocations;
+
+    @BeforeEach
+    public void setup() {
+        mockDepositLocation1 = new DepositLocation("Location 1", "http://localhost/1", "Collection 1", "User 1", "Password 1", "Behalf Of 1", null, "Depsitor 1", 100);
+        mockDepositLocation1.setId(1L);
+        mockDepositLocation1.setPosition(1L);
+
+        mockDepositLocation2 = new DepositLocation("Location 2", "http://localhost/2", "Collection 2", "User 2", "Password 2", "Behalf Of 2", null, "Depsitor 2", 200);
+        mockDepositLocation2.setId(2L);
+        mockDepositLocation2.setPosition(2L);
+
+        mockDepositLocation3 = new DepositLocation("Location 3", "http://localhost/3", "Collection 3", "User 3", "Password 3", "Behalf Of 3", null, "Depsitor 3", 300);
+        mockDepositLocation3.setId(3L);
+        mockDepositLocation3.setPosition(3L);
+
+        mockDepositLocation4 = new DepositLocation("Location 4", "http://localhost/4", "Collection 4", "User 4", "Password 4", "Behalf Of 4", null, "Depsitor 4", 400);
+        mockDepositLocation4.setId(4L);
+        mockDepositLocation4.setPosition(4L);
+
+        mockDepositLocations = new ArrayList<DepositLocation>(Arrays.asList(new DepositLocation[] { mockDepositLocation1, mockDepositLocation2, mockDepositLocation3 }));
+    }
+
+    @Test
+    public void testAllDepositLocations() {
+        when(depositLocationRepo.findAllByOrderByPositionAsc()).thenReturn(mockDepositLocations);
+
+        ApiResponse response = depositLocationController.allDepositLocations();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<DepositLocation>");
+        assertEquals(mockDepositLocations.size(), list.size());
+    }
+
+    @Test
+    public void testCreateDepositLocation() {
+        when(depositLocationRepo.create(anyMap())).thenReturn(mockDepositLocation4);
+
+        Map<String, Object> map = new HashMap<>();
+
+        ApiResponse response = depositLocationController.createDepositLocation(map);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DepositLocation depositLocation = (DepositLocation) response.getPayload().get("DepositLocation");
+        assertEquals(mockDepositLocation4.getId(), depositLocation.getId());
+    }
+
+    @Test
+    public void testUpdateDepositLocation() {
+        when(depositLocationRepo.update(any(DepositLocation.class))).thenReturn(mockDepositLocation4);
+
+        ApiResponse response = depositLocationController.updateDepositLocation(mockDepositLocation3);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DepositLocation depositLocation = (DepositLocation) response.getPayload().get("DepositLocation");
+        assertEquals(mockDepositLocation4.getId(), depositLocation.getId());
+    }
+
+    @Test
+    public void testRemoveDepositLocation() {
+        doNothing().when(depositLocationRepo).remove(any(DepositLocation.class));
+
+        ApiResponse response = depositLocationController.removeDepositLocation(mockDepositLocation1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(depositLocationRepo, times(1)).remove(any(DepositLocation.class));
+    }
+
+    @Test
+    public void testReorderDepositLocations() {
+        doNothing().when(depositLocationRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = depositLocationController.reorderDepositLocations(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(depositLocationRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/DocumentTypeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DocumentTypeControllerTest.java
@@ -1,0 +1,122 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.DocumentType;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.repo.DocumentTypeRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class DocumentTypeControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private DocumentTypeRepo documentTypeRepo;
+
+    @InjectMocks
+    private DocumentTypeController documentTypeController;
+
+    private DocumentType mockDocumentType1;
+    private DocumentType mockDocumentType2;
+
+    private FieldPredicate mockFieldPredicate1;
+    private FieldPredicate mockFieldPredicate2;
+
+    private static List<DocumentType> mockDocumentTypes;
+
+    @BeforeEach
+    public void setup() {
+        mockFieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
+        mockFieldPredicate1.setId(1L);
+
+        mockFieldPredicate2 = new FieldPredicate("FieldPredicate 2", false);
+        mockFieldPredicate2.setId(2L);
+
+        mockDocumentType1 = new DocumentType("DocumentType 1", mockFieldPredicate1);
+        mockDocumentType1.setId(1L);
+        mockDocumentType1.setPosition(1L);
+
+        mockDocumentType2 = new DocumentType("DocumentType 2", mockFieldPredicate2);
+        mockDocumentType2.setId(2L);
+        mockDocumentType2.setPosition(2L);
+
+        mockDocumentTypes = new ArrayList<DocumentType>(Arrays.asList(new DocumentType[] { mockDocumentType1 }));
+    }
+
+    @Test
+    public void testAllDocumentTypes() {
+        when(documentTypeRepo.findAllByOrderByPositionAsc()).thenReturn(mockDocumentTypes);
+
+        ApiResponse response = documentTypeController.allDocumentTypes();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<DocumentType>");
+        assertEquals(mockDocumentTypes.size(), list.size());
+    }
+
+    @Test
+    public void testCreateDocumentType() {
+        when(documentTypeRepo.create(any(String.class))).thenReturn(mockDocumentType2);
+
+        ApiResponse response = documentTypeController.createDocumentType(mockDocumentType1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DocumentType documentType = (DocumentType) response.getPayload().get("DocumentType");
+        assertEquals(mockDocumentType2.getId(), documentType.getId());
+    }
+
+    @Test
+    public void testUpdateDocumentType() {
+        when(documentTypeRepo.update(any(DocumentType.class))).thenReturn(mockDocumentType2);
+
+        ApiResponse response = documentTypeController.updateDocumentType(mockDocumentType1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DocumentType documentType = (DocumentType) response.getPayload().get("DocumentType");
+        assertEquals(mockDocumentType2.getId(), documentType.getId());
+    }
+
+    @Test
+    public void testRemoveDocumentType() {
+        doNothing().when(documentTypeRepo).remove(any(DocumentType.class));
+
+        ApiResponse response = documentTypeController.removeDocumentType(mockDocumentType2);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(documentTypeRepo, times(1)).remove(any(DocumentType.class));
+    }
+
+    @Test
+    public void testRemoveDocumentTypeIsDenied() {
+        ApiResponse response = documentTypeController.removeDocumentType(mockDocumentType1);
+        assertEquals(ApiStatus.INVALID, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testReorderDocumentTypes() {
+        doNothing().when(documentTypeRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = documentTypeController.reorderDocumentTypes(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(documentTypeRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/FieldPredicateControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldPredicateControllerTest.java
@@ -1,0 +1,105 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class FieldPredicateControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @InjectMocks
+    private FieldPredicateController fieldPredicateController;
+
+    private FieldPredicate mockFieldPredicate1;
+    private FieldPredicate mockFieldPredicate2;
+
+    private static List<FieldPredicate> mockFieldPredicates;
+
+    @BeforeEach
+    public void setup() {
+        mockFieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
+        mockFieldPredicate1.setId(1L);
+
+        mockFieldPredicate2 = new FieldPredicate("FieldPredicate 2", false);
+        mockFieldPredicate2.setId(2L);
+
+        mockFieldPredicates = new ArrayList<FieldPredicate>(Arrays.asList(new FieldPredicate[] { mockFieldPredicate1 }));
+    }
+
+    @Test
+    public void testAllFieldPredicates() {
+        when(fieldPredicateRepo.findAll()).thenReturn(mockFieldPredicates);
+
+        ApiResponse response = fieldPredicateController.getAllFieldPredicates();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<FieldPredicate>");
+        assertEquals(mockFieldPredicates.size(), list.size());
+    }
+
+    @Test
+    public void testGetFieldPredicate() {
+        when(fieldPredicateRepo.findByValue(any(String.class))).thenReturn(mockFieldPredicate1);
+
+        ApiResponse response = fieldPredicateController.getFieldPredicateByValue("value");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        FieldPredicate fieldPredicate = (FieldPredicate) response.getPayload().get("FieldPredicate");
+        assertEquals(mockFieldPredicate1.getId(), fieldPredicate.getId());
+    }
+
+    @Test
+    public void testCreateFieldPredicate() {
+        when(fieldPredicateRepo.create(any(String.class), any(Boolean.class))).thenReturn(mockFieldPredicate2);
+
+        ApiResponse response = fieldPredicateController.createFieldPredicate(mockFieldPredicate1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        FieldPredicate fieldPredicate = (FieldPredicate) response.getPayload().get("FieldPredicate");
+        assertEquals(mockFieldPredicate2.getId(), fieldPredicate.getId());
+    }
+
+    @Test
+    public void testUpdateFieldPredicate() {
+        when(fieldPredicateRepo.update(any(FieldPredicate.class))).thenReturn(mockFieldPredicate2);
+
+        ApiResponse response = fieldPredicateController.updateFieldPredicate(mockFieldPredicate1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        FieldPredicate fieldPredicate = (FieldPredicate) response.getPayload().get("FieldPredicate");
+        assertEquals(mockFieldPredicate2.getId(), fieldPredicate.getId());
+    }
+
+    @Test
+    public void testRemoveFieldPredicate() {
+        doNothing().when(fieldPredicateRepo).delete(any(FieldPredicate.class));
+
+        ApiResponse response = fieldPredicateController.removeFieldPredicate(mockFieldPredicate1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(fieldPredicateRepo, times(1)).delete(any(FieldPredicate.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/FieldProfileControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldProfileControllerTest.java
@@ -1,0 +1,54 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.repo.FieldProfileRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class FieldProfileControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private FieldProfileRepo fieldProfileRepo;
+
+    @InjectMocks
+    private FieldProfileController fieldProfileController;
+
+    private FieldProfile mockFieldProfile1;
+
+    private static List<FieldProfile> mockFieldProfiles;
+
+    @BeforeEach
+    public void setup() {
+        mockFieldProfile1 = new FieldProfile();
+        mockFieldProfile1.setId(1L);
+
+        mockFieldProfiles = new ArrayList<FieldProfile>(Arrays.asList(new FieldProfile[] { mockFieldProfile1 }));
+    }
+
+    @Test
+    public void testAllFieldProfiles() {
+        when(fieldProfileRepo.findAll()).thenReturn(mockFieldProfiles);
+
+        ApiResponse response = fieldProfileController.getAllFieldProfiles();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<FieldProfile>");
+        assertEquals(mockFieldProfiles.size(), list.size());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/GraduationMonthControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/GraduationMonthControllerTest.java
@@ -1,0 +1,115 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.GraduationMonth;
+import org.tdl.vireo.model.repo.GraduationMonthRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class GraduationMonthControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private GraduationMonthRepo graduationMonthRepo;
+
+    @InjectMocks
+    private GraduationMonthController graduationMonthController;
+
+    private GraduationMonth mockGraduationMonth1;
+    private GraduationMonth mockGraduationMonth2;
+
+    private static List<GraduationMonth> mockGraduationMonths;
+
+    @BeforeEach
+    public void setup() {
+        mockGraduationMonth1 = new GraduationMonth(1);
+        mockGraduationMonth1.setId(1L);
+
+        mockGraduationMonth2 = new GraduationMonth(2);
+        mockGraduationMonth2.setId(2L);
+
+        mockGraduationMonths = new ArrayList<GraduationMonth>(Arrays.asList(new GraduationMonth[] { mockGraduationMonth1 }));
+    }
+
+    @Test
+    public void testAllGraduationMonths() {
+        when(graduationMonthRepo.findAllByOrderByPositionAsc()).thenReturn(mockGraduationMonths);
+
+        ApiResponse response = graduationMonthController.allGraduationMonths();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<GraduationMonth>");
+        assertEquals(mockGraduationMonths.size(), list.size());
+    }
+
+    @Test
+    public void testCreateGraduationMonth() {
+        when(graduationMonthRepo.create(anyInt())).thenReturn(mockGraduationMonth2);
+
+        ApiResponse response = graduationMonthController.createGraduationMonth(mockGraduationMonth1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        GraduationMonth graduationMonth = (GraduationMonth) response.getPayload().get("GraduationMonth");
+        assertEquals(mockGraduationMonth2.getId(), graduationMonth.getId());
+    }
+
+    @Test
+    public void testUpdateGraduationMonth() {
+        when(graduationMonthRepo.update(any(GraduationMonth.class))).thenReturn(mockGraduationMonth2);
+
+        ApiResponse response = graduationMonthController.updateGraduationMonth(mockGraduationMonth1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        GraduationMonth graduationMonth = (GraduationMonth) response.getPayload().get("GraduationMonth");
+        assertEquals(mockGraduationMonth2.getId(), graduationMonth.getId());
+    }
+
+    @Test
+    public void testRemoveGraduationMonth() {
+        doNothing().when(graduationMonthRepo).remove(any(GraduationMonth.class));
+
+        ApiResponse response = graduationMonthController.removeGraduationMonth(mockGraduationMonth1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(graduationMonthRepo, times(1)).remove(any(GraduationMonth.class));
+    }
+
+    @Test
+    public void testReorderGraduationMonths() {
+        doNothing().when(graduationMonthRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = graduationMonthController.reorderGraduationMonths(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(graduationMonthRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    public void testSortGraduationMonths() {
+        doNothing().when(graduationMonthRepo).sort(any(String.class));
+
+        ApiResponse response = graduationMonthController.sortGraduationMonths("column");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(graduationMonthRepo, times(1)).sort(any(String.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/InputTypeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/InputTypeControllerTest.java
@@ -1,0 +1,54 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.InputType;
+import org.tdl.vireo.model.repo.InputTypeRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class InputTypeControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private InputTypeRepo inputTypeRepo;
+
+    @InjectMocks
+    private InputTypeController inputTypeController;
+
+    private InputType mockInputType1;
+
+    private static List<InputType> mockInputTypes;
+
+    @BeforeEach
+    public void setup() {
+        mockInputType1 = new InputType("InputType 1");
+        mockInputType1.setId(1L);
+
+        mockInputTypes = new ArrayList<InputType>(Arrays.asList(new InputType[] { mockInputType1 }));
+    }
+
+    @Test
+    public void testAllInputTypes() {
+        when(inputTypeRepo.findAll()).thenReturn(mockInputTypes);
+
+        ApiResponse response = inputTypeController.getAllInputTypes();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<InputType>");
+        assertEquals(mockInputTypes.size(), list.size());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/LanguageControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/LanguageControllerTest.java
@@ -1,0 +1,137 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.Language;
+import org.tdl.vireo.model.repo.LanguageRepo;
+import org.tdl.vireo.service.ProquestCodesService;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class LanguageControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private LanguageRepo languageRepo;
+
+    @Mock
+    private ProquestCodesService proquestCodesService;
+
+    @InjectMocks
+    private LanguageController languageController;
+
+    private Language mockLanguage1;
+    private Language mockLanguage2;
+
+    private static List<Language> mockLanguages;
+
+    @BeforeEach
+    public void setup() {
+        mockLanguage1 = new Language("Language 1");
+        mockLanguage1.setId(1L);
+        mockLanguage1.setPosition(1L);
+
+        mockLanguage2 = new Language("Language 2");
+        mockLanguage2.setId(2L);
+        mockLanguage2.setPosition(2L);
+
+        mockLanguages = new ArrayList<Language>(Arrays.asList(new Language[] { mockLanguage1 }));
+    }
+
+    @Test
+    public void testAllLanguages() {
+        when(languageRepo.findAllByOrderByPositionAsc()).thenReturn(mockLanguages);
+
+        ApiResponse response = languageController.getAllLanguages();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Language>");
+        assertEquals(mockLanguages.size(), list.size());
+    }
+
+    @Test
+    public void testCreateLanguage() {
+        when(languageRepo.create(any(String.class))).thenReturn(mockLanguage2);
+
+        ApiResponse response = languageController.createLanguage(mockLanguage1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Language language = (Language) response.getPayload().get("Language");
+        assertEquals(mockLanguage2.getId(), language.getId());
+    }
+
+    @Test
+    public void testUpdateLanguage() {
+        when(languageRepo.update(any(Language.class))).thenReturn(mockLanguage2);
+
+        ApiResponse response = languageController.updateLanguage(mockLanguage1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Language language = (Language) response.getPayload().get("Language");
+        assertEquals(mockLanguage2.getId(), language.getId());
+    }
+
+    @Test
+    public void testRemoveLanguage() {
+        doNothing().when(languageRepo).remove(any(Language.class));
+
+        ApiResponse response = languageController.removeLanguage(mockLanguage1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(languageRepo, times(1)).remove(any(Language.class));
+    }
+
+    @Test
+    public void testReorderLanguages() {
+        doNothing().when(languageRepo).reorder(any(Long.class), any(Long.class));
+
+        ApiResponse response = languageController.reorderLanguage(1L, 2L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(languageRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    public void testSortLanguages() {
+        doNothing().when(languageRepo).sort(any(String.class));
+
+        ApiResponse response = languageController.sortLanguage("column");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(languageRepo, times(1)).sort(any(String.class));
+    }
+
+    @Test
+    public void testGetProquestLanguageCodes() {
+        Map<String, String> map = new HashMap<>();
+        map.put("a", "b");
+
+        when(proquestCodesService.getCodes(any(String.class))).thenReturn(map);
+
+        ApiResponse response = languageController.getProquestLanguageCodes();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> mapReturned = (HashMap<String, String>) response.getPayload().get("HashMap");
+        assertEquals(mapReturned.get("a"), map.get("a"));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/NoteControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/NoteControllerTest.java
@@ -1,0 +1,54 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.Note;
+import org.tdl.vireo.model.repo.NoteRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class NoteControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private NoteRepo noteRepo;
+
+    @InjectMocks
+    private NoteController noteController;
+
+    private Note mockNote1;
+
+    private static List<Note> mockNotes;
+
+    @BeforeEach
+    public void setup() {
+        mockNote1 = new Note("Note 1", "text 1");
+        mockNote1.setId(1L);
+
+        mockNotes = new ArrayList<Note>(Arrays.asList(new Note[] { mockNote1 }));
+    }
+
+    @Test
+    public void testAllNotes() {
+        when(noteRepo.findAll()).thenReturn(mockNotes);
+
+        ApiResponse response = noteController.getAllNotes();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Note>");
+        assertEquals(mockNotes.size(), list.size());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/OrganizationCategoryControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationCategoryControllerTest.java
@@ -1,0 +1,94 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.repo.OrganizationCategoryRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class OrganizationCategoryControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private OrganizationCategoryRepo organizationCategoryRepo;
+
+    @InjectMocks
+    private OrganizationCategoryController organizationCategoryController;
+
+    private OrganizationCategory mockOrganizationCategory1;
+    private OrganizationCategory mockOrganizationCategory2;
+
+    private static List<OrganizationCategory> mockOrganizationCategorys;
+
+    @BeforeEach
+    public void setup() {
+        mockOrganizationCategory1 = new OrganizationCategory("OrganizationCategory 1");
+        mockOrganizationCategory1.setId(1L);
+
+        mockOrganizationCategory2 = new OrganizationCategory("OrganizationCategory 2");
+        mockOrganizationCategory2.setId(2L);
+
+        mockOrganizationCategorys = new ArrayList<OrganizationCategory>(Arrays.asList(new OrganizationCategory[] { mockOrganizationCategory1 }));
+    }
+
+    @Test
+    public void testAllOrganizationCategorys() {
+        when(organizationCategoryRepo.findAll()).thenReturn(mockOrganizationCategorys);
+
+        ApiResponse response = organizationCategoryController.getOrganizationCategories();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<OrganizationCategory>");
+        assertEquals(mockOrganizationCategorys.size(), list.size());
+    }
+
+    @Test
+    public void testCreateOrganizationCategory() {
+        when(organizationCategoryRepo.create(any(String.class))).thenReturn(mockOrganizationCategory2);
+
+        ApiResponse response = organizationCategoryController.createOrganizationCategory(mockOrganizationCategory1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        OrganizationCategory organizationCategory = (OrganizationCategory) response.getPayload().get("OrganizationCategory");
+        assertEquals(mockOrganizationCategory2.getId(), organizationCategory.getId());
+    }
+
+    @Test
+    public void testUpdateOrganizationCategory() {
+        when(organizationCategoryRepo.update(any(OrganizationCategory.class))).thenReturn(mockOrganizationCategory2);
+
+        ApiResponse response = organizationCategoryController.updateOrganizationCategory(mockOrganizationCategory1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        OrganizationCategory organizationCategory = (OrganizationCategory) response.getPayload().get("OrganizationCategory");
+        assertEquals(mockOrganizationCategory2.getId(), organizationCategory.getId());
+    }
+
+    @Test
+    public void testRemoveOrganizationCategory() {
+        doNothing().when(organizationCategoryRepo).delete(any(OrganizationCategory.class));
+
+        ApiResponse response = organizationCategoryController.removeOrganizationCategory(mockOrganizationCategory1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(organizationCategoryRepo, times(1)).delete(any(OrganizationCategory.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
@@ -1,0 +1,118 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.repo.OrganizationRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class OrganizationControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private OrganizationRepo organizationRepo;
+
+    @InjectMocks
+    private OrganizationController organizationController;
+
+    private Organization mockOrganization1;
+    private Organization mockOrganization2;
+
+    private OrganizationCategory mockOrganizationCategory1;
+    private OrganizationCategory mockOrganizationCategory2;
+
+    private static List<Organization> mockOrganizations;
+
+    @BeforeEach
+    public void setup() {
+        mockOrganizationCategory1 = new OrganizationCategory("1");
+        mockOrganizationCategory1.setId(1L);
+
+        mockOrganizationCategory2 = new OrganizationCategory("2");
+        mockOrganizationCategory2.setId(2L);
+
+        mockOrganization1 = new Organization("Organization 1", mockOrganizationCategory1);
+        mockOrganization1.setId(1L);
+
+        mockOrganization2 = new Organization("Organization 2", mockOrganizationCategory2);
+        mockOrganization2.setId(2L);
+
+        mockOrganizations = new ArrayList<Organization>(Arrays.asList(new Organization[] { mockOrganization1 }));
+    }
+
+    @Test
+    public void testAllOrganizations() {
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(mockOrganizations);
+
+        ApiResponse response = organizationController.allOrganizations();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
+        assertEquals(mockOrganizations.size(), list.size());
+    }
+
+    @Test
+    public void testGetOrganization() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
+
+        ApiResponse response = organizationController.getOrganization(mockOrganization1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Organization organization = (Organization) response.getPayload().get("Organization");
+        assertEquals(mockOrganization1.getId(), organization.getId());
+    }
+
+    @Test
+    public void testCreateOrganization() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
+        when(organizationRepo.create(any(String.class), any(Organization.class), any(OrganizationCategory.class))).thenReturn(mockOrganization2);
+
+        ApiResponse response = organizationController.createOrganization(0L, mockOrganization1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Organization organization = (Organization) response.getPayload().get("Organization");
+        assertEquals(mockOrganization2.getId(), organization.getId());
+    }
+
+    @Test
+    public void testUpdateOrganization() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization2);
+        when(organizationRepo.update(any(Organization.class))).thenReturn(mockOrganization2);
+
+        ApiResponse response = organizationController.updateOrganization(mockOrganization1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Organization organization = (Organization) response.getPayload().get("Organization");
+        assertEquals(mockOrganization2.getId(), organization.getId());
+    }
+
+    @Test
+    public void testRemoveOrganization() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
+        doNothing().when(organizationRepo).delete(any(Organization.class));
+
+        ApiResponse response = organizationController.deleteOrganization(mockOrganization1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(organizationRepo, times(1)).delete(any(Organization.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/SubmissionStatusControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/SubmissionStatusControllerTest.java
@@ -1,0 +1,54 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.SubmissionStatus;
+import org.tdl.vireo.model.repo.SubmissionStatusRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class SubmissionStatusControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private SubmissionStatusRepo submissionStatusRepo;
+
+    @InjectMocks
+    private SubmissionStatusController submissionStatusController;
+
+    private SubmissionStatus mockSubmissionStatus1;
+
+    private static List<SubmissionStatus> mockSubmissionStatuss;
+
+    @BeforeEach
+    public void setup() {
+        mockSubmissionStatus1 = new SubmissionStatus();
+        mockSubmissionStatus1.setId(1L);
+
+        mockSubmissionStatuss = new ArrayList<SubmissionStatus>(Arrays.asList(new SubmissionStatus[] { mockSubmissionStatus1 }));
+    }
+
+    @Test
+    public void testAllSubmissionStatuss() {
+        when(submissionStatusRepo.findAll()).thenReturn(mockSubmissionStatuss);
+
+        ApiResponse response = submissionStatusController.getAllSubmissionStatuses();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionStatus>");
+        assertEquals(mockSubmissionStatuss.size(), list.size());
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
@@ -1,0 +1,71 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.WorkflowStep;
+import org.tdl.vireo.model.repo.WorkflowStepRepo;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public class WorkflowStepControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private WorkflowStepRepo fieldPredicateRepo;
+
+    @InjectMocks
+    private WorkflowStepController fieldPredicateController;
+
+    private WorkflowStep mockWorkflowStep1;
+    private WorkflowStep mockWorkflowStep2;
+
+    private static List<WorkflowStep> mockWorkflowSteps;
+
+    @BeforeEach
+    public void setup() {
+        mockWorkflowStep1 = new WorkflowStep("WorkflowStep 1");
+        mockWorkflowStep1.setId(1L);
+
+        mockWorkflowStep2 = new WorkflowStep("WorkflowStep 2");
+        mockWorkflowStep2.setId(2L);
+
+        mockWorkflowSteps = new ArrayList<WorkflowStep>(Arrays.asList(new WorkflowStep[] { mockWorkflowStep1 }));
+    }
+
+    @Test
+    public void testAllWorkflowSteps() {
+        when(fieldPredicateRepo.findAll()).thenReturn(mockWorkflowSteps);
+
+        ApiResponse response = fieldPredicateController.getAll();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<WorkflowStep>");
+        assertEquals(mockWorkflowSteps.size(), list.size());
+    }
+
+    @Test
+    public void testGetWorkflowStep() {
+        when(fieldPredicateRepo.findById(any(Long.class))).thenReturn(Optional.of(mockWorkflowStep1));
+
+        ApiResponse response = fieldPredicateController.getStepById(1L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        WorkflowStep fieldPredicate = (WorkflowStep) response.getPayload().get("WorkflowStep");
+        assertEquals(mockWorkflowStep1.getId(), fieldPredicate.getId());
+    }
+
+}


### PR DESCRIPTION
resolves #1819

This is based off of:
- #1812, which must be committed first.
- #1813, which must be committed second.
- #1818, which must be committed third.

All of which must be committed before this one.

This issue is that the error reporting in Deposit Location connection testing is making the reason for the failure unclear. Vireo is working but the bad error reporting is obfuscating the problem.

The **On Behalf Of** is to be solved in another newly created feature issue:
- #1820