### PR TITLE
Issue 1832: Handle unsupported dates in a safer manner.

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -304,10 +304,18 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
                     }
                 }
             } else {
-                date1Value = date1Value.toISOString();
+                var date = new Date(date1Value);
 
-                if (date2Value !== null) {
-                    date2Value = date2Value.toISOString();
+                if (!Number.isNaN(date) && !Number.isNaN(date.getTime())) {
+                    date1Value = date.toISOString();
+
+                    if (date2Value !== null) {
+                        date = new Date(date2Value);
+
+                        if (!Number.isNaN(date) && !Number.isNaN(date.getTime())) {
+                            date2Value = date2Value.toISOString();
+                        }
+                    }
                 }
             }
 

--- a/src/main/webapp/app/filters/displayFieldValue.js
+++ b/src/main/webapp/app/filters/displayFieldValue.js
@@ -48,12 +48,18 @@ vireo.filter('displayFieldValue', function($filter, InputTypes) {
                 return value;
             }
 
-            return $filter('date')(new Date(split[1] + ' 01, ' + split[2]).toISOString(), dateColumn.format, 'utc');
+            var date = new Date(split[1] + ' 01, ' + split[2]);
+
+            if (Number.isNaN(date) || Number.isNaN(date.getTime())) {
+                return value;
+            }
+
+            return $filter('date')(date.toISOString(), dateColumn.format, 'utc');
         }
 
         var date = new Date(value);
 
-        if (isNaN(date)) {
+        if (isNaN(date) || Number.isNaN(date.getTime())) {
             return value;
         }
 

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -706,7 +706,11 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
                             offsetDate.setSeconds(0);
                             offsetDate.setMilliseconds(0);
 
-                            fieldValue.valuePopup = offsetDate.toISOString();
+                            if (Number.isNaN(offsetDate.getTime())) {
+                                fieldValue.valuePopup = fieldValue.value;
+                            } else {
+                                fieldValue.valuePopup = offsetDate.toISOString();
+                            }
                         }
                     } else {
                         fieldValue.valuePopup = fieldValue.value;


### PR DESCRIPTION
resolves #1832

Check for `isNan()` in more cases to prevent Javascript exception. The web page should still load even on invalid date. The dates will fallback to the non-updated value if cannot convert.

see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Invalid_date