### PR TITLE
Issue 1835: Fix Non-Chairing Committee Contact E-mails to show up on forms.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/AbstractFieldProfile.java
+++ b/src/main/java/org/tdl/vireo/model/AbstractFieldProfile.java
@@ -24,7 +24,7 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 @Table(uniqueConstraints = @UniqueConstraint(columnNames = { "originating_workflow_step_id", "field_predicate_id", "fp_type", "overrideable" }))
 public abstract class AbstractFieldProfile<FP> extends ValidatingBaseEntity {
 
-    @JsonView(Views.SubmissionIndividual.class)
+    @JsonView(Views.Partial.class)
     @ManyToOne(fetch = EAGER, optional = false)
     private FieldPredicate fieldPredicate;
 

--- a/src/main/java/org/tdl/vireo/model/AbstractWorkflowStep.java
+++ b/src/main/java/org/tdl/vireo/model/AbstractWorkflowStep.java
@@ -28,7 +28,7 @@ public abstract class AbstractWorkflowStep<WS extends AbstractWorkflowStep<WS, F
     @Column(nullable = false)
     private Boolean overrideable;
 
-    @JsonView(Views.SubmissionIndividual.class)
+    @JsonView(Views.Partial.class)
     @ManyToMany(cascade = { REFRESH }, fetch = EAGER)
     @OrderColumn
     private List<FP> aggregateFieldProfiles;

--- a/src/main/java/org/tdl/vireo/model/VocabularyWord.java
+++ b/src/main/java/org/tdl/vireo/model/VocabularyWord.java
@@ -40,6 +40,7 @@ public class VocabularyWord extends ValidatingBaseEntity {
     @Column(nullable = true)
     private String identifier;
 
+    @JsonView(Views.Partial.class)
     @ElementCollection(fetch = LAZY)
     @Fetch(FetchMode.SUBSELECT)
     private List<String> contacts;


### PR DESCRIPTION
resolves #1835

Previous sprints improved performance by adding `@JsonView` and causing this regression.

The Vocabulary Word needs to include the contacts e-mails for the Field Predicate and Field Profile. Add `@JsonView(Views.Partial.class)` to the contacts in Vocabulary Word.

This, however, is not enough.
Both the Field Predicate and the Field Profile need to be set to at least `Views.Partial.class`.

When this is done, the contact e-mail will now transfer to the UI as expected and required.