### PR TITLE
Issue 1825: Use Integer.valueOf() to cast String to Integer for Deposit Location timeout.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/DepositLocationRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/DepositLocationRepoImpl.java
@@ -34,7 +34,6 @@ public class DepositLocationRepoImpl extends AbstractWeaverOrderedRepoImpl<Depos
 
     @Override
     public DepositLocation create(Map<String, Object> depositLocationJson) {
-
         Packager<?> packager = packagerRepo.findById(objectMapper.convertValue(depositLocationJson.get("packager"), JsonNode.class).get("id").asLong()).get();
 
         String onBehalfOf = null;
@@ -42,7 +41,9 @@ public class DepositLocationRepoImpl extends AbstractWeaverOrderedRepoImpl<Depos
             onBehalfOf = (String) depositLocationJson.get("onBehalfOf");
         }
 
-        return create((String) depositLocationJson.get("name"), (String) depositLocationJson.get("repository"), (String) depositLocationJson.get("collection"), (String) depositLocationJson.get("username"), (String) depositLocationJson.get("password"), onBehalfOf, packager, (String) depositLocationJson.get("depositorName"), (Integer) depositLocationJson.get("timeout"));
+        Integer timeout = Integer.valueOf((String) depositLocationJson.getOrDefault("timeout", "240"));
+
+        return create((String) depositLocationJson.get("name"), (String) depositLocationJson.get("repository"), (String) depositLocationJson.get("collection"), (String) depositLocationJson.get("username"), (String) depositLocationJson.get("password"), onBehalfOf, packager, (String) depositLocationJson.get("depositorName"), timeout);
     }
 
     @Override


### PR DESCRIPTION
resolves #1825

The `Integer.valueOf()` is the more proper way to conver to an integer.

Also add the default timeout of 240 as a fail safe.