### PR TITLE
Issue 1807: Deposit ID and Notes list problems and escape SQL improvements.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -232,7 +232,7 @@ public class Submission extends ValidatingBaseEntity {
     @Column(nullable = true)
     private String advisorReviewURL;
 
-    @JsonView(Views.SubmissionIndividual.class)
+    @JsonView(Views.SubmissionList.class)
     @Column(nullable = true)
     private String depositURL;
 

--- a/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
+++ b/src/main/resources/submission_list_columns/SYSTEM_Default_Submission_List_Columns.json
@@ -109,7 +109,7 @@
   {
     "title": "Deposit ID",
     "sort": "NONE",
-    "valuePath": [],
+    "valuePath": ["depositURL"],
     "status": null,
     "inputType": {
       "name": "INPUT_TEXT"


### PR DESCRIPTION
resolves #1807

The Deposit ID and the Notes are both not being filtered and displayed properly on the Submission List admin view page.

The `depositURL` must be set to the JsonView of `Views.SubmissionList.class` to allow for the data to be transferred.

The columns must be selected in the SQL query in the "alias" part of the query. Change the logic to handle this.
Fix an SQL escape security concern while working on this.

The System default for the Submission List columns is missing the appropriate `valuePath`. The `valuePath` must be set to exactly what the Submission model returns (case-sensitive), which happens to be `depositURL`.