### PR TITLE
Improve Unit Tests for Controllers, Models, and Enumerations.

### DIFF
--- a/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
@@ -61,10 +61,10 @@ public abstract class AbstractControllerTest extends MockData {
     protected BCryptPasswordEncoder passwordEncoder;
 
     @Mock
-    private SimpMessagingTemplate simpMessagingTemplate;
+    protected SimpMessagingTemplate simpMessagingTemplate;
 
     @Mock
-    private Environment env;
+    protected Environment env;
 
     @Mock
     protected TokenService tokenService;
@@ -72,14 +72,13 @@ public abstract class AbstractControllerTest extends MockData {
     @Mock
     protected MockEmailService mockEmailService;
 
-    @Spy
     @InjectMocks
     protected HttpUtility httpUtility;
 
-    @InjectMocks
+    @Mock
     protected CryptoService cryptoService;
 
-    @InjectMocks
+    @Mock
     protected TemplateUtility templateUtility;
 
     protected Credentials TEST_CREDENTIALS = new Credentials();

--- a/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
@@ -1,13 +1,19 @@
 package org.tdl.vireo.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.weaver.auth.model.Credentials;
+import edu.tamu.weaver.auth.service.CryptoService;
+import edu.tamu.weaver.email.service.MockEmailService;
+import edu.tamu.weaver.token.service.TokenService;
+import edu.tamu.weaver.utility.HttpUtility;
 import java.security.Key;
-
 import javax.crypto.spec.SecretKeySpec;
-
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.env.Environment;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -16,15 +22,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.tdl.vireo.mock.MockData;
 import org.tdl.vireo.utility.TemplateUtility;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import edu.tamu.weaver.auth.model.Credentials;
-import edu.tamu.weaver.auth.service.CryptoService;
-import edu.tamu.weaver.email.service.MockEmailService;
-import edu.tamu.weaver.token.service.TokenService;
-import edu.tamu.weaver.utility.HttpUtility;
-
 @ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 @ExtendWith(SpringExtension.class)
 public abstract class AbstractControllerTest extends MockData {
 
@@ -60,7 +59,8 @@ public abstract class AbstractControllerTest extends MockData {
     @Spy
     protected BCryptPasswordEncoder passwordEncoder;
 
-    @Mock
+    // Must use MockBean rather than Mock here because LookAndFeelController.executeLogoReset() calls simpMessagingTemplate.
+    @MockBean
     protected SimpMessagingTemplate simpMessagingTemplate;
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/AbstractControllerTest.java
@@ -76,11 +76,9 @@ public abstract class AbstractControllerTest extends MockData {
     @InjectMocks
     protected HttpUtility httpUtility;
 
-    @Spy
     @InjectMocks
     protected CryptoService cryptoService;
 
-    @Spy
     @InjectMocks
     protected TemplateUtility templateUtility;
 

--- a/src/test/java/org/tdl/vireo/controller/ConfigurableSettingsControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/ConfigurableSettingsControllerTest.java
@@ -1,0 +1,146 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.Configuration;
+import org.tdl.vireo.model.DefaultConfiguration;
+import org.tdl.vireo.model.ManagedConfiguration;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.service.VireoThemeManagerService;
+
+@ActiveProfiles("test")
+public class ConfigurableSettingsControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private ConfigurationRepo configurationRepo;
+
+    @Mock
+    private VireoThemeManagerService themeManagerService;
+
+    @InjectMocks
+    private ConfigurableSettingsController configurableSettingsController;
+
+    private static Map<String, List<Configuration>> mockConfiguration;
+    private static List<Configuration> defaultConfigurations;
+    private static List<Configuration> managedConfigurations;
+    private static List<Configuration> managedLookAndFeelConfigurations;
+    private static DefaultConfiguration defaultConfiguration;
+    private static ManagedConfiguration managedConfiguration;
+    private static ManagedConfiguration managedLookAndFeelConfiguration;
+
+    @BeforeEach
+    public void setup() {
+        defaultConfiguration = new DefaultConfiguration("default name", "value", "default");
+        managedConfiguration = new ManagedConfiguration("managed name", "value", "managed");
+        managedLookAndFeelConfiguration = new ManagedConfiguration("managed name", "value", "lookAndFeel");
+        defaultConfigurations = new ArrayList<>();
+        managedConfigurations = new ArrayList<>();
+        managedLookAndFeelConfigurations = new ArrayList<>();
+        mockConfiguration = new HashMap<>();
+
+        defaultConfigurations.add(defaultConfiguration);
+        managedConfigurations.add(managedConfiguration);
+        managedLookAndFeelConfigurations.add(managedLookAndFeelConfiguration);
+
+        mockConfiguration.put("default", defaultConfigurations);
+        mockConfiguration.put("managed", managedConfigurations);
+        mockConfiguration.put("lookAndFeel", managedLookAndFeelConfigurations);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetSettings() {
+        when(configurationRepo.getCurrentConfigurations()).thenReturn(mockConfiguration);
+
+        ApiResponse response = configurableSettingsController.getSettings();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Map<String, List<Configuration>> map = (HashMap<String, List<Configuration>>) response.getPayload().get("HashMap");
+        assertNotNull(mockConfiguration, "Payload response is not a HashMap.");
+        assertEquals(mockConfiguration.size(), map.size(), "Payload response map is the wrong length.");
+        assertEquals(mockConfiguration.get("default"), map.get("default"), "Map['default'] is not the correct configurations array.");
+    }
+
+    @Test
+    public void testUpdateSettings() {
+        when(configurationRepo.save(any(ManagedConfiguration.class))).thenReturn(managedConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = configurableSettingsController.updateSetting(managedConfiguration);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ManagedConfiguration managed = (ManagedConfiguration) response.getPayload().get("ManagedConfiguration");
+        assertNotNull(managed, "Payload response is not a ManagedConfiguration.");
+        assertEquals(managedConfiguration, managed, "Payload response is not the correct configuration.");
+
+        Mockito.verify(themeManagerService, Mockito.never()).refreshCurrentTheme();
+        Mockito.verify(simpMessagingTemplate, Mockito.only()).convertAndSend(anyString(), any(ApiResponse.class));
+    }
+
+    @Test
+    public void testUpdateSettingsForLookAndFeelType() {
+        when(configurationRepo.save(any(ManagedConfiguration.class))).thenReturn(managedLookAndFeelConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = configurableSettingsController.updateSetting(managedLookAndFeelConfiguration);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ManagedConfiguration managed = (ManagedConfiguration) response.getPayload().get("ManagedConfiguration");
+        assertNotNull(managed, "Payload response is not a ManagedConfiguration.");
+        assertEquals(managedLookAndFeelConfiguration, managed, "Payload response is not the correct configuration.");
+
+        Mockito.verify(themeManagerService, Mockito.only()).refreshCurrentTheme();
+        Mockito.verify(simpMessagingTemplate, Mockito.only()).convertAndSend(anyString(), any(ApiResponse.class));
+    }
+
+    @Test
+    public void testResetSettings() {
+        when(configurationRepo.reset(any(ManagedConfiguration.class))).thenReturn(defaultConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = configurableSettingsController.resetSetting(managedConfiguration);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DefaultConfiguration defaultConfig = (DefaultConfiguration) response.getPayload().get("DefaultConfiguration");
+        assertNotNull(defaultConfig, "Payload response is not a DefaultConfiguration.");
+        assertEquals(defaultConfiguration, defaultConfig, "Payload response is not the correct configuration.");
+
+        Mockito.verify(themeManagerService, Mockito.never()).refreshCurrentTheme();
+        Mockito.verify(simpMessagingTemplate, Mockito.only()).convertAndSend(anyString(), any(ApiResponse.class));
+    }
+
+    @Test
+    public void testResetSettingsForLookAndFeelType() {
+        when(configurationRepo.reset(any(ManagedConfiguration.class))).thenReturn(defaultConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+        doNothing().when(themeManagerService).refreshCurrentTheme();
+
+        ApiResponse response = configurableSettingsController.resetSetting(managedLookAndFeelConfiguration);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        DefaultConfiguration defaultConfig = (DefaultConfiguration) response.getPayload().get("DefaultConfiguration");
+        assertNotNull(defaultConfig, "Payload response is not a DefaultConfiguration.");
+        assertEquals(defaultConfiguration, defaultConfig, "Payload response is not the correct configuration.");
+
+        Mockito.verify(themeManagerService, Mockito.only()).refreshCurrentTheme();
+        Mockito.verify(simpMessagingTemplate, Mockito.only()).convertAndSend(anyString(), any(ApiResponse.class));
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
@@ -2,106 +2,153 @@ package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiStatus;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+import org.tdl.vireo.Application;
 import org.tdl.vireo.model.ControlledVocabulary;
+import org.tdl.vireo.model.ControlledVocabularyCache;
+import org.tdl.vireo.model.VocabularyWord;
 import org.tdl.vireo.model.repo.ControlledVocabularyRepo;
+import org.tdl.vireo.model.repo.VocabularyWordRepo;
+import org.tdl.vireo.service.ControlledVocabularyCachingService;
 
+@SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class ControlledVocabularyControllerTest extends AbstractControllerTest {
 
     @Mock
     private ControlledVocabularyRepo controlledVocabularyRepo;
 
+    @Mock
+    private VocabularyWordRepo vocabularyWordRepo;
+
+    @Mock
+    private ControlledVocabularyCachingService controlledVocabularyCachingService;
+
     @InjectMocks
     private ControlledVocabularyController controlledVocabularyController;
 
-    private ControlledVocabulary mockControlledVocabulary1;
-    private ControlledVocabulary mockControlledVocabulary2;
+    private ControlledVocabulary controlledVocabulary1;
+    private ControlledVocabulary controlledVocabulary2;
 
-    private static List<ControlledVocabulary> mockControlledVocabularys;
+    private VocabularyWord vocabularyWord1;
+    private VocabularyWord vocabularyWord2;
+
+    private List<String> contacts1;
+    private List<String> contacts2;
+
+    private List<VocabularyWord> dictionaries1;
+    private List<VocabularyWord> dictionaries2;
+
+    private List<ControlledVocabulary> controlledVocabularys;
 
     @BeforeEach
     public void setup() {
-        mockControlledVocabulary1 = new ControlledVocabulary("ControlledVocabulary 1");
-        mockControlledVocabulary1.setId(1L);
+        contacts1 = new ArrayList<>();
+        contacts1.add("contact1");
 
-        mockControlledVocabulary2 = new ControlledVocabulary("ControlledVocabulary 2");
-        mockControlledVocabulary2.setId(2L);
+        contacts2 = new ArrayList<>();
+        contacts2.add("contact2");
 
-        mockControlledVocabularys = new ArrayList<ControlledVocabulary>(Arrays.asList(new ControlledVocabulary[] { mockControlledVocabulary1 }));
+        vocabularyWord1 = new VocabularyWord("name1", "definition1", "identifier1", contacts1);
+        vocabularyWord2 = new VocabularyWord("name2", "definition2", "identifier2", contacts2);
+
+        vocabularyWord1.setId(1L);
+        vocabularyWord2.setId(2L);
+
+        dictionaries1 = new ArrayList<>();
+        dictionaries1.add(vocabularyWord1);
+
+        dictionaries2 = new ArrayList<>();
+        dictionaries2.add(vocabularyWord2);
+
+        controlledVocabulary1 = new ControlledVocabulary("ControlledVocabulary 1", false);
+        controlledVocabulary1.setId(1L);
+        controlledVocabulary1.setDictionary(dictionaries1);
+        controlledVocabulary1.setPosition(1L);
+
+        controlledVocabulary2 = new ControlledVocabulary("ControlledVocabulary 2", false);
+        controlledVocabulary2.setId(2L);
+        controlledVocabulary2.setDictionary(dictionaries2);
+        controlledVocabulary2.setPosition(2L);
+
+        controlledVocabularys = new ArrayList<ControlledVocabulary>(Arrays.asList(new ControlledVocabulary[] { controlledVocabulary1 }));
     }
 
     @Test
     public void testAllControlledVocabularys() {
-        when(controlledVocabularyRepo.findAllByOrderByPositionAsc()).thenReturn(mockControlledVocabularys);
+        when(controlledVocabularyRepo.findAllByOrderByPositionAsc()).thenReturn(controlledVocabularys);
 
         ApiResponse response = controlledVocabularyController.getAllControlledVocabulary();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<ControlledVocabulary>");
-        assertEquals(mockControlledVocabularys.size(), list.size());
+        assertEquals(controlledVocabularys.size(), list.size());
     }
 
     @Test
     public void testGetControlledVocabulary() {
-        when(controlledVocabularyRepo.findByName(any(String.class))).thenReturn(mockControlledVocabulary1);
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
 
         ApiResponse response = controlledVocabularyController.getControlledVocabularyByName("name");
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
-        assertEquals(mockControlledVocabulary1.getId(), controlledVocabulary.getId());
+        assertEquals(controlledVocabulary1.getId(), controlledVocabulary.getId());
     }
 
     @Test
     public void testCreateControlledVocabulary() {
-        when(controlledVocabularyRepo.create(any(String.class))).thenReturn(mockControlledVocabulary2);
+        when(controlledVocabularyRepo.create(anyString())).thenReturn(controlledVocabulary2);
 
-        ApiResponse response = controlledVocabularyController.createControlledVocabulary(mockControlledVocabulary1);
+        ApiResponse response = controlledVocabularyController.createControlledVocabulary(controlledVocabulary1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
-        assertEquals(mockControlledVocabulary2.getId(), controlledVocabulary.getId());
+        assertEquals(controlledVocabulary2.getId(), controlledVocabulary.getId());
     }
 
     @Test
     public void testUpdateControlledVocabulary() {
-        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(mockControlledVocabulary2));
-        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(mockControlledVocabulary2);
+        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(controlledVocabulary2));
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary2);
 
-        ApiResponse response = controlledVocabularyController.updateControlledVocabulary(mockControlledVocabulary1);
+        ApiResponse response = controlledVocabularyController.updateControlledVocabulary(controlledVocabulary1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         ControlledVocabulary controlledVocabulary = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
-        assertEquals(mockControlledVocabulary2.getId(), controlledVocabulary.getId());
+        assertEquals(controlledVocabulary2.getId(), controlledVocabulary.getId());
     }
 
     @Test
     public void testRemoveControlledVocabulary() {
         doNothing().when(controlledVocabularyRepo).remove(any(ControlledVocabulary.class));
 
-        ApiResponse response = controlledVocabularyController.removeControlledVocabulary(mockControlledVocabulary1);
+        ApiResponse response = controlledVocabularyController.removeControlledVocabulary(controlledVocabulary1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(controlledVocabularyRepo, times(1)).remove(any(ControlledVocabulary.class));
+        verify(controlledVocabularyRepo, only()).remove(any(ControlledVocabulary.class));
     }
 
     @Test
@@ -111,17 +158,278 @@ public class ControlledVocabularyControllerTest extends AbstractControllerTest {
         ApiResponse response = controlledVocabularyController.reorderControlledVocabulary(1L, 2L);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(controlledVocabularyRepo, times(1)).reorder(any(Long.class), any(Long.class));
+        verify(controlledVocabularyRepo, only()).reorder(any(Long.class), any(Long.class));
     }
 
     @Test
     public void testSortControlledVocabularys() {
-        doNothing().when(controlledVocabularyRepo).sort(any(String.class));
+        doNothing().when(controlledVocabularyRepo).sort(anyString());
 
         ApiResponse response = controlledVocabularyController.sortControlledVocabulary("column");
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(controlledVocabularyRepo, times(1)).sort(any(String.class));
+        verify(controlledVocabularyRepo, only()).sort(anyString());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testExportControlledVocabulary() {
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+
+        ApiResponse response = controlledVocabularyController.exportControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Map<String, Object> map = (HashMap<String, Object>) response.getPayload().get("HashMap");
+
+        assertEquals(2, map.size(), "Returned map has the wrong size.");
+
+        List<String> headers = (List<String>) map.get("headers");
+        assertEquals(4, headers.size(), "Returned map has the wrong headers size.");
+        assertEquals("name",  headers.get(0), "The headers has the wrong value for name column.");
+        assertEquals("definition",  headers.get(1), "The headers has the wrong value for definition column.");
+        assertEquals("identifier",  headers.get(2), "The headers has the wrong value for identifier column.");
+        assertEquals("contacts",  headers.get(3), "The headers has the wrong value for contacts column.");
+
+        // Warning: The 'List<List<Object>>' should probably instead be 'List<List<String>>' in exportControlledVocabulary().
+        List<List<String>> rows = (List<List<String>>) map.get("rows");
+        assertEquals(1, rows.size(), "Returned map has the wrong rows size.");
+        assertEquals(vocabularyWord1.getName(), rows.get(0).get(0), "The row has the wrong name.");
+        assertEquals(vocabularyWord1.getDefinition(), rows.get(0).get(1), "The row has the wrong definition.");
+        assertEquals(vocabularyWord1.getIdentifier(), rows.get(0).get(2), "The row has the wrong identifier.");
+
+        // Warning: There is a possible bug here where if the contacts has a comma, then the form will be incorrect.
+        assertEquals(String.join(",", vocabularyWord1.getContacts()), rows.get(0).get(3), "The row has the wrong contacts.");
+
+        verify(controlledVocabularyRepo, only()).findByName(anyString());
+    }
+
+    @Test
+    public void testImportControlledVocabularyStatus() {
+        when(controlledVocabularyCachingService.doesControlledVocabularyExist(anyString())).thenReturn(true);
+
+        ApiResponse response = controlledVocabularyController.importControlledVocabularyStatus("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Boolean got = (Boolean) response.getPayload().get("Boolean");
+        assertEquals(true, got, "Returned boolean has the wrong value.");
+
+        verify(controlledVocabularyCachingService, only()).doesControlledVocabularyExist(anyString());
+    }
+
+    @Test
+    public void testCancelImportControlledVocabulary() {
+        doNothing().when(controlledVocabularyCachingService).removeControlledVocabularyCache(anyString());
+
+        ApiResponse response = controlledVocabularyController.cancelImportControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyCachingService, only()).removeControlledVocabularyCache(anyString());
+    }
+
+    @Test
+    public void testCompareControlledVocabulary() throws IOException {
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        doNothing().when(controlledVocabularyCachingService).addControlledVocabularyCache(any(ControlledVocabularyCache.class));
+
+        MultipartFile file = new MockMultipartFile("name", "originalName", "text/plain", "".getBytes());
+
+        ApiResponse response = controlledVocabularyController.compareControlledVocabulary("name", file);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyCachingService, only()).addControlledVocabularyCache(any(ControlledVocabularyCache.class));
+    }
+
+    @Test
+    public void testCompareControlledVocabularyWithCSV() throws IOException {
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        doNothing().when(controlledVocabularyCachingService).addControlledVocabularyCache(any(ControlledVocabularyCache.class));
+
+        MultipartFile file = new MockMultipartFile("name", "originalName", "text/plain", "name,definition,identifier,contacts\nname1,definition1,identifier1,\nname2,definition2,identifier2,contact1\nname2,definition2,identifier2,contact2".getBytes());
+
+        ApiResponse response = controlledVocabularyController.compareControlledVocabulary("name", file);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(controlledVocabularyCachingService, only()).addControlledVocabularyCache(any(ControlledVocabularyCache.class));
+    }
+
+    @Test
+    public void testImportControlledVocabulary() {
+        ControlledVocabularyCache cache = new ControlledVocabularyCache();
+        cache.setControlledVocabularyName(controlledVocabulary1.getName());
+        cache.setNewVocabularyWords(new ArrayList<>());
+        cache.setUpdatingVocabularyWords(new ArrayList<>());
+        cache.setRemovedVocabularyWords(new ArrayList<>());
+        cache.setTimestamp(1234L);
+
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        when(controlledVocabularyCachingService.getControlledVocabularyCache(anyString())).thenReturn(cache);
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary2);
+        doNothing().when(controlledVocabularyCachingService).removeControlledVocabularyCache(anyString());
+
+        ApiResponse response = controlledVocabularyController.importControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary got = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(controlledVocabulary2, got, "Did not get expected Controlled Vocabulary in the response.");
+
+        // Warning: These checks are throwing NPE.
+        //verify(controlledVocabularyCachingService, only()).getControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyCachingService, only()).removeControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyRepo, only()).update(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testImportControlledVocabularyWithNewVocabularyWord() {
+        List<VocabularyWord> newWords = new ArrayList<>();
+        newWords.add(vocabularyWord2);
+
+        ControlledVocabularyCache cache = new ControlledVocabularyCache();
+        cache.setControlledVocabularyName(controlledVocabulary1.getName());
+        cache.setNewVocabularyWords(newWords);
+        cache.setUpdatingVocabularyWords(new ArrayList<>());
+        cache.setRemovedVocabularyWords(new ArrayList<>());
+        cache.setTimestamp(1234L);
+
+        VocabularyWord newWord = new VocabularyWord(controlledVocabulary1, "name3", "definition3", "identifier3", contacts1);
+        newWord.setId(3L);
+
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        when(controlledVocabularyCachingService.getControlledVocabularyCache(anyString())).thenReturn(cache);
+        when(vocabularyWordRepo.create(any(), any(), any(), any(), any())).thenReturn(newWord);
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary2);
+        doNothing().when(controlledVocabularyCachingService).removeControlledVocabularyCache(anyString());
+
+        ApiResponse response = controlledVocabularyController.importControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary got = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(controlledVocabulary2, got, "Did not get expected Controlled Vocabulary in the response.");
+
+        verify(vocabularyWordRepo, only()).create(any(), any(), any(), any(), any());
+
+        // Warning: These checks are throwing NPE.
+        //verify(controlledVocabularyCachingService, only()).getControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyCachingService, only()).removeControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyRepo, only()).update(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testImportControlledVocabularyWithUpdatingVocabularyWord() {
+        // Warning: importControlledVocabulary() is expected updatingVocabularyWord[1].
+        VocabularyWord[] updatingWords = { vocabularyWord1, vocabularyWord1 };
+        List<VocabularyWord[]> updatingWordsList = new ArrayList<>();
+        updatingWordsList.add(updatingWords);
+
+        ControlledVocabularyCache cache = new ControlledVocabularyCache();
+        cache.setControlledVocabularyName(controlledVocabulary1.getName());
+        cache.setNewVocabularyWords(new ArrayList<>());
+        cache.setUpdatingVocabularyWords(updatingWordsList);
+        cache.setRemovedVocabularyWords(new ArrayList<>());
+        cache.setTimestamp(1234L);
+
+        VocabularyWord newWord = new VocabularyWord(controlledVocabulary1, "name3", "definition3", "identifier3", contacts1);
+        newWord.setId(3L);
+
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        when(controlledVocabularyCachingService.getControlledVocabularyCache(anyString())).thenReturn(cache);
+        when(vocabularyWordRepo.findByNameAndControlledVocabulary(anyString(), any(ControlledVocabulary.class))).thenReturn(vocabularyWord1);
+        when(vocabularyWordRepo.save(any(VocabularyWord.class))).thenReturn(newWord);
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary2);
+        doNothing().when(controlledVocabularyCachingService).removeControlledVocabularyCache(anyString());
+
+        ApiResponse response = controlledVocabularyController.importControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary got = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(controlledVocabulary2, got, "Did not get expected Controlled Vocabulary in the response.");
+
+        // Warning: These checks are throwing NPE.
+        //verify(vocabularyWordRepo, only()).save(any(VocabularyWord.class));
+        //verify(controlledVocabularyCachingService, only()).getControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyCachingService, only()).removeControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyRepo, only()).update(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testImportControlledVocabularyWithRemoveVocabularyWord() {
+        // Warning: importControlledVocabulary() calls another controller method: removeVocabularyWord().
+        List<VocabularyWord> removeWords = new ArrayList<>();
+        removeWords.add(vocabularyWord1);
+
+        ControlledVocabularyCache cache = new ControlledVocabularyCache();
+        cache.setControlledVocabularyName(controlledVocabulary1.getName());
+        cache.setNewVocabularyWords(new ArrayList<>());
+        cache.setUpdatingVocabularyWords(new ArrayList<>());
+        cache.setRemovedVocabularyWords(removeWords);
+        cache.setTimestamp(1234L);
+
+        when(controlledVocabularyRepo.findByName(anyString())).thenReturn(controlledVocabulary1);
+        when(controlledVocabularyCachingService.getControlledVocabularyCache(anyString())).thenReturn(cache);
+        when(controlledVocabularyRepo.findById(any())).thenReturn(Optional.of(controlledVocabulary1));
+        when(vocabularyWordRepo.findById(any())).thenReturn(Optional.of(vocabularyWord1));
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary2);
+        doNothing().when(controlledVocabularyCachingService).removeControlledVocabularyCache(anyString());
+
+        ApiResponse response = controlledVocabularyController.importControlledVocabulary("name");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary got = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(controlledVocabulary2, got, "Did not get expected Controlled Vocabulary in the response.");
+
+        // Warning: These checks are throwing NPE.
+        //verify(controlledVocabularyCachingService, only()).getControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyCachingService, only()).removeControlledVocabularyCache(anyString());
+        //verify(controlledVocabularyRepo, only()).update(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testAddVocabularyWord() {
+        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(controlledVocabulary1));
+        when(vocabularyWordRepo.create(any(), any(), any(), any(), any())).thenReturn(vocabularyWord1);
+        doNothing().when(controlledVocabularyRepo).broadcast(any(Long.class));
+
+        ApiResponse response = controlledVocabularyController.addVocabularyWord(vocabularyWord1.getId(), vocabularyWord1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        VocabularyWord got = (VocabularyWord) response.getPayload().get("VocabularyWord");
+        assertEquals(vocabularyWord1, got, "Did not get expected Vocabulary Word in the response.");
+
+        verify(vocabularyWordRepo, only()).create(any(), any(), any(), any(), any());
+
+        // Warning: These checks are throwing NPE.
+        //verify(controlledVocabularyRepo, only()).broadcast(any(Long.class));
+    }
+
+    @Test
+    public void testRemoveVocabularyWord() {
+        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(controlledVocabulary1));
+        when(vocabularyWordRepo.findById(any(Long.class))).thenReturn(Optional.of(vocabularyWord1));
+        when(controlledVocabularyRepo.update(any(ControlledVocabulary.class))).thenReturn(controlledVocabulary1);
+
+        ApiResponse response = controlledVocabularyController.removeVocabularyWord(vocabularyWord1.getId(), 100L);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ControlledVocabulary got = (ControlledVocabulary) response.getPayload().get("ControlledVocabulary");
+        assertEquals(controlledVocabulary1, got, "Did not get expected Controlled Vocabulary in the response.");
+
+        // Warning: These checks are throwing NPE.
+        //verify(controlledVocabularyRepo, only()).update(any(ControlledVocabulary.class));
+    }
+
+    @Test
+    public void testUpdateVocabularyWord() {
+        when(controlledVocabularyRepo.findById(any(Long.class))).thenReturn(Optional.of(controlledVocabulary1));
+        when(vocabularyWordRepo.update(any(VocabularyWord.class))).thenReturn(vocabularyWord1);
+        doNothing().when(controlledVocabularyRepo).broadcast(any(Long.class));
+
+        ApiResponse response = controlledVocabularyController.updateVocabularyWord(vocabularyWord1.getId(), vocabularyWord2);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        VocabularyWord got = (VocabularyWord) response.getPayload().get("VocabularyWord");
+        assertEquals(vocabularyWord1, got, "Did not get expected Vocabulary Word in the response.");
+
+        // Warning: These checks are throwing NPE.
+        //verify(vocabularyWordRepo, only()).update(any(VocabularyWord.class));
     }
 
 }

--- a/src/test/java/org/tdl/vireo/controller/CustomActionControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/CustomActionControllerTest.java
@@ -14,16 +14,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.CustomActionDefinition;
 import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class CustomActionControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/DegreeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DegreeControllerTest.java
@@ -2,8 +2,8 @@ package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,10 +16,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.Degree;
 import org.tdl.vireo.model.DegreeLevel;
@@ -27,7 +25,6 @@ import org.tdl.vireo.model.repo.DegreeRepo;
 import org.tdl.vireo.service.ProquestCodesService;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class DegreeControllerTest extends AbstractControllerTest {
 
     @Mock
@@ -39,74 +36,85 @@ public class DegreeControllerTest extends AbstractControllerTest {
     @InjectMocks
     private DegreeController degreeController;
 
-    private Degree mockDegree1;
-    private Degree mockDegree2;
+    private Degree degree1;
+    private Degree degree2;
 
-    private DegreeLevel mockDegreeLevel1;
-    private DegreeLevel mockDegreeLevel2;
+    private DegreeLevel degreeLevel1;
+    private DegreeLevel degreeLevel2;
 
-    private static List<Degree> mockDegrees;
+    private static List<Degree> degrees;
 
     @BeforeEach
     public void setup() {
-        mockDegreeLevel1 = new DegreeLevel("1");
-        mockDegreeLevel1.setId(1L);
+        degreeLevel1 = new DegreeLevel("1");
+        degreeLevel2 = new DegreeLevel("2");
+        degree1 = new Degree("Degree 1", degreeLevel1, "Proquest 1");
+        degree2 = new Degree("Degree 2", degreeLevel2, "Proquest 2");
 
-        mockDegreeLevel2 = new DegreeLevel("2");
-        mockDegreeLevel2.setId(2L);
+        degreeLevel1.setId(1L);
+        degreeLevel2.setId(2L);
+        degree1.setId(1L);
+        degree2.setId(2L);
 
-        mockDegree1 = new Degree("Degree 1", mockDegreeLevel1, "Proquest 1");
-        mockDegree1.setId(1L);
-        mockDegree1.setPosition(1L);
+        degree1.setPosition(1L);
+        degree2.setPosition(2L);
 
-        mockDegree2 = new Degree("Degree 2", mockDegreeLevel2, "Proquest 2");
-        mockDegree2.setId(2L);
-        mockDegree2.setPosition(2L);
-
-        mockDegrees = new ArrayList<Degree>(Arrays.asList(new Degree[] { mockDegree1 }));
+        degrees = new ArrayList<Degree>(Arrays.asList(new Degree[] { degree1 }));
     }
 
     @Test
     public void testAllDegrees() {
-        when(degreeRepo.findAllByOrderByPositionAsc()).thenReturn(mockDegrees);
+        when(degreeRepo.findAllByOrderByPositionAsc()).thenReturn(degrees);
 
         ApiResponse response = degreeController.allDegrees();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Degree>");
-        assertEquals(mockDegrees.size(), list.size());
+        assertEquals(degrees.size(), list.size());
     }
 
     @Test
     public void testCreateDegree() {
-        when(degreeRepo.create(any(String.class), any(DegreeLevel.class))).thenReturn(mockDegree2);
+        when(degreeRepo.create(any(String.class), any(DegreeLevel.class))).thenReturn(degree2);
 
-        ApiResponse response = degreeController.createDegree(mockDegree1);
+        ApiResponse response = degreeController.createDegree(degree1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         Degree degree = (Degree) response.getPayload().get("Degree");
-        assertEquals(mockDegree2.getId(), degree.getId());
+        assertEquals(degree2.getId(), degree.getId());
     }
 
     @Test
     public void testUpdateDegree() {
-        when(degreeRepo.update(any(Degree.class))).thenReturn(mockDegree2);
+        when(degreeRepo.update(any(Degree.class))).thenReturn(degree2);
 
-        ApiResponse response = degreeController.updateDegree(mockDegree1);
+        ApiResponse response = degreeController.updateDegree(degree1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         Degree degree = (Degree) response.getPayload().get("Degree");
-        assertEquals(mockDegree2.getId(), degree.getId());
+        assertEquals(degree2.getId(), degree.getId());
     }
 
     @Test
     public void testRemoveDegree() {
         doNothing().when(degreeRepo).remove(any(Degree.class));
 
-        ApiResponse response = degreeController.removeDegree(mockDegree1);
+        ApiResponse response = degreeController.removeDegree(degree1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(degreeRepo, times(1)).remove(any(Degree.class));
+        verify(degreeRepo).remove(any(Degree.class));
+    }
+
+    @Test
+    public void testRemoveAllDegrees() {
+        doNothing().when(degreeRepo).deleteAll();
+        doNothing().when(degreeRepo).broadcast(anyList());
+
+        ApiResponse response = degreeController.removeAllDegrees();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(degreeRepo).deleteAll();
+        verify(degreeRepo).broadcast(anyList());
     }
 
     @Test
@@ -116,7 +124,7 @@ public class DegreeControllerTest extends AbstractControllerTest {
         ApiResponse response = degreeController.reorderDegrees(1L, 2L);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(degreeRepo, times(1)).reorder(any(Long.class), any(Long.class));
+        verify(degreeRepo).reorder(any(Long.class), any(Long.class));
     }
 
     @Test
@@ -126,7 +134,7 @@ public class DegreeControllerTest extends AbstractControllerTest {
         ApiResponse response = degreeController.sortDegrees("column");
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(degreeRepo, times(1)).sort(any(String.class));
+        verify(degreeRepo).sort(any(String.class));
     }
 
     @Test

--- a/src/test/java/org/tdl/vireo/controller/DegreeLevelControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DegreeLevelControllerTest.java
@@ -10,16 +10,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.DegreeLevel;
 import org.tdl.vireo.model.repo.DegreeLevelRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class DegreeLevelControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/DepositLocationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DepositLocationControllerTest.java
@@ -17,10 +17,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.DepositLocation;
 import org.tdl.vireo.model.depositor.SWORDv1Depositor;
@@ -28,7 +26,6 @@ import org.tdl.vireo.model.repo.DepositLocationRepo;
 import org.tdl.vireo.service.DepositorService;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class DepositLocationControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/DocumentTypeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/DocumentTypeControllerTest.java
@@ -2,6 +2,7 @@ package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -14,17 +15,14 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.DocumentType;
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.repo.DocumentTypeRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class DocumentTypeControllerTest extends AbstractControllerTest {
 
     @Mock
@@ -33,71 +31,70 @@ public class DocumentTypeControllerTest extends AbstractControllerTest {
     @InjectMocks
     private DocumentTypeController documentTypeController;
 
-    private DocumentType mockDocumentType1;
-    private DocumentType mockDocumentType2;
+    private DocumentType documentType1;
+    private DocumentType documentType2;
 
-    private FieldPredicate mockFieldPredicate1;
-    private FieldPredicate mockFieldPredicate2;
+    private FieldPredicate fieldPredicate1;
+    private FieldPredicate fieldPredicate2;
 
-    private static List<DocumentType> mockDocumentTypes;
+    private static List<DocumentType> documentTypes;
 
     @BeforeEach
     public void setup() {
-        mockFieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
-        mockFieldPredicate1.setId(1L);
+        fieldPredicate1 = new FieldPredicate("FieldPredicate 1", true);
+        fieldPredicate2 = new FieldPredicate("FieldPredicate 2", false);
+        documentType1 = new DocumentType("DocumentType 1", fieldPredicate1);
+        documentType2 = new DocumentType("DocumentType 2", fieldPredicate2);
 
-        mockFieldPredicate2 = new FieldPredicate("FieldPredicate 2", false);
-        mockFieldPredicate2.setId(2L);
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(2L);
+        documentType1.setId(1L);
+        documentType2.setId(2L);
 
-        mockDocumentType1 = new DocumentType("DocumentType 1", mockFieldPredicate1);
-        mockDocumentType1.setId(1L);
-        mockDocumentType1.setPosition(1L);
+        documentType1.setPosition(1L);
+        documentType2.setPosition(2L);
 
-        mockDocumentType2 = new DocumentType("DocumentType 2", mockFieldPredicate2);
-        mockDocumentType2.setId(2L);
-        mockDocumentType2.setPosition(2L);
-
-        mockDocumentTypes = new ArrayList<DocumentType>(Arrays.asList(new DocumentType[] { mockDocumentType1 }));
+        documentTypes = new ArrayList<DocumentType>(Arrays.asList(new DocumentType[] { documentType1 }));
     }
 
     @Test
     public void testAllDocumentTypes() {
-        when(documentTypeRepo.findAllByOrderByPositionAsc()).thenReturn(mockDocumentTypes);
+        when(documentTypeRepo.findAllByOrderByPositionAsc()).thenReturn(documentTypes);
 
         ApiResponse response = documentTypeController.allDocumentTypes();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<DocumentType>");
-        assertEquals(mockDocumentTypes.size(), list.size());
+        assertEquals(documentTypes.size(), list.size());
     }
 
     @Test
     public void testCreateDocumentType() {
-        when(documentTypeRepo.create(any(String.class))).thenReturn(mockDocumentType2);
+        when(documentTypeRepo.create(any(String.class))).thenReturn(documentType2);
 
-        ApiResponse response = documentTypeController.createDocumentType(mockDocumentType1);
+        ApiResponse response = documentTypeController.createDocumentType(documentType1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         DocumentType documentType = (DocumentType) response.getPayload().get("DocumentType");
-        assertEquals(mockDocumentType2.getId(), documentType.getId());
+        assertEquals(documentType2.getId(), documentType.getId());
     }
 
     @Test
     public void testUpdateDocumentType() {
-        when(documentTypeRepo.update(any(DocumentType.class))).thenReturn(mockDocumentType2);
+        when(documentTypeRepo.update(any(DocumentType.class))).thenReturn(documentType2);
 
-        ApiResponse response = documentTypeController.updateDocumentType(mockDocumentType1);
+        ApiResponse response = documentTypeController.updateDocumentType(documentType1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         DocumentType documentType = (DocumentType) response.getPayload().get("DocumentType");
-        assertEquals(mockDocumentType2.getId(), documentType.getId());
+        assertEquals(documentType2.getId(), documentType.getId());
     }
 
     @Test
     public void testRemoveDocumentType() {
         doNothing().when(documentTypeRepo).remove(any(DocumentType.class));
 
-        ApiResponse response = documentTypeController.removeDocumentType(mockDocumentType2);
+        ApiResponse response = documentTypeController.removeDocumentType(documentType2);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         verify(documentTypeRepo, times(1)).remove(any(DocumentType.class));
@@ -105,7 +102,7 @@ public class DocumentTypeControllerTest extends AbstractControllerTest {
 
     @Test
     public void testRemoveDocumentTypeIsDenied() {
-        ApiResponse response = documentTypeController.removeDocumentType(mockDocumentType1);
+        ApiResponse response = documentTypeController.removeDocumentType(documentType1);
         assertEquals(ApiStatus.INVALID, response.getMeta().getStatus());
     }
 
@@ -117,6 +114,14 @@ public class DocumentTypeControllerTest extends AbstractControllerTest {
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         verify(documentTypeRepo, times(1)).reorder(any(Long.class), any(Long.class));
+    }
+
+    @Test
+    public void testSortDocumentTypes() {
+        doNothing().when(documentTypeRepo).sort(anyString());
+
+        ApiResponse response = documentTypeController.sortDocumentTypes("column");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
     }
 
 }

--- a/src/test/java/org/tdl/vireo/controller/EmailTemplateControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/EmailTemplateControllerTest.java
@@ -6,26 +6,21 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.tdl.vireo.model.EmailTemplate;
 import org.tdl.vireo.model.repo.EmailTemplateRepo;
 
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.response.ApiStatus;
-
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class EmailTemplateControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/EmbargoControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/EmbargoControllerTest.java
@@ -7,27 +7,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.Embargo;
 import org.tdl.vireo.model.EmbargoGuarantor;
 import org.tdl.vireo.model.repo.EmbargoRepo;
 
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.response.ApiStatus;
-
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class EmbargoControllerTest extends AbstractControllerTest {
 
     protected static final String EMBARGO_NAME = "Embargo Name";

--- a/src/test/java/org/tdl/vireo/controller/FieldPredicateControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldPredicateControllerTest.java
@@ -14,16 +14,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.repo.FieldPredicateRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class FieldPredicateControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/FieldProfileControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/FieldProfileControllerTest.java
@@ -10,16 +10,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.FieldProfile;
 import org.tdl.vireo.model.repo.FieldProfileRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class FieldProfileControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/GraduationMonthControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/GraduationMonthControllerTest.java
@@ -15,16 +15,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.GraduationMonth;
 import org.tdl.vireo.model.repo.GraduationMonthRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class GraduationMonthControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/InputTypeControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/InputTypeControllerTest.java
@@ -10,16 +10,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.InputType;
 import org.tdl.vireo.model.repo.InputTypeRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class InputTypeControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/LanguageControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/LanguageControllerTest.java
@@ -16,17 +16,14 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.Language;
 import org.tdl.vireo.model.repo.LanguageRepo;
 import org.tdl.vireo.service.ProquestCodesService;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class LanguageControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/LookAndFeelControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/LookAndFeelControllerTest.java
@@ -1,0 +1,87 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.io.IOException;
+import javax.mail.MessagingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.multipart.MultipartFile;
+import org.tdl.vireo.model.ManagedConfiguration;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.service.AssetService;
+
+@ActiveProfiles("test")
+public class LookAndFeelControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private ConfigurationRepo configurationRepo;
+
+    @Mock
+    private AssetService assetService;
+
+    @InjectMocks
+    private LookAndFeelController lookAndFeelController;
+
+    private ManagedConfiguration managedConfiguration;
+
+    @BeforeEach
+    public void setup() throws MessagingException {
+        managedConfiguration = new ManagedConfiguration("name", "value", "type");
+    }
+
+    @Test
+    public void testUploadLogo() throws IOException {
+        MultipartFile file = new MockMultipartFile("name", "originalName", "text/plain", "".getBytes());
+
+        when(configurationRepo.getByNameAndType(anyString(), anyString())).thenReturn(managedConfiguration);
+        doNothing().when(assetService).write(any(byte[].class), anyString());
+        when(configurationRepo.findByName(anyString())).thenReturn(managedConfiguration);
+        when(configurationRepo.reset(any(ManagedConfiguration.class))).thenReturn(managedConfiguration);
+        when(configurationRepo.create(anyString(), anyString(), anyString())).thenReturn(managedConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = lookAndFeelController.uploadLogo("setting", "text/plain", file);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUploadLogoWithoutConfiguration() throws IOException {
+        MultipartFile file = new MockMultipartFile("name", "originalName", "text/plain", "".getBytes());
+
+        when(configurationRepo.getByNameAndType(anyString(), anyString())).thenReturn(managedConfiguration);
+        doNothing().when(assetService).write(any(byte[].class), anyString());
+        when(configurationRepo.findByName(anyString())).thenReturn(null);
+        when(configurationRepo.create(anyString(), anyString(), anyString())).thenReturn(managedConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = lookAndFeelController.uploadLogo("setting", "text/plain", file);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testResetLogo() {
+        when(configurationRepo.getByNameAndType(anyString(), anyString())).thenReturn(managedConfiguration);
+        when(configurationRepo.reset(any(ManagedConfiguration.class))).thenReturn(managedConfiguration);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = lookAndFeelController.resetLogo("setting");
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        ManagedConfiguration got = (ManagedConfiguration) response.getPayload().get("ManagedConfiguration");
+        assertEquals(managedConfiguration, got, "Did not get expected Managed Configuration in the response.");
+    }
+}

--- a/src/test/java/org/tdl/vireo/controller/NoteControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/NoteControllerTest.java
@@ -10,16 +10,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.Note;
 import org.tdl.vireo.model.repo.NoteRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class NoteControllerTest extends AbstractControllerTest {
 
     @Mock
@@ -28,27 +25,27 @@ public class NoteControllerTest extends AbstractControllerTest {
     @InjectMocks
     private NoteController noteController;
 
-    private Note mockNote1;
+    private Note note1;
 
-    private static List<Note> mockNotes;
+    private static List<Note> notes;
 
     @BeforeEach
     public void setup() {
-        mockNote1 = new Note("Note 1", "text 1");
-        mockNote1.setId(1L);
+        note1 = new Note("Note 1", "text 1");
+        note1.setId(1L);
 
-        mockNotes = new ArrayList<Note>(Arrays.asList(new Note[] { mockNote1 }));
+        notes = new ArrayList<Note>(Arrays.asList(new Note[] { note1 }));
     }
 
     @Test
     public void testAllNotes() {
-        when(noteRepo.findAll()).thenReturn(mockNotes);
+        when(noteRepo.findAll()).thenReturn(notes);
 
         ApiResponse response = noteController.getAllNotes();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Note>");
-        assertEquals(mockNotes.size(), list.size());
+        assertEquals(notes.size(), list.size());
     }
 
 }

--- a/src/test/java/org/tdl/vireo/controller/OrganizationCategoryControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationCategoryControllerTest.java
@@ -14,16 +14,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.OrganizationCategory;
 import org.tdl.vireo.model.repo.OrganizationCategoryRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class OrganizationCategoryControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
@@ -2,8 +2,9 @@ package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,108 +12,493 @@ import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
+import org.tdl.vireo.exception.SystemEmailRuleNotDeleteableException;
+import org.tdl.vireo.exception.WorkflowStepNonOverrideableException;
+import org.tdl.vireo.model.EmailRecipient;
+import org.tdl.vireo.model.EmailRecipientAssignee;
+import org.tdl.vireo.model.EmailRecipientContact;
+import org.tdl.vireo.model.EmailRecipientOrganization;
+import org.tdl.vireo.model.EmailRecipientSubmitter;
+import org.tdl.vireo.model.EmailTemplate;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.FieldPredicate;
 import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.SubmissionState;
+import org.tdl.vireo.model.SubmissionStatus;
+import org.tdl.vireo.model.WorkflowStep;
+import org.tdl.vireo.model.repo.AbstractEmailRecipientRepo;
+import org.tdl.vireo.model.repo.EmailTemplateRepo;
+import org.tdl.vireo.model.repo.EmailWorkflowRuleRepo;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
 import org.tdl.vireo.model.repo.OrganizationRepo;
+import org.tdl.vireo.model.repo.SubmissionRepo;
+import org.tdl.vireo.model.repo.SubmissionStatusRepo;
+import org.tdl.vireo.model.repo.WorkflowStepRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class OrganizationControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private AbstractEmailRecipientRepo abstractEmailRecipientRepo;
+
+    @Mock
+    private EmailTemplateRepo emailTemplateRepo;
+
+    @Mock
+    private EmailWorkflowRuleRepo emailWorkflowRuleRepo;
+
+    @Mock
+    private FieldPredicateRepo fieldPredicateRepo;
 
     @Mock
     private OrganizationRepo organizationRepo;
 
+    @Mock
+    private SubmissionRepo submissionRepo;
+
+    @Mock
+    private SubmissionStatusRepo submissionStatusRepo;
+
+    @Mock
+    private WorkflowStepRepo workflowStepRepo;
+
     @InjectMocks
     private OrganizationController organizationController;
+    private EmailTemplate emailTemplate1;
+    private EmailTemplate emailTemplate2;
 
-    private Organization mockOrganization1;
-    private Organization mockOrganization2;
+    private EmailWorkflowRule emailWorkflowRule1;
 
-    private OrganizationCategory mockOrganizationCategory1;
-    private OrganizationCategory mockOrganizationCategory2;
+    private Organization organization1;
+    private Organization organization2;
 
-    private static List<Organization> mockOrganizations;
+    private OrganizationCategory organizationCategory1;
+    private OrganizationCategory organizationCategory2;
+
+    private SubmissionStatus submissionStatus1;
+    private SubmissionStatus submissionStatus2;
+
+    private WorkflowStep workflowStep1;
+    private WorkflowStep workflowStep2;
+
+    private List<Organization> organizations;
+    private List<WorkflowStep> workflowSteps;
+    private List<EmailWorkflowRule> emailWorkflowRules;
 
     @BeforeEach
     public void setup() {
-        mockOrganizationCategory1 = new OrganizationCategory("1");
-        mockOrganizationCategory1.setId(1L);
+        emailTemplate1 = new EmailTemplate("name1", "subject1", "message1");
+        emailTemplate2 = new EmailTemplate("name2", "subject2", "message2");
+        emailWorkflowRule1 = new EmailWorkflowRule();
+        organizationCategory1 = new OrganizationCategory("1");
+        organizationCategory2 = new OrganizationCategory("2");
+        organization1 = new Organization("Organization 1", organizationCategory1);
+        organization2 = new Organization("Organization 2", organizationCategory2);
+        submissionStatus1 = new SubmissionStatus("name1", false, false, false, false, false, true, SubmissionState.IN_PROGRESS);
+        submissionStatus2 = new SubmissionStatus("name1", false, true, true, true, true, true, SubmissionState.APPROVED);
+        workflowStep1 = new WorkflowStep("WorkflowStep 1");
+        workflowStep2 = new WorkflowStep("WorkflowStep 2");
 
-        mockOrganizationCategory2 = new OrganizationCategory("2");
-        mockOrganizationCategory2.setId(2L);
+        emailTemplate1.setId(1L);
+        emailTemplate2.setId(2L);
+        emailWorkflowRule1.setId(1L);
+        organizationCategory1.setId(1L);
+        organizationCategory2.setId(2L);
+        organization1.setId(1L);
+        organization2.setId(2L);
+        submissionStatus1.setId(1L);
+        submissionStatus2.setId(2L);
+        workflowStep1.setId(1L);
+        workflowStep2.setId(2L);
 
-        mockOrganization1 = new Organization("Organization 1", mockOrganizationCategory1);
-        mockOrganization1.setId(1L);
-
-        mockOrganization2 = new Organization("Organization 2", mockOrganizationCategory2);
-        mockOrganization2.setId(2L);
-
-        mockOrganizations = new ArrayList<Organization>(Arrays.asList(new Organization[] { mockOrganization1 }));
+        organizations = new ArrayList<>(Arrays.asList(organization1));
+        workflowSteps = new ArrayList<>(Arrays.asList(workflowStep1));
+        emailWorkflowRules = new ArrayList<>(Arrays.asList(emailWorkflowRule1));
     }
 
     @Test
     public void testAllOrganizations() {
-        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(mockOrganizations);
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
 
         ApiResponse response = organizationController.allOrganizations();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
-        assertEquals(mockOrganizations.size(), list.size());
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
+        assertEquals(organizations.size(), got.size());
     }
 
     @Test
     public void testGetOrganization() {
-        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
 
-        ApiResponse response = organizationController.getOrganization(mockOrganization1.getId());
+        ApiResponse response = organizationController.getOrganization(organization1.getId());
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        Organization organization = (Organization) response.getPayload().get("Organization");
-        assertEquals(mockOrganization1.getId(), organization.getId());
+        Organization got = (Organization) response.getPayload().get("Organization");
+        assertEquals(organization1, got);
     }
 
     @Test
     public void testCreateOrganization() {
-        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
-        when(organizationRepo.create(any(String.class), any(Organization.class), any(OrganizationCategory.class))).thenReturn(mockOrganization2);
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(organizationRepo.create(any(String.class), any(Organization.class), any(OrganizationCategory.class))).thenReturn(organization2);
 
-        ApiResponse response = organizationController.createOrganization(0L, mockOrganization1);
+        ApiResponse response = organizationController.createOrganization(0L, organization1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        Organization organization = (Organization) response.getPayload().get("Organization");
-        assertEquals(mockOrganization2.getId(), organization.getId());
+        Organization got = (Organization) response.getPayload().get("Organization");
+        assertEquals(organization2, got);
     }
 
     @Test
     public void testUpdateOrganization() {
-        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization2);
-        when(organizationRepo.update(any(Organization.class))).thenReturn(mockOrganization2);
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization2);
+        when(organizationRepo.update(any(Organization.class))).thenReturn(organization2);
 
-        ApiResponse response = organizationController.updateOrganization(mockOrganization1);
+        ApiResponse response = organizationController.updateOrganization(organization1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        Organization organization = (Organization) response.getPayload().get("Organization");
-        assertEquals(mockOrganization2.getId(), organization.getId());
+        Organization got = (Organization) response.getPayload().get("Organization");
+        assertEquals(organization2, got);
     }
 
     @Test
     public void testRemoveOrganization() {
-        when(organizationRepo.read(any(Long.class))).thenReturn(mockOrganization1);
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
         doNothing().when(organizationRepo).delete(any(Organization.class));
 
-        ApiResponse response = organizationController.deleteOrganization(mockOrganization1);
+        ApiResponse response = organizationController.deleteOrganization(organization1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        verify(organizationRepo, times(1)).delete(any(Organization.class));
+        verify(organizationRepo).delete(any(Organization.class));
     }
 
+    @Test
+    public void testRestoreOrganizationDefaults() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(organizationRepo.restoreDefaults(any(Organization.class))).thenReturn(organization2);
+
+        ApiResponse response = organizationController.restoreOrganizationDefaults(organization1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testGetWorkflowStepsForOrganization() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+
+        ApiResponse response = organizationController.getWorkflowStepsForOrganization(organization1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testCreateWorkflowStepsForOrganization() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.create(anyString(), any(Organization.class))).thenReturn(workflowStep2);
+
+        ApiResponse response = organizationController.createWorkflowStepsForOrganization(organization1.getId(), workflowStep1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        WorkflowStep got = (WorkflowStep) response.getPayload().get("WorkflowStep");
+        assertEquals(workflowStep2, got);
+    }
+
+    @Test
+    public void testUpdateWorkflowStepsForOrganization() throws WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.update(any(WorkflowStep.class), any(Organization.class))).thenReturn(workflowStep2);
+
+        ApiResponse response = organizationController.updateWorkflowStepsForOrganization(organization1.getId(), workflowStep1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testDeleteWorkflowStep() {
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        doNothing().when(workflowStepRepo).removeFromOrganization(any(Organization.class), any(WorkflowStep.class));
+
+        ApiResponse response = organizationController.deleteWorkflowStep(organization1.getId(), workflowStep1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepUp() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep1);
+        workflowSteps.add(workflowStep2);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(organizationRepo.reorderWorkflowSteps(any(Organization.class), any(WorkflowStep.class), any(WorkflowStep.class))).thenReturn(organization1);
+
+        ApiResponse response = organizationController.shiftWorkflowStepUp(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepUpWhenWorkflowIsNotFound() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep1);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+
+        ApiResponse response = organizationController.shiftWorkflowStepUp(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepUpWhenWorkflowIsAtTop() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep2);
+        workflowSteps.add(workflowStep1);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+
+        ApiResponse response = organizationController.shiftWorkflowStepUp(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepDown() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep2);
+        workflowSteps.add(workflowStep1);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(organizationRepo.reorderWorkflowSteps(any(Organization.class), any(WorkflowStep.class), any(WorkflowStep.class))).thenReturn(organization1);
+
+        ApiResponse response = organizationController.shiftWorkflowStepDown(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepDownWhenWorkflowIsNotFound() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep1);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+
+        ApiResponse response = organizationController.shiftWorkflowStepDown(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testShiftWorkflowStepDownWhenWorkflowIsAtBOttom() {
+        organization1.setAggregateWorkflowSteps(workflowSteps);
+        workflowSteps.clear();
+        workflowSteps.add(workflowStep1);
+        workflowSteps.add(workflowStep2);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+
+        ApiResponse response = organizationController.shiftWorkflowStepDown(organization1.getId(), workflowStep1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEmailRecipientData")
+    public void testAddEmailWorkflowRule(String type, EmailRecipient emailRecipient) {
+        Map<String, Object> data = setupEmailWorkflowData(type, emailRecipient);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(submissionStatusRepo.findById(any(Long.class))).thenReturn(Optional.of(submissionStatus1));
+
+        if (emailRecipient != null) {
+            when(emailWorkflowRuleRepo.create(any(SubmissionStatus.class), any(EmailRecipient.class), any(EmailTemplate.class))).thenReturn(emailWorkflowRule1);
+            when(organizationRepo.update(any(Organization.class))).thenReturn(organization1);
+        }
+
+        ApiResponse response = organizationController.addEmailWorkflowRule(organization1.getId(), data);
+
+        if (emailRecipient == null) {
+            assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+        } else {
+            assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEmailRecipientData")
+    public void testUpdateEmailWorkflowRule(String type, EmailRecipient emailRecipient) {
+        Map<String, Object> data = setupEmailWorkflowData(type, emailRecipient);
+
+        when(emailWorkflowRuleRepo.findById(any(Long.class))).thenReturn(Optional.of(emailWorkflowRule1));
+
+        if (emailRecipient != null) {
+            when(emailWorkflowRuleRepo.save(any(EmailWorkflowRule.class))).thenReturn(emailWorkflowRule1);
+            doNothing().when(organizationRepo).broadcast(any(Long.class));
+        }
+
+        ApiResponse response = organizationController.editEmailWorkflowRule(organization1.getId(), emailWorkflowRule1.getId(), data);
+
+        if (emailRecipient == null) {
+            assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+        } else {
+            assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        }
+    }
+
+    @Test
+    public void testRemoveEmailWorkflowRule() throws SystemEmailRuleNotDeleteableException {
+        emailWorkflowRule1.isSystem(false);
+        organization1.setEmailWorkflowRules(emailWorkflowRules);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(emailWorkflowRuleRepo.findById(any(Long.class))).thenReturn(Optional.of(emailWorkflowRule1));
+        doNothing().when(emailWorkflowRuleRepo).delete(any(EmailWorkflowRule.class));
+        when(organizationRepo.update(any(Organization.class))).thenReturn(organization1);
+
+        ApiResponse response = organizationController.removeEmailWorkflowRule(organization1.getId(), emailWorkflowRule1.getId());
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveEmailWorkflowRuleWhenIsSystem() {
+        emailWorkflowRule1.isSystem(true);
+
+        when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        when(emailWorkflowRuleRepo.findById(any(Long.class))).thenReturn(Optional.of(emailWorkflowRule1));
+
+        Assertions.assertThrows(SystemEmailRuleNotDeleteableException.class, () -> {
+            organizationController.removeEmailWorkflowRule(organization1.getId(), emailWorkflowRule1.getId());
+        });
+    }
+
+    @Test
+    public void testChangeEmailWorkflowRuleActivationWhenIsDisabled() {
+        boolean isDisabled = true;
+
+        emailWorkflowRule1.isDisabled(isDisabled);
+        organization1.setEmailWorkflowRules(emailWorkflowRules);
+
+        when(emailWorkflowRuleRepo.findById(any(Long.class))).thenReturn(Optional.of(emailWorkflowRule1));
+        when(emailWorkflowRuleRepo.save(any(EmailWorkflowRule.class))).thenReturn(emailWorkflowRule1);
+        doNothing().when(organizationRepo).broadcast(any(Long.class));
+
+        ApiResponse response = organizationController.changeEmailWorkflowRuleActivation(organization1.getId(), emailWorkflowRule1.getId());
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        assertEquals(!isDisabled, emailWorkflowRule1.isDisabled());
+    }
+
+    @Test
+    public void testChangeEmailWorkflowRuleActivationWhenNotIsDisabled() {
+        boolean isDisabled = false;
+
+        emailWorkflowRule1.isDisabled(isDisabled);
+        organization1.setEmailWorkflowRules(emailWorkflowRules);
+
+        when(emailWorkflowRuleRepo.findById(any(Long.class))).thenReturn(Optional.of(emailWorkflowRule1));
+        when(emailWorkflowRuleRepo.save(any(EmailWorkflowRule.class))).thenReturn(emailWorkflowRule1);
+        doNothing().when(organizationRepo).broadcast(any(Long.class));
+
+        ApiResponse response = organizationController.changeEmailWorkflowRuleActivation(organization1.getId(), emailWorkflowRule1.getId());
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+        assertEquals(!isDisabled, emailWorkflowRule1.isDisabled());
+    }
+
+    @Test
+    public void testCountSubmissions() {
+        Long count = 1L;
+
+        when(submissionRepo.countByOrganizationId(any(Long.class))).thenReturn(count);
+
+        ApiResponse response = organizationController.countSubmissions(organization1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Long got = (Long) response.getPayload().get("Long");
+        assertEquals(1L, got);
+    }
+
+    private Map<String, Object> setupEmailWorkflowData(String type, EmailRecipient emailRecipient) {
+        Map<String, Object> recipient = new HashMap<>();
+        recipient.put("type", type);
+        recipient.put("name", "name");
+        recipient.put("data", "1");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("submissionStatusId", Integer.valueOf(1)); // Warning: the code does this: "Long.valueOf((Integer)...", which is not very safe.
+        data.put("recipient", recipient);
+        data.put("templateId", Integer.valueOf(1)); // Warning: the code does this: "Long.valueOf((Integer)...", which is not very safe.
+
+        when(emailTemplateRepo.findById(any(Long.class))).thenReturn(Optional.of(emailTemplate1));
+
+        lenient().when(abstractEmailRecipientRepo.createSubmitterRecipient()).thenReturn(emailRecipient);
+        lenient().when(abstractEmailRecipientRepo.createAssigneeRecipient()).thenReturn(emailRecipient);
+        lenient().when(abstractEmailRecipientRepo.createContactRecipient(anyString(), any(FieldPredicate.class))).thenReturn(emailRecipient);
+        lenient().when(abstractEmailRecipientRepo.createOrganizationRecipient(any(Organization.class))).thenReturn(emailRecipient);
+
+        if (emailRecipient instanceof EmailRecipientContact) {
+            FieldPredicate fieldPredicate = ((EmailRecipientContact) emailRecipient).getFieldPredicate();
+
+            lenient().when(fieldPredicateRepo.findByValue(any(String.class))).thenReturn(fieldPredicate);
+            lenient().when(fieldPredicateRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldPredicate));
+        }
+
+        if (emailRecipient instanceof EmailRecipientOrganization) {
+            when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
+        }
+
+        return data;
+    }
+
+    private static Stream<Arguments> provideEmailRecipientData() {
+        FieldPredicate fieldPredicate1 = new FieldPredicate("value1", false);
+        OrganizationCategory organizationCategory1 = new OrganizationCategory("1");
+        Organization organization1 = new Organization("Organization 1", organizationCategory1);
+
+        EmailRecipientAssignee emailRecipientAssignee = new EmailRecipientAssignee();
+        EmailRecipientContact emailRecipientContact = new EmailRecipientContact("contact", fieldPredicate1);
+        EmailRecipientContact emailRecipientAdvisor = new EmailRecipientContact("advisor", fieldPredicate1);
+        EmailRecipientOrganization emailRecipientOrganization = new EmailRecipientOrganization();
+        EmailRecipientSubmitter emailRecipientSubmitter = new EmailRecipientSubmitter();
+
+        fieldPredicate1.setId(1L);
+        emailRecipientAssignee.setId(1L);
+        emailRecipientContact.setId(2L);
+        emailRecipientAdvisor.setId(3L);
+        emailRecipientOrganization.setId(4L);
+        emailRecipientSubmitter.setId(5L);
+        organizationCategory1.setId(1L);
+        organization1.setId(1L);
+
+        return Stream.of(
+            Arguments.of("SUBMITTER", emailRecipientSubmitter),
+            Arguments.of("ASSIGNEE", emailRecipientAssignee),
+            Arguments.of("ADVISOR", emailRecipientAdvisor),
+            Arguments.of("ORGANIZATION", emailRecipientOrganization),
+            Arguments.of("CONTACT", emailRecipientContact),
+            Arguments.of("DOES NOT EXIST", null)
+        );
+    }
 }

--- a/src/test/java/org/tdl/vireo/controller/PackagerControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/PackagerControllerTest.java
@@ -1,0 +1,47 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.packager.AbstractPackager;
+import org.tdl.vireo.model.repo.AbstractPackagerRepo;
+
+@ActiveProfiles("test")
+public class PackagerControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private AbstractPackagerRepo packagerRepo;
+
+    @InjectMocks
+    private PackagerController packagerController;
+
+    private static List<AbstractPackager<?>> mockPackages;
+
+    @BeforeEach
+    public void setup() {
+        mockPackages = new ArrayList<AbstractPackager<?>>();
+    }
+
+    @Test
+    public void testAllNotes() {
+        when(packagerRepo.findAll()).thenReturn(mockPackages);
+
+        ApiResponse response = packagerController.allPackagers();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList");
+        assertNotNull(mockPackages, "Payload response is not an ArrayList.");
+        assertEquals(mockPackages.size(), list.size(), "Payload response array is the wrong length.");
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/SubmissionControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/SubmissionControllerTest.java
@@ -13,16 +13,13 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.tdl.vireo.model.ActionLog;
 import org.tdl.vireo.model.Role;
 import org.tdl.vireo.model.SubmissionState;
@@ -31,9 +28,7 @@ import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.ActionLogRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
-@ExtendWith(MockitoExtension.class)
-public class SubmissionControllerTest {
+public class SubmissionControllerTest extends AbstractControllerTest {
 
     private static final String TEST_USER_1_EMAIL = "User 1 email";
     private static final String TEST_USER_1_FIRST_NAME = "User 1 first name";

--- a/src/test/java/org/tdl/vireo/controller/SubmissionListControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/SubmissionListControllerTest.java
@@ -1,0 +1,255 @@
+package org.tdl.vireo.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.model.NamedSearchFilter;
+import org.tdl.vireo.model.NamedSearchFilterGroup;
+import org.tdl.vireo.model.Role;
+import org.tdl.vireo.model.Sort;
+import org.tdl.vireo.model.SubmissionListColumn;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.repo.NamedSearchFilterGroupRepo;
+import org.tdl.vireo.model.repo.NamedSearchFilterRepo;
+import org.tdl.vireo.model.repo.SubmissionListColumnRepo;
+import org.tdl.vireo.model.repo.UserRepo;
+import org.tdl.vireo.service.DefaultSubmissionListColumnService;
+
+@ActiveProfiles("test")
+public class SubmissionListControllerTest extends AbstractControllerTest {
+
+    @Mock
+    private DefaultSubmissionListColumnService defaultSubmissionListColumnService;
+
+    @Mock
+    private NamedSearchFilterRepo namedSearchFilterRepo;
+
+    @Mock
+    private NamedSearchFilterGroupRepo namedSearchFilterGroupRepo;
+
+    @Mock
+    private SubmissionListColumnRepo submissionListColumnRepo;
+
+    @Mock
+    private UserRepo userRepo;
+
+    @InjectMocks
+    private SubmissionListController submissionlistController;
+
+    private NamedSearchFilter namedSearchFilter1;
+
+    private NamedSearchFilterGroup namedSearchFilterGroup1;
+
+    private SubmissionListColumn submissionListColumn1;
+    private SubmissionListColumn submissionListColumn2;
+
+    private User user1;
+
+    private List<SubmissionListColumn> submissionListColumns1;
+    private List<SubmissionListColumn> submissionListColumns2;
+
+    private Set<NamedSearchFilter> namedSearchFilters1;
+
+    @BeforeEach
+    public void setup() {
+        namedSearchFilter1 = new NamedSearchFilter();
+        namedSearchFilterGroup1 = new NamedSearchFilterGroup();
+        submissionListColumn1 = new SubmissionListColumn("title1", Sort.NONE);
+        submissionListColumn2 = new SubmissionListColumn("title2", Sort.NONE);
+        user1 = new User("email1", "firstname1", "lastname1", Role.ROLE_ADMIN);
+
+        namedSearchFilter1.setId(1L);
+        namedSearchFilterGroup1.setId(1L);
+        submissionListColumn1.setId(1L);
+        submissionListColumn2.setId(2L);
+        user1.setId(1L);
+
+        namedSearchFilters1 = new HashSet<>(Arrays.asList(namedSearchFilter1));
+        submissionListColumns1 = new ArrayList<>(Arrays.asList(submissionListColumn1));
+        submissionListColumns2 = new ArrayList<>(Arrays.asList(submissionListColumn2));
+
+        namedSearchFilterGroup1.setNamedSearchFilters(namedSearchFilters1);
+    }
+
+    @Test
+    public void testGetSubmissionViewColumns() {
+        when(submissionListColumnRepo.findAll()).thenReturn(submissionListColumns1);
+
+        ApiResponse response = submissionlistController.getSubmissionViewColumns();
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionListColumn>");
+        assertEquals(submissionListColumns1, got);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testGetSubmissionViewColumnsByUser(boolean withColumns) {
+        ReflectionTestUtils.setField(namedSearchFilterGroup1, "columnsFlag", withColumns);
+        ReflectionTestUtils.setField(user1, "activeFilter", namedSearchFilterGroup1);
+
+        if (withColumns) {
+            ReflectionTestUtils.setField(namedSearchFilterGroup1, "savedColumns", submissionListColumns1);
+        } else {
+            ReflectionTestUtils.setField(user1, "submissionViewColumns", submissionListColumns1);
+        }
+
+        ApiResponse response = submissionlistController.getSubmissionViewColumnsByUser(user1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionListColumn>");
+        assertEquals(submissionListColumns1, got);
+    }
+
+    @Test
+    public void testGetFilterColumnsByUser() {
+        ReflectionTestUtils.setField(user1, "filterColumns", submissionListColumns1);
+
+        ApiResponse response = submissionlistController.getFilterColumnsByUser(user1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionListColumn>");
+        assertEquals(submissionListColumns1, got);
+    }
+
+    @Test
+    public void testGetSubmissionViewPageSizeByUser() {
+        Integer size = 1;
+        ReflectionTestUtils.setField(user1, "pageSize", size);
+
+        ApiResponse response = submissionlistController.getSubmissionViewPageSizeByUser(user1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Integer got = (Integer) response.getPayload().get("Integer");
+        assertEquals(size, got);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testUpdateUserSubmissionViewColumns(boolean withColumns) {
+        Integer size = 1;
+
+        ReflectionTestUtils.setField(namedSearchFilterGroup1, "columnsFlag", withColumns);
+        ReflectionTestUtils.setField(user1, "pageSize", 0);
+        ReflectionTestUtils.setField(user1, "submissionViewColumns", new ArrayList<SubmissionListColumn>());
+        ReflectionTestUtils.setField(user1, "activeFilter", namedSearchFilterGroup1);
+
+        when(userRepo.update(any(User.class))).thenReturn(user1);
+
+        if (withColumns) {
+            when(namedSearchFilterGroupRepo.create(any(User.class))).thenReturn(namedSearchFilterGroup1);
+            when(namedSearchFilterRepo.clone(any(NamedSearchFilter.class))).thenReturn(namedSearchFilter1);
+        }
+
+        ApiResponse response = submissionlistController.updateUserSubmissionViewColumns(user1, size, submissionListColumns1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionListColumn>");
+        assertEquals(submissionListColumns1, got);
+        assertEquals(submissionListColumns1, user1.getSubmissionViewColumns());
+        assertEquals(size, user1.getPageSize());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testResetUserSubmissionViewColumns(boolean withColumns) {
+        List<SubmissionListColumn> defaultColumns = new ArrayList<>();
+
+        ReflectionTestUtils.setField(namedSearchFilterGroup1, "columnsFlag", withColumns);
+        ReflectionTestUtils.setField(user1, "pageSize", 0);
+        ReflectionTestUtils.setField(user1, "submissionViewColumns", submissionListColumns1);
+        ReflectionTestUtils.setField(user1, "activeFilter", namedSearchFilterGroup1);
+
+        when(defaultSubmissionListColumnService.getDefaultSubmissionListColumns()).thenReturn(defaultColumns);
+        when(userRepo.update(any(User.class))).thenReturn(user1);
+
+        if (withColumns) {
+            when(namedSearchFilterGroupRepo.create(any(User.class))).thenReturn(namedSearchFilterGroup1);
+            when(namedSearchFilterRepo.clone(any(NamedSearchFilter.class))).thenReturn(namedSearchFilter1);
+        }
+
+        ApiResponse response = submissionlistController.resetUserSubmissionViewColumns(user1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList");
+
+        assertEquals(defaultColumns, got);
+        assertEquals(defaultColumns, user1.getSubmissionViewColumns());
+        assertEquals(10, user1.getPageSize());
+    }
+
+    @Test
+    public void testUpdateUserFilterColumns() {
+        when(userRepo.update(any(User.class))).thenReturn(user1);
+
+        ReflectionTestUtils.setField(user1, "filterColumns", submissionListColumns1);
+
+        ApiResponse response = submissionlistController.updateUserFilterColumns(user1, submissionListColumns2);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<SubmissionListColumn>");
+        assertEquals(submissionListColumns2, got);
+        assertEquals(submissionListColumns2, user1.getFilterColumns());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSortEnums")
+    public void testUpdateSort(Sort sort, Integer sortOrder) {
+        ReflectionTestUtils.setField(submissionListColumn1, "sort", sort);
+        ReflectionTestUtils.setField(submissionListColumn1, "sortOrder", sortOrder);
+        ReflectionTestUtils.setField(namedSearchFilterGroup1, "sortColumnTitle", "some title");
+        ReflectionTestUtils.setField(namedSearchFilterGroup1, "sortDirection", sort == Sort.NONE ? Sort.ASC : Sort.NONE);
+        ReflectionTestUtils.setField(user1, "activeFilter", namedSearchFilterGroup1);
+
+        when(namedSearchFilterGroupRepo.update(any(NamedSearchFilterGroup.class))).thenReturn(namedSearchFilterGroup1);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        ApiResponse response = submissionlistController.updateSort(user1, submissionListColumns1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        NamedSearchFilterGroup got = (NamedSearchFilterGroup) response.getPayload().get("NamedSearchFilterGroup");
+        assertEquals(namedSearchFilterGroup1, got);
+
+        if (sortOrder == 0) {
+            assertNotEquals(submissionListColumn1.getTitle(), namedSearchFilterGroup1.getSortColumnTitle());
+            assertNotEquals(submissionListColumn1.getSort(), namedSearchFilterGroup1.getSortDirection());
+        } else {
+            assertEquals(submissionListColumn1.getTitle(), namedSearchFilterGroup1.getSortColumnTitle());
+            assertEquals(submissionListColumn1.getSort(), namedSearchFilterGroup1.getSortDirection());
+        }
+    }
+
+    private static Stream<Arguments> provideSortEnums() {
+        return Stream.of(
+            Arguments.of(Sort.NONE, 0),
+            Arguments.of(Sort.NONE, 1),
+            Arguments.of(Sort.ASC, 0),
+            Arguments.of(Sort.ASC, 1),
+            Arguments.of(Sort.DESC, 0),
+            Arguments.of(Sort.DESC, 1)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/controller/SubmissionStatusControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/SubmissionStatusControllerTest.java
@@ -10,16 +10,13 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.model.SubmissionStatus;
 import org.tdl.vireo.model.repo.SubmissionStatusRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class SubmissionStatusControllerTest extends AbstractControllerTest {
 
     @Mock

--- a/src/test/java/org/tdl/vireo/controller/UserControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/UserControllerTest.java
@@ -1,23 +1,27 @@
 package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import edu.tamu.weaver.auth.model.Credentials;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -25,54 +29,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.tdl.vireo.model.Role;
 import org.tdl.vireo.model.User;
 import org.tdl.vireo.model.repo.UserRepo;
 import org.tdl.vireo.model.request.FilteredPageRequest;
 
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.response.ApiStatus;
-
 @ActiveProfiles("test")
-@ExtendWith(SpringExtension.class)
-@ExtendWith(MockitoExtension.class)
-public class UserControllerTest {
-
-    private static final String TEST_USER_1_EMAIL = "User 1 email";
-    private static final String TEST_USER_2_EMAIL = "User 2 email";
-    private static final String TEST_USER_3_EMAIL = "User 3 email";
-    private static final String TEST_USER_4_EMAIL = "User 4 email";
-    private static final String TEST_USER_5_EMAIL = "User 5 email";
-    private static final String TEST_USER_1_FIRST_NAME = "User 1 first name";
-    private static final String TEST_USER_2_FIRST_NAME = "User 2 first name";
-    private static final String TEST_USER_3_FIRST_NAME = "User 3 first name";
-    private static final String TEST_USER_4_FIRST_NAME = "User 4 first name";
-    private static final String TEST_USER_5_FIRST_NAME = "User 5 first name";
-    private static final String TEST_USER_1_LAST_NAME = "User 1 last name";
-    private static final String TEST_USER_2_LAST_NAME = "User 2 last name";
-    private static final String TEST_USER_3_LAST_NAME = "User 3 last name";
-    private static final String TEST_USER_4_LAST_NAME = "User 4 last name";
-    private static final String TEST_USER_5_LAST_NAME = "User 5 last name";
-    private static final Role TEST_USER_1_ROLE = Role.ROLE_ADMIN;
-    private static final Role TEST_USER_2_ROLE = Role.ROLE_REVIEWER;
-    private static final Role TEST_USER_3_ROLE = Role.ROLE_MANAGER;
-    private static final Role TEST_USER_4_ROLE = Role.ROLE_STUDENT;
-    private static final Role TEST_USER_5_ROLE = Role.ROLE_ANONYMOUS;
-
-    private static final User TEST_USER_1 = new User(TEST_USER_1_EMAIL, TEST_USER_1_FIRST_NAME, TEST_USER_1_LAST_NAME, TEST_USER_1_ROLE);
-    private static final User TEST_USER_2 = new User(TEST_USER_2_EMAIL, TEST_USER_2_FIRST_NAME, TEST_USER_2_LAST_NAME, TEST_USER_2_ROLE);
-    private static final User TEST_USER_3 = new User(TEST_USER_3_EMAIL, TEST_USER_3_FIRST_NAME, TEST_USER_3_LAST_NAME, TEST_USER_3_ROLE);
-    private static final User TEST_USER_4 = new User(TEST_USER_4_EMAIL, TEST_USER_4_FIRST_NAME, TEST_USER_4_LAST_NAME, TEST_USER_4_ROLE);
-    private static final User TEST_USER_5 = new User(TEST_USER_5_EMAIL, TEST_USER_5_FIRST_NAME, TEST_USER_5_LAST_NAME, TEST_USER_5_ROLE);
-
-    private static final List<User> TEST_USER_LIST = new ArrayList<>(Arrays.asList(TEST_USER_1, TEST_USER_2, TEST_USER_3, TEST_USER_4, TEST_USER_5));
-    private static final List<User> TEST_USER_LIST_ASSIGNED = new ArrayList<>(Arrays.asList(TEST_USER_1, TEST_USER_2, TEST_USER_3));
-    private static final List<User> TEST_USER_LIST_UNASSIGNED = new ArrayList<>(Arrays.asList(TEST_USER_4, TEST_USER_5));
-    private static final List<User> TEST_USER_LIST_PAGE_ASSIGNED = new ArrayList<>(Arrays.asList(TEST_USER_1));
-    private static final List<User> TEST_USER_LIST_PAGE_UNASSIGNED = new ArrayList<>(Arrays.asList(TEST_USER_4));
-
-    private static final Page<User> TEST_USER_PAGE = new PageImpl<>(TEST_USER_LIST);
+public class UserControllerTest extends AbstractControllerTest {
 
     @Mock
     private UserRepo userRepo;
@@ -80,14 +43,67 @@ public class UserControllerTest {
     @InjectMocks
     private UserController userController;
 
+    private Credentials credentials1;
+    private User user1;
+    private User user2;
+
+    private List<User> users;
+    private Page<User> page1;
+    private Map<String, String> settings1;
+    private Map<String, String> settings2;
+
+    private Pageable pageable;
+
     @BeforeEach
     public void setup() {
+        credentials1 = new Credentials();
+        user1 = new User("email1", "firstname1", "lastname1", Role.ROLE_ADMIN);
+        user2 = new User("email2", "firstname2", "lastname2", Role.ROLE_MANAGER);
 
+        user1.setId(1L);
+        user2.setId(2L);
+
+        users = new ArrayList<>(Arrays.asList(user1));
+        page1 = new PageImpl<>(users);
+        settings1 = new HashMap<>();
+        settings2 = new HashMap<>();
+
+        settings1.put("key1", "value1");
+        settings2.put("key2", "value2");
+
+        user1.setSettings(settings1);
+
+        pageable = PageRequest.of(0, users.size());
     }
 
     @Test
+    public void testCredentials() {
+        ApiResponse response = userController.credentials(credentials1);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Credentials got = (Credentials) response.getPayload().get("Credentials");
+
+        assertEquals(credentials1, got);
+    }
+
+    @Test
+    public void testAllUsers() {
+        when(userRepo.findAll()).thenReturn(users);
+
+        ApiResponse response = userController.allUsers();
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+
+        assertEquals(users, got);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
     public void testPage() {
-        when(userRepo.findAll(Mockito.<Specification<User>>any(), any(Pageable.class))).thenReturn(TEST_USER_PAGE);
+        when(userRepo.findAll((Specification<User>) argThat(argument -> argument instanceof Specification), any(Pageable.class))).thenReturn(page1);
 
         FilteredPageRequest fpr = new FilteredPageRequest();
         fpr.setPageNumber(0);
@@ -95,70 +111,218 @@ public class UserControllerTest {
         ApiResponse response = userController.page(fpr);
 
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
-        verify(userRepo, times(1)).findAll(Mockito.<Specification<User>>any(), any(Pageable.class));
+        verify(userRepo).findAll((Specification<User>) argThat(argument -> argument instanceof Specification), any(Pageable.class));
     }
 
     @Test
-    public void testAllAssignableUsers() {
-        when(userRepo.findAllByRoleIn(any(), any(Sort.class))).thenReturn(TEST_USER_LIST_ASSIGNED);
+    public void testAllAssignableUsersEmptyName() {
+        when(userRepo.findAllByRoleIn(anyList(), any(Sort.class))).thenReturn(users);
 
-        Pageable pageable = PageRequest.of(0, TEST_USER_LIST_ASSIGNED.size());
         ApiResponse response = userController.allAssignableUsers(0, "", pageable);
 
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        List<?> users = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
 
-        assertEquals(pageable.getPageSize(), users.size());
-        assertTrue(users.contains(TEST_USER_1));
-        assertTrue(users.contains(TEST_USER_2));
-        assertTrue(users.contains(TEST_USER_3));
+        assertEquals(users, got);
     }
 
     @Test
-    public void testAllAssignableUsersPaginated() {
-        when(userRepo.findAllByRoleIn(any(), any(Pageable.class))).thenReturn(TEST_USER_LIST_PAGE_ASSIGNED);
+    public void testAllAssignableUsers() {
+        when(userRepo.findAllByRoleInAndNameContainsIgnoreCase(anyList(), anyString(), any(Sort.class))).thenReturn(users);
 
-        Pageable pageable = PageRequest.of(0, TEST_USER_LIST_PAGE_ASSIGNED.size());
+        ApiResponse response = userController.allAssignableUsers(0, "name", pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+
+        assertEquals(users, got);
+    }
+
+    @Test
+    public void testAllAssignableUsersPaginatedEmptyName() {
+        when(userRepo.findAllByRoleIn(anyList(), any(Pageable.class))).thenReturn(users);
+
         ApiResponse response = userController.allAssignableUsers(1, "", pageable);
 
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        List<?> users = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
 
-        assertEquals(pageable.getPageSize(), users.size());
-        assertTrue(users.contains(TEST_USER_1));
+        assertEquals(users, got);
     }
 
     @Test
-    public void testAllUnassignableUsers() {
-        when(userRepo.findAllByRoleIn(any(), any(Sort.class))).thenReturn(TEST_USER_LIST_UNASSIGNED);
+    public void testAllAssignableUsersPaginated() {
+        when(userRepo.findAllByRoleInAndNameContainsIgnoreCase(anyList(), anyString(), any(Pageable.class))).thenReturn(users);
 
-        Pageable pageable = PageRequest.of(0, TEST_USER_LIST_UNASSIGNED.size());
+        ApiResponse response = userController.allAssignableUsers(1, "name", pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+
+        assertEquals(users, got);
+    }
+
+    @Test
+    public void testCountAssignableUsersEmptyName() {
+        Long count = 1L;
+
+        when(userRepo.countByRoleIn(anyList())).thenReturn(count);
+
+        ApiResponse response = userController.countAssignableUsers("");
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Long got = (Long) response.getPayload().get("Long");
+
+        assertEquals(count, got);
+    }
+
+    @Test
+    public void testCountAssignableUsers() {
+        Long count = 1L;
+
+        when(userRepo.countByRoleInAndNameContainsIgnoreCase(anyList(), anyString())).thenReturn(count);
+
+        ApiResponse response = userController.countAssignableUsers("name");
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Long got = (Long) response.getPayload().get("Long");
+
+        assertEquals(count, got);
+    }
+
+    @Test
+    public void testAllUnassignableUsersEmptyName() {
+        when(userRepo.findAllByRoleIn(anyList(), any(Sort.class))).thenReturn(users);
+
         ApiResponse response = userController.allUnassignableUsers(0, "", pageable);
 
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        List<?> users = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
 
-        assertEquals(pageable.getPageSize(), users.size());
-        assertTrue(users.contains(TEST_USER_4));
-        assertTrue(users.contains(TEST_USER_5));
+        assertEquals(users, got);
     }
 
     @Test
-    public void testAllUnassignablePaginated() {
-        when(userRepo.findAllByRoleIn(any(), any(Pageable.class))).thenReturn(TEST_USER_LIST_PAGE_UNASSIGNED);
+    public void testAllUnassignableUsers() {
+        when(userRepo.findAllByRoleInAndNameContainsIgnoreCase(anyList(), anyString(), any(Sort.class))).thenReturn(users);
 
-        Pageable pageable = PageRequest.of(0, TEST_USER_LIST_PAGE_UNASSIGNED.size());
+        ApiResponse response = userController.allUnassignableUsers(0, "name", pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+
+        assertEquals(users, got);
+    }
+
+    @Test
+    public void testAllUnassignablePaginatedEmptyName() {
+        when(userRepo.findAllByRoleIn(anyList(), any(Pageable.class))).thenReturn(users);
+
         ApiResponse response = userController.allUnassignableUsers(1, "", pageable);
 
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
-        List<?> users = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
 
-        assertEquals(pageable.getPageSize(), users.size());
-        assertTrue(users.contains(TEST_USER_4));
+        assertEquals(users, got);
+    }
+
+    @Test
+    public void testAllUnassignablePaginated() {
+        when(userRepo.findAllByRoleInAndNameContainsIgnoreCase(anyList(), anyString(), any(Pageable.class))).thenReturn(users);
+
+        ApiResponse response = userController.allUnassignableUsers(1, "name", pageable);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<User>");
+
+        assertEquals(users, got);
+    }
+
+    @Test
+    public void testCountUnassignableUsersEmptyName() {
+        Long count = 1L;
+
+        when(userRepo.countByRoleIn(anyList())).thenReturn(count);
+
+        ApiResponse response = userController.countUnassignableUsers("");
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Long got = (Long) response.getPayload().get("Long");
+
+        assertEquals(count, got);
+    }
+
+    @Test
+    public void testCountUnassignableUsers() {
+        Long count = 1L;
+
+        when(userRepo.countByRoleInAndNameContainsIgnoreCase(anyList(), anyString())).thenReturn(count);
+
+        ApiResponse response = userController.countUnassignableUsers("name");
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Long got = (Long) response.getPayload().get("Long");
+
+        assertEquals(count, got);
+    }
+
+    @Test
+    public void testUpdate() {
+        when(userRepo.findById(any(Long.class))).thenReturn(Optional.of(user1));
+        when(userRepo.update(any(User.class))).thenReturn(user1);
+        doNothing().when(userRepo).broadcast(anyList());
+
+        ApiResponse response = userController.update(user2);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        User got = (User) response.getPayload().get("User");
+
+        assertEquals(user1, got);
+    }
+
+    @Test
+    public void testGetSettings() {
+        ApiResponse response = userController.getSettings(user1);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        Map<?, ?> got = (HashMap<?, ?>) response.getPayload().get("HashMap");
+
+        assertEquals(settings1, got);
+    }
+
+    @Test
+    public void testUpdateSettings() {
+        when(userRepo.update(any(User.class))).thenReturn(user1);
+        doNothing().when(simpMessagingTemplate).convertAndSend(anyString(), any(ApiResponse.class));
+
+        // Warning: The function is named "updateSetting" rather than "updateSettings".
+        ApiResponse response = userController.updateSetting(user1, settings2);
+
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testHandleExceptions() {
+        String message = "example exception";
+
+        ApiResponse response = userController.handleExceptions(new RuntimeException(message));
+
+        assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+        assertEquals(message, response.getMeta().getMessage());
     }
 
 }

--- a/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
@@ -2,70 +2,341 @@ package org.tdl.vireo.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiStatus;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
+import org.tdl.vireo.exception.HeritableModelNonOverrideableException;
+import org.tdl.vireo.exception.WorkflowStepNonOverrideableException;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.ManagedConfiguration;
+import org.tdl.vireo.model.Note;
+import org.tdl.vireo.model.Organization;
 import org.tdl.vireo.model.WorkflowStep;
+import org.tdl.vireo.model.repo.ConfigurationRepo;
+import org.tdl.vireo.model.repo.FieldPredicateRepo;
+import org.tdl.vireo.model.repo.FieldProfileRepo;
+import org.tdl.vireo.model.repo.NoteRepo;
+import org.tdl.vireo.model.repo.OrganizationRepo;
 import org.tdl.vireo.model.repo.WorkflowStepRepo;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class)
 public class WorkflowStepControllerTest extends AbstractControllerTest {
 
     @Mock
-    private WorkflowStepRepo fieldPredicateRepo;
+    private ConfigurationRepo configurationRepo;
+
+    @Mock
+    private FieldPredicateRepo fieldPredicateRepo;
+
+    @Mock
+    private FieldProfileRepo fieldProfileRepo;
+
+    @Mock
+    private NoteRepo noteRepo;
+
+    @Mock
+    private OrganizationRepo organizationRepo;
+
+    @Mock
+    private WorkflowStepRepo workflowStepRepo;
 
     @InjectMocks
     private WorkflowStepController fieldPredicateController;
 
-    private WorkflowStep mockWorkflowStep1;
-    private WorkflowStep mockWorkflowStep2;
+    private FieldProfile fieldProfile1;
+    private FieldProfile fieldProfile2;
 
-    private static List<WorkflowStep> mockWorkflowSteps;
+    private ManagedConfiguration managedConfiguration1;
+    private ManagedConfiguration managedConfiguration2;
+
+    private Note note1;
+    private Note note2;
+
+    private Organization organization1;
+    private Organization organization2;
+
+    private WorkflowStep workflowStep1;
+    private WorkflowStep workflowStep2;
+
+    private List<FieldProfile> fieldProfiles;
+    private List<Organization> organizations;
+    private List<WorkflowStep> workflowSteps;
 
     @BeforeEach
     public void setup() {
-        mockWorkflowStep1 = new WorkflowStep("WorkflowStep 1");
-        mockWorkflowStep1.setId(1L);
+        fieldProfile1 = new FieldProfile();
+        fieldProfile2 = new FieldProfile();
+        managedConfiguration1 = new ManagedConfiguration("name1", "value1", "type1");
+        managedConfiguration2 = new ManagedConfiguration("name2", "value2", "type2");
+        note1 = new Note("name1", "text1");
+        note2 = new Note("name2", "text2");
+        organization1 = new Organization("Organization 1");
+        organization2 = new Organization("Organization 2");
+        workflowStep1 = new WorkflowStep("WorkflowStep 1");
+        workflowStep2 = new WorkflowStep("WorkflowStep 2");
 
-        mockWorkflowStep2 = new WorkflowStep("WorkflowStep 2");
-        mockWorkflowStep2.setId(2L);
+        fieldProfiles = new ArrayList<>();
+        organizations = new ArrayList<>();
+        workflowSteps = new ArrayList<>();
 
-        mockWorkflowSteps = new ArrayList<WorkflowStep>(Arrays.asList(new WorkflowStep[] { mockWorkflowStep1 }));
+        fieldProfile1.setId(1L);
+        fieldProfile2.setId(2L);
+        managedConfiguration1.setId(1L);
+        managedConfiguration1.setId(2L);
+        note1.setId(1L);
+        note2.setId(2L);
+        organization1.setId(1L);
+        organization2.setId(2L);
+        workflowStep1.setId(1L);
+        workflowStep2.setId(2L);
+
+        fieldProfile1.setMappedShibAttribute(managedConfiguration1);
+        fieldProfile1.setOriginating(fieldProfile1);
+        fieldProfile2.setOriginating(fieldProfile2);
+        fieldProfile1.setOriginatingWorkflowStep(workflowStep1);
+        fieldProfile2.setOriginatingWorkflowStep(workflowStep2);
+
+        workflowStep1.setOriginalFieldProfiles(fieldProfiles);
+        workflowStep2.setOriginalFieldProfiles(fieldProfiles);
+        workflowStep1.setOriginatingOrganization(organization1);
+        workflowStep2.setOriginatingOrganization(organization2);
+
+        fieldProfiles.add(fieldProfile1);
+        organizations.add(organization1);
+        workflowSteps.add(workflowStep1);
     }
 
     @Test
-    public void testAllWorkflowSteps() {
-        when(fieldPredicateRepo.findAll()).thenReturn(mockWorkflowSteps);
+    public void testGetAll() {
+        when(workflowStepRepo.findAll()).thenReturn(workflowSteps);
 
         ApiResponse response = fieldPredicateController.getAll();
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         List<?> list = (ArrayList<?>) response.getPayload().get("ArrayList<WorkflowStep>");
-        assertEquals(mockWorkflowSteps.size(), list.size());
+        assertEquals(workflowSteps.size(), list.size());
     }
 
     @Test
-    public void testGetWorkflowStep() {
-        when(fieldPredicateRepo.findById(any(Long.class))).thenReturn(Optional.of(mockWorkflowStep1));
+    public void testGetStepById() {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
 
         ApiResponse response = fieldPredicateController.getStepById(1L);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         WorkflowStep fieldPredicate = (WorkflowStep) response.getPayload().get("WorkflowStep");
-        assertEquals(mockWorkflowStep1.getId(), fieldPredicate.getId());
+        assertEquals(workflowStep1.getId(), fieldPredicate.getId());
+    }
+
+    @Test
+    public void testCreateFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(fieldProfileRepo.create(any(WorkflowStep.class), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(fieldProfile1);
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.createFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testCreateFieldProfileUpdatingOrganization() throws JsonProcessingException, WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.update(any(WorkflowStep.class), any(Organization.class))).thenReturn(workflowStep2);
+        when(fieldProfileRepo.create(any(WorkflowStep.class), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(fieldProfile1);
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.createFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdateFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.updateFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdateFieldProfileWithNullShibAttribute() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        managedConfiguration1 = null;
+
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.updateFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdateFieldProfileWithNullShibAttributeId() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        managedConfiguration1.setId(null);
+
+        when(configurationRepo.findByNameAndType(anyString(), anyString())).thenReturn(managedConfiguration1);
+        when(fieldProfileRepo.update(any(FieldProfile.class), any(Organization.class))).thenReturn(fieldProfile1);
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.updateFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdateFieldProfileWithNullShibAttributeIDAndNullPersistedAttribute() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        managedConfiguration1.setId(null);
+        managedConfiguration2 = null;
+
+        when(configurationRepo.findByNameAndType(anyString(), anyString())).thenReturn(managedConfiguration2);
+        when(fieldProfileRepo.update(any(FieldProfile.class), any(Organization.class))).thenReturn(fieldProfile1);
+        when(configurationRepo.create(any(ManagedConfiguration.class))).thenReturn(managedConfiguration1);
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.updateFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(fieldProfileRepo).delete(any(FieldProfile.class));
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileWithDifferentProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testReorderFieldProfile() throws WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.reorderFieldProfiles(any(Organization.class), any(WorkflowStep.class), anyInt(), anyInt())).thenReturn(workflowStep1);
+
+        // Warning: Unlike other broadcasts for reorder functions, this one broadcasts using the ID rather than a list.
+        doNothing().when(organizationRepo).broadcast(anyLong());
+
+        ApiResponse response = fieldPredicateController.reorderFieldProfiles(organization1.getId(), workflowStep1.getId(), 1, 2);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testAddNote() throws WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(noteRepo.create(any(WorkflowStep.class), anyString(), anyString(), anyBoolean())).thenReturn(note1); 
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.addNote(organization1.getId(), workflowStep1.getId(), note1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testAddNoteUpdatingWorkflowStep() throws WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        workflowStep1.setOriginatingOrganization(organization2);
+
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.update(any(WorkflowStep.class), any(Organization.class))).thenReturn(workflowStep1);
+        when(noteRepo.create(any(WorkflowStep.class), anyString(), anyString(), anyBoolean())).thenReturn(note1);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.addNote(organization1.getId(), workflowStep1.getId(), note1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdateNoteUpdatingWorkflowStep() throws HeritableModelNonOverrideableException, WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(noteRepo.update(any(Note.class), any(Organization.class))).thenReturn(note1);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.updateNote(organization1.getId(), workflowStep1.getId(), note1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveNote() throws NumberFormatException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        workflowStep1.setOriginatingOrganization(organization1);
+        note1.setOriginatingWorkflowStep(workflowStep1);
+
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(noteRepo.findById(any(Long.class))).thenReturn(Optional.of(note1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        doNothing().when(noteRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(Note.class));
+        doNothing().when(noteRepo).delete(any(Note.class));
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeNote(organization1.getId(), workflowStep1.getId(), note1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveNoteWithDifferentOriginatingWorkflowStep() throws NumberFormatException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        workflowStep1.setOriginatingOrganization(organization1);
+        note1.setOriginatingWorkflowStep(workflowStep2);
+
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(noteRepo.findById(any(Long.class))).thenReturn(Optional.of(note1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        doNothing().when(noteRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(Note.class));
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeNote(organization1.getId(), workflowStep1.getId(), note1);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testReorderNote() throws WorkflowStepNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.reorderNotes(any(Organization.class), any(WorkflowStep.class), anyInt(), anyInt())).thenReturn(workflowStep1); 
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.reorderNotes(organization1.getId(), workflowStep1.getId(), 1, 2);
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
     }
 
 }

--- a/src/test/java/org/tdl/vireo/model/AbstractEnumTest.java
+++ b/src/test/java/org/tdl/vireo/model/AbstractEnumTest.java
@@ -1,0 +1,34 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public abstract class AbstractEnumTest<E extends Enum<?>> {
+
+    public static final String NAME_MESSAGE = "The enumeration name is different than expected.";
+    public static final String ORDINAL_MESSAGE = "The enumeration ordinal is different than expected.";
+
+    /**
+     * Perform the test for the given enum.
+     *
+     * The implementing class must implement the provideEnumParameters() static method, returning Stream<Arguments>.
+     *
+     * @param enumeration The enumeration to test.
+     * @param name The expected enumeration name value.
+     * @param ordinal The ordinal of the enumeration.
+     */
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testEnum(Enum<?> enumeration, String name, int ordinal) {
+        assertEquals(enumeration.name(), name, NAME_MESSAGE);
+        assertEquals(enumeration.ordinal(), ordinal, ORDINAL_MESSAGE);
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/AbstractModelCustomMethodTest.java
+++ b/src/test/java/org/tdl/vireo/model/AbstractModelCustomMethodTest.java
@@ -1,0 +1,46 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+public abstract class AbstractModelCustomMethodTest<M> extends AbstractModelTest<M> {
+
+    /**
+     * Perform the test for the given getter using a custom function name.
+     *
+     * The implementing class must implement the provideGetterMethodParameters() static method, returning Stream<Arguments>.
+     *
+     * @param method The name of the method on the model.
+     * @param property The name of the property on the model.
+     * @param value The expected value to get (and set).
+     */
+    @ParameterizedTest
+    @MethodSource("provideGetterMethodParameters")
+    public void testGetterMethod(String method, String property, Object value) {
+        ReflectionTestUtils.setField(getInstance(), property, value);
+
+        assertEquals(value, ReflectionTestUtils.invokeMethod(getInstance(), method), GETTER_MESSAGE + property + " and method: " + method + ".");
+    }
+
+    /**
+     * Perform the test for the given setter using a custom function name.
+     *
+     * The implementing class must implement the provideSetterMethodParameters() static method, returning Stream<Arguments>.
+     *
+     * @param method The name of the method on the model.
+     * @param property The name of the property on the model.
+     * @param value The expected value to set (and get).
+     */
+    @ParameterizedTest
+    @MethodSource("provideSetterMethodParameters")
+    public void testSetterMethod(String method, String property, Object value) {
+        ReflectionTestUtils.invokeMethod(getInstance(), method, value);
+
+        assertEquals(value, ReflectionTestUtils.getField(getInstance(), property), SETTER_MESSAGE + property + " and method: " + method + ".");
+    }
+}

--- a/src/test/java/org/tdl/vireo/model/AbstractModelTest.java
+++ b/src/test/java/org/tdl/vireo/model/AbstractModelTest.java
@@ -1,0 +1,58 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+public abstract class AbstractModelTest<M> {
+
+    public static final String GETTER_MESSAGE = "The getter must return the correct response for property: ";
+    public static final String SETTER_MESSAGE = "The setter must assign the correct value for property: ";
+
+    /**
+     * Perform the test for the given getter.
+     *
+     * The implementing class must implement the provideGetterParameters() static method, returning Stream<Arguments>.
+     *
+     * @param property The name of the property on the model.
+     * @param value The expected value to get (and set).
+     */
+    @ParameterizedTest
+    @MethodSource("provideGetterParameters")
+    public void testGetter(String property, Object value) {
+        ReflectionTestUtils.setField(getInstance(), property, value);
+
+        assertEquals(value, ReflectionTestUtils.invokeGetterMethod(getInstance(), property), GETTER_MESSAGE + property + ".");
+    }
+
+    /**
+     * Perform the test for the given setter.
+     *
+     * The implementing class must implement the provideSetterParameters() static method, returning Stream<Arguments>.
+     *
+     * @param property The name of the property on the model.
+     * @param value The expected value to set (and get).
+     */
+    @ParameterizedTest
+    @MethodSource("provideSetterParameters")
+    public void testSetter(String property, Object value) {
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), property, value);
+
+        assertEquals(value, ReflectionTestUtils.getField(getInstance(), property), SETTER_MESSAGE + property + ".");
+    }
+
+    /**
+     * Provide the instance of the given model M.
+     *
+     * @return The instance for the testGetter() and the testSetter() methods to use.
+     */
+    abstract protected M getInstance();
+
+}

--- a/src/test/java/org/tdl/vireo/model/ActionLogTest.java
+++ b/src/test/java/org/tdl/vireo/model/ActionLogTest.java
@@ -1,0 +1,49 @@
+package org.tdl.vireo.model;
+
+import java.util.Calendar;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class ActionLogTest extends AbstractModelCustomMethodTest<ActionLog> {
+
+    @InjectMocks
+    private ActionLog actionLog;
+
+    @Override
+    protected ActionLog getInstance() {
+        return actionLog;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isPrivateFlag", "privateFlag", true),
+            Arguments.of("isPrivateFlag", "privateFlag", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setPrivateFlag", "privateFlag", true),
+            Arguments.of("setPrivateFlag", "privateFlag", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("submissionStatus", new SubmissionStatus()),
+            Arguments.of("user", new User()),
+            Arguments.of("actionDate", Calendar.getInstance()),
+            Arguments.of("entry", "value") 
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/AddressTest.java
+++ b/src/test/java/org/tdl/vireo/model/AddressTest.java
@@ -1,0 +1,36 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class AddressTest extends AbstractModelTest<Address> {
+
+    @InjectMocks
+    private Address address;
+
+    @Override
+    protected Address getInstance() {
+        return address;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("address1", "value"),
+            Arguments.of("address2", "value"),
+            Arguments.of("city", "value"),
+            Arguments.of("state", "value"),
+            Arguments.of("postalCode", "value"),
+            Arguments.of("country", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/ContactInfoTest.java
+++ b/src/test/java/org/tdl/vireo/model/ContactInfoTest.java
@@ -1,0 +1,33 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class ContactInfoTest extends AbstractModelTest<ContactInfo> {
+
+    @InjectMocks
+    private ContactInfo contactInfo;
+
+    @Override
+    protected ContactInfo getInstance() {
+        return contactInfo;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("address", new Address()),
+            Arguments.of("phone", "value"),
+            Arguments.of("email", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/ControlledVocabularyCacheTest.java
+++ b/src/test/java/org/tdl/vireo/model/ControlledVocabularyCacheTest.java
@@ -1,0 +1,45 @@
+package org.tdl.vireo.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class ControlledVocabularyCacheTest extends AbstractModelTest<ControlledVocabularyCache> {
+
+    @InjectMocks
+    private ControlledVocabularyCache controlledVocabularyCache;
+
+    @Override
+    protected ControlledVocabularyCache getInstance() {
+        return controlledVocabularyCache;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<VocabularyWord> words = new ArrayList<>();
+        words.add(new VocabularyWord());
+
+        List<VocabularyWord[]> wordArrayList = new ArrayList<>();
+        VocabularyWord[] wordsArray = { new VocabularyWord() }; 
+        wordArrayList.add(wordsArray);
+
+        return Stream.of(
+            Arguments.of("timestamp", 123L),
+            Arguments.of("controlledVocabularyName", "name"),
+            Arguments.of("newVocabularyWords", words),
+            Arguments.of("updatingVocabularyWords", wordArrayList),
+            Arguments.of("duplicateVocabularyWords", words),
+            Arguments.of("removedVocabularyWords", words)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/ControlledVocabularyTest.java
+++ b/src/test/java/org/tdl/vireo/model/ControlledVocabularyTest.java
@@ -1,0 +1,111 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.Application;
+import org.tdl.vireo.service.EntityControlledVocabularyService;
+
+@SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ControlledVocabularyTest extends AbstractModelCustomMethodTest<ControlledVocabulary> {
+
+    @InjectMocks
+    private ControlledVocabulary controlledVocabulary;
+
+    @MockBean
+    EntityControlledVocabularyService entityControlledVocabularyService;
+
+    @Test
+    public void testGetDictionary() {
+        List<VocabularyWord> dictionary = new ArrayList<>();
+        VocabularyWord vocabularyWord = new VocabularyWord();
+
+        vocabularyWord.setId(1L);
+        dictionary.add(vocabularyWord);
+
+        ReflectionTestUtils.setField(controlledVocabulary, "dictionary", dictionary);
+        ReflectionTestUtils.setField(controlledVocabulary, "isEntityProperty", false);
+
+        List<VocabularyWord> got = controlledVocabulary.getDictionary();
+
+        assertEquals(1, got.size(), GETTER_MESSAGE);
+    }
+
+    @Test
+    public void testGetDictionaryThrowsClassNotFoundException() throws ClassNotFoundException {
+        List<VocabularyWord> dictionary = new ArrayList<>();
+        VocabularyWord vocabularyWord = new VocabularyWord();
+
+        vocabularyWord.setId(1L);
+        dictionary.add(vocabularyWord);
+
+        ReflectionTestUtils.setField(controlledVocabulary, "dictionary", dictionary);
+        ReflectionTestUtils.setField(controlledVocabulary, "isEntityProperty", true);
+        ReflectionTestUtils.setField(controlledVocabulary, "name", "Should not be found.");
+
+        when(entityControlledVocabularyService.getControlledVocabularyWords(anyString())).thenThrow(ClassNotFoundException.class);
+
+        List<VocabularyWord> got = controlledVocabulary.getDictionary();
+
+        assertEquals(0, got.size(), "The Vocabulary Word array should be empty when ClassNotFoundException is thrown.");
+    }
+
+    @Test
+    public void testSetDictionary() {
+        List<VocabularyWord> dictionary = new ArrayList<>();
+        VocabularyWord vocabularyWord = new VocabularyWord();
+
+        vocabularyWord.setId(1L);
+        dictionary.add(vocabularyWord);
+
+        ReflectionTestUtils.setField(controlledVocabulary, "isEntityProperty", false);
+
+        controlledVocabulary.setDictionary(dictionary);
+
+        assertEquals(dictionary, ReflectionTestUtils.getField(controlledVocabulary, "dictionary"), SETTER_MESSAGE + "dictionary.");
+    }
+
+    @Override
+    protected ControlledVocabulary getInstance() {
+        return controlledVocabulary;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getIsEntityProperty", "isEntityProperty", true),
+            Arguments.of("getIsEntityProperty", "isEntityProperty", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setIsEntityProperty", "isEntityProperty", true),
+            Arguments.of("setIsEntityProperty", "isEntityProperty", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/CustomActionDefinitionTest.java
+++ b/src/test/java/org/tdl/vireo/model/CustomActionDefinitionTest.java
@@ -1,0 +1,46 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class CustomActionDefinitionTest extends AbstractModelCustomMethodTest<CustomActionDefinition> {
+
+    @InjectMocks
+    private CustomActionDefinition customActionDefinition;
+
+    @Override
+    protected CustomActionDefinition getInstance() {
+        return customActionDefinition;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return getParameterMethodStream();
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return getParameterMethodStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("label", "value")
+        );
+    }
+
+    private static Stream<Arguments> getParameterMethodStream() {
+        return Stream.of(
+            Arguments.of("isStudentVisible", "isStudentVisible", true),
+            Arguments.of("isStudentVisible", "isStudentVisible", false)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/CustomActionValueTest.java
+++ b/src/test/java/org/tdl/vireo/model/CustomActionValueTest.java
@@ -1,0 +1,45 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class CustomActionValueTest extends AbstractModelCustomMethodTest<CustomActionValue> {
+
+    @InjectMocks
+    private CustomActionValue customActionValue;
+
+    @Override
+    protected CustomActionValue getInstance() {
+        return customActionValue;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getValue", "value", true),
+            Arguments.of("getValue", "value", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setValue", "value", true),
+            Arguments.of("setValue", "value", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("definition", new CustomActionDefinition())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DefaultConfigurationTest.java
+++ b/src/test/java/org/tdl/vireo/model/DefaultConfigurationTest.java
@@ -1,0 +1,34 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DefaultConfigurationTest {
+
+    // Warning: The tests fail here due to strange initialization problems and so an explicit assignment is provided.
+    @InjectMocks
+    private DefaultConfiguration defaultConfiguration = new DefaultConfiguration("a", "b", "c");
+
+    @ParameterizedTest
+    @MethodSource("provideGetterParameters")
+    public void testGetter(String property, Object value) {
+        ReflectionTestUtils.setField(defaultConfiguration, property, value);
+
+        assertEquals(value, ReflectionTestUtils.invokeGetterMethod(defaultConfiguration, property), AbstractModelTest.GETTER_MESSAGE);
+    }
+
+    private static Stream<Arguments> provideGetterParameters() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("value", "value"),
+            Arguments.of("type", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DefaultPreferencesTest.java
+++ b/src/test/java/org/tdl/vireo/model/DefaultPreferencesTest.java
@@ -1,0 +1,53 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class DefaultPreferencesTest extends AbstractModelTest<DefaultPreferences> {
+
+    @InjectMocks
+    private DefaultPreferences defaultPreferences;
+
+    @Test
+    public void testDefaultPreferencesInstantiation() {
+        List<DefaultConfiguration> preferences = new ArrayList<>();
+        preferences.add(new DefaultConfiguration("name", "value", "type"));
+
+        defaultPreferences.setPreferences(preferences);
+        defaultPreferences.setType("type");
+
+        DefaultPreferences newDefaultPreferences = new DefaultPreferences(defaultPreferences.getType(), defaultPreferences.getPreferences());
+
+        assertEquals(newDefaultPreferences.getPreferences(), defaultPreferences.getPreferences(), "Preferences does not match.");
+        assertEquals(newDefaultPreferences.getType(), defaultPreferences.getType(), "Type does not match.");
+    }
+
+    @Override
+    protected DefaultPreferences getInstance() {
+        return defaultPreferences;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<DefaultConfiguration> preferences = new ArrayList<>();
+
+        return Stream.of(
+            Arguments.of("preferences", preferences),
+            Arguments.of("type", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DegreeLevelTest.java
+++ b/src/test/java/org/tdl/vireo/model/DegreeLevelTest.java
@@ -1,0 +1,31 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class DegreeLevelTest extends AbstractModelTest<DegreeLevel> {
+
+    @InjectMocks
+    private DegreeLevel degreeLevel;
+
+    @Override
+    protected DegreeLevel getInstance() {
+        return degreeLevel;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DegreeTest.java
+++ b/src/test/java/org/tdl/vireo/model/DegreeTest.java
@@ -1,0 +1,70 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class DegreeTest extends AbstractModelTest<Degree> {
+
+    @InjectMocks
+    private Degree degree;
+
+    @Test
+    public void testGetControlledName() {
+        String name = "name";
+
+        ReflectionTestUtils.setField(getInstance(), "name", name);
+
+        assertEquals(name, degree.getControlledName(), "Controlled Name does not match.");
+    }
+
+    @Test
+    public void testGetControlledDefinition() {
+        String degreeCode = "degreeCode";
+
+        ReflectionTestUtils.setField(getInstance(), "degreeCode", degreeCode);
+
+        assertEquals(degreeCode, degree.getControlledDefinition(), "Controlled Definition does not match.");
+    }
+
+    @Test
+    public void testGetControlledIdentifier() {
+        DegreeLevel degreeLevel = new DegreeLevel("level");
+
+        ReflectionTestUtils.setField(getInstance(), "level", degreeLevel);
+
+        assertEquals(degreeLevel.getName(), degree.getControlledIdentifier(), "Controlled Identifier does not match.");
+    }
+
+    @Test
+    public void testGetControlledContacts() {
+        assertNotNull(degree.getControlledContacts(), "Controlled Contacts is null.");
+    }
+
+    @Override
+    protected Degree getInstance() {
+        return degree;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("degreeCode", "value"),
+            Arguments.of("level", new DegreeLevel())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DepositLocationTest.java
+++ b/src/test/java/org/tdl/vireo/model/DepositLocationTest.java
@@ -1,0 +1,42 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.tdl.vireo.model.packager.DSpaceMetsPackager;
+import org.tdl.vireo.model.packager.DSpaceSimplePackager;
+
+public class DepositLocationTest extends AbstractModelTest<DepositLocation> {
+
+    @InjectMocks
+    private DepositLocation depositLocation;
+
+    @Override
+    protected DepositLocation getInstance() {
+        return depositLocation;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("repository", "value"),
+            Arguments.of("collection", "value"),
+            Arguments.of("username", "value"),
+            Arguments.of("password", "value"),
+            Arguments.of("onBehalfOf", "value"),
+            Arguments.of("packager", new DSpaceMetsPackager()),
+            Arguments.of("packager", new DSpaceSimplePackager()),
+            Arguments.of("depositorName", "value"),
+            Arguments.of("timeout", 123)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
+++ b/src/test/java/org/tdl/vireo/model/DocumentTypeTest.java
@@ -1,0 +1,49 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class DocumentTypeTest extends AbstractModelTest<DocumentType> {
+
+    @InjectMocks
+    private DocumentType documentType;
+
+    @Test
+    public void testDocumentTypeInstantiation() {
+        FieldPredicate fieldPredicate = new FieldPredicate();
+
+        fieldPredicate.setId(1L);
+        documentType.setName("name");
+        documentType.setFieldPredicate(fieldPredicate);
+
+        DocumentType newDocumentType = new DocumentType(documentType.getName(), documentType.getFieldPredicate());
+
+        assertEquals(newDocumentType.getName(), documentType.getName(), "Name does not match.");
+        assertEquals(newDocumentType.getFieldPredicate(), documentType.getFieldPredicate(), "Field Predicate does not match.");
+    }
+
+    @Override
+    protected DocumentType getInstance() {
+        return documentType;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("fieldPredicate", new FieldPredicate())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientAssigneeTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientAssigneeTest.java
@@ -1,0 +1,60 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailRecipientAssigneeTest extends AbstractModelTest<EmailRecipientAssignee> {
+
+    @InjectMocks
+    private EmailRecipientAssignee emailRecipientAssignee;
+
+    @Test
+    public void testGetEmails() {
+        Submission submission = new Submission();
+        User assignee = new User();
+        Map<String, String> settings = new HashMap<>();
+
+        // Warning: "prefered" is a typo in the functional code (this should instead be "preferred").
+        String key = "preferedEmail";
+
+        settings.put(key, "nobody@example.com");
+        assignee.setId(1L);
+        assignee.setSettings(settings);
+
+        ReflectionTestUtils.setField(submission, "assignee", assignee);
+
+        List<String> got = emailRecipientAssignee.getEmails(submission);
+
+        assertNotNull(got, "E-mails array must not be null.");
+        assertTrue(got.contains(settings.get(key)), "E-mail is not found.");
+    }
+
+    @Override
+    protected EmailRecipientAssignee getInstance() {
+        return emailRecipientAssignee;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientContactTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientContactTest.java
@@ -1,0 +1,86 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailRecipientContactTest extends AbstractModelTest<EmailRecipientContact> {
+
+    @InjectMocks
+    private EmailRecipientContact emailRecipientContact;
+
+    @Mock
+    private Submission submission;
+
+    @Test
+    public void testGetEmails() {
+        List<String> emails = new ArrayList<String>();
+        List<FieldValue> fieldValues = new ArrayList<FieldValue>();
+        FieldValue fieldValue = new FieldValue();
+        FieldValue otherFieldValue = new FieldValue();
+        FieldPredicate fieldPredicate = new FieldPredicate();
+
+        emails.add("first@example.com");
+        emails.add("second@example.com");
+        otherFieldValue.setId(1L);
+        otherFieldValue.setValue("value1");
+        fieldValue.setId(2L);
+        fieldValue.setValue("value2");
+        fieldValue.setContacts(emails);
+        fieldValues.add(fieldValue);
+        fieldValues.add(otherFieldValue);
+        fieldPredicate.setId(1L);
+
+        ReflectionTestUtils.setField(emailRecipientContact, "fieldPredicate", fieldPredicate);
+
+        when(submission.getFieldValuesByPredicate(any(FieldPredicate.class))).thenReturn(fieldValues);
+
+        List<String> got = emailRecipientContact.getEmails(submission);
+
+        assertEquals(got.size(), emails.size(), "Emails array does not have the correct length.");
+
+        emails.forEach(email -> {
+            String found = null;
+
+            for (String e : got) {
+                if (e == email) {
+                    found = e;
+                    break;
+                }
+            }
+
+            assertNotNull(found, "Did not find e-mail '" + email + "' in the returned array.");
+        });
+    }
+
+    @Override
+    protected EmailRecipientContact getInstance() {
+        return emailRecipientContact;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("fieldPredicate", new FieldPredicate())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientOrganizationTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientOrganizationTest.java
@@ -1,0 +1,54 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailRecipientOrganizationTest extends AbstractModelTest<EmailRecipientOrganization> {
+
+    // Warning: @InjectMocks throws NPE here and so an explicit assignment is provided. 
+    @InjectMocks
+    private EmailRecipientOrganization emailRecipientOrganization = new EmailRecipientOrganization();
+
+    @Test
+    public void testGetEmails() {
+        Submission submission = new Submission();
+        Organization organization = new Organization();
+        String email = "nobody@example.com";
+
+        organization.addEmail(email);
+
+        ReflectionTestUtils.setField(emailRecipientOrganization, "organization", organization);
+
+        List<String> got = emailRecipientOrganization.getEmails(submission);
+
+        assertNotNull(got, "E-mails array must not be null.");
+        assertTrue(got.contains(email), "E-mail is not found.");
+    }
+
+    @Override
+    protected EmailRecipientOrganization getInstance() {
+        return emailRecipientOrganization;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientPlainAddressTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientPlainAddressTest.java
@@ -1,0 +1,50 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailRecipientPlainAddressTest extends AbstractModelTest<EmailRecipientPlainAddress> {
+
+    @InjectMocks
+    private EmailRecipientPlainAddress emailRecipientPlainAddress;
+
+    @Test
+    public void testGetEmails() {
+        Submission submission = new Submission();
+        String email = "nobody@example.com";
+
+        ReflectionTestUtils.setField(emailRecipientPlainAddress, "name", email);
+
+        List<String> got = emailRecipientPlainAddress.getEmails(submission);
+
+        assertNotNull(got, "E-mails array must not be null.");
+        assertTrue(got.contains(email), "E-mail is not found.");
+    }
+
+    @Override
+    protected EmailRecipientPlainAddress getInstance() {
+        return emailRecipientPlainAddress;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientSubmitterTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientSubmitterTest.java
@@ -1,0 +1,60 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmailRecipientSubmitterTest extends AbstractModelTest<EmailRecipientSubmitter> {
+
+    @InjectMocks
+    private EmailRecipientSubmitter emailRecipientSubmitter;
+
+    @Test
+    public void testGetEmails() {
+        Submission submission = new Submission();
+        User submitter = new User();
+        Map<String, String> settings = new HashMap<>();
+
+        // Warning: "prefered" is a typo in the functional code (this should instead be "preferred").
+        String key = "preferedEmail";
+
+        settings.put(key, "nobody@example.com");
+        submitter.setId(1L);
+        submitter.setSettings(settings);
+
+        ReflectionTestUtils.setField(submission, "submitter", submitter);
+
+        List<String> got = emailRecipientSubmitter.getEmails(submission);
+
+        assertNotNull(got, "E-mails array must not be null.");
+        assertTrue(got.contains(settings.get(key)), "E-mail is not found.");
+    }
+
+    @Override
+    protected EmailRecipientSubmitter getInstance() {
+        return emailRecipientSubmitter;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailRecipientTypeTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailRecipientTypeTest.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class EmailRecipientTypeTest extends AbstractEnumTest<EmailRecipientType> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(EmailRecipientType.ASSIGNEE, "ASSIGNEE", 0),
+            Arguments.of(EmailRecipientType.ADVISOR, "ADVISOR", 1),
+            Arguments.of(EmailRecipientType.CONTACT, "CONTACT", 2),
+            Arguments.of(EmailRecipientType.ORGANIZATION, "ORGANIZATION", 3),
+            Arguments.of(EmailRecipientType.PLAIN_ADDRESS, "PLAIN_ADDRESS", 4),
+            Arguments.of(EmailRecipientType.SUBMITTER, "SUBMITTER", 5)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailTemplateTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailTemplateTest.java
@@ -1,0 +1,47 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class EmailTemplateTest extends AbstractModelCustomMethodTest<EmailTemplate> {
+
+    @InjectMocks
+    private EmailTemplate emailTemplate;
+
+    @Override
+    protected EmailTemplate getInstance() {
+        return emailTemplate;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getSystemRequired", "systemRequired", true),
+            Arguments.of("getSystemRequired", "systemRequired", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setSystemRequired", "systemRequired", true),
+            Arguments.of("setSystemRequired", "systemRequired", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("subject", "value"),
+            Arguments.of("message", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmailWorkflowRuleTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmailWorkflowRuleTest.java
@@ -1,0 +1,51 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class EmailWorkflowRuleTest extends AbstractModelCustomMethodTest<EmailWorkflowRule> {
+
+    @InjectMocks
+    private EmailWorkflowRule emailWorkflowRule;
+
+    @Override
+    protected EmailWorkflowRule getInstance() {
+        return emailWorkflowRule;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isSystem", "isSystem", true),
+            Arguments.of("isSystem", "isSystem", false),
+            Arguments.of("isDisabled", "isDisabled", true),
+            Arguments.of("isDisabled", "isDisabled", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isSystem", "isSystem", true),
+            Arguments.of("isSystem", "isSystem", false),
+            Arguments.of("isDisabled", "isDisabled", true),
+            Arguments.of("isDisabled", "isDisabled", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("emailRecipient", new EmailRecipientOrganization()),
+            Arguments.of("emailRecipient", new EmailRecipientPlainAddress()),
+            Arguments.of("emailTemplate", new EmailTemplate())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmbargoGuarantorTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmbargoGuarantorTest.java
@@ -1,0 +1,44 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class EmbargoGuarantorTest extends AbstractEnumTest<EmbargoGuarantor> {
+
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testGetValue(EmbargoGuarantor enumeration, String name, int ordinal) {
+        assertEquals(ordinal, enumeration.getValue(), "Value is incorrect.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testToString(EmbargoGuarantor enumeration, String name, int ordinal) {
+        assertEquals(name, enumeration.toString(), "Name is incorrect.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testFromString(EmbargoGuarantor enumeration, String name, int ordinal) {
+        assertEquals(enumeration, EmbargoGuarantor.fromString(name), "Enumeration is incorrect.");
+    }
+
+    @Test
+    public void testFromStringReturnsNull() {
+        assertNull(EmbargoGuarantor.fromString("This cannot exist."), "Did not return null.");
+    }
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(EmbargoGuarantor.DEFAULT, "DEFAULT", 0),
+            Arguments.of(EmbargoGuarantor.PROQUEST, "PROQUEST", 1)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EmbargoTest.java
+++ b/src/test/java/org/tdl/vireo/model/EmbargoTest.java
@@ -1,0 +1,115 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class EmbargoTest extends AbstractModelCustomMethodTest<Embargo> {
+
+    @InjectMocks
+    private Embargo embargo;
+
+    @Test
+    public void testGetControlledName() {
+        String name = "name";
+
+        ReflectionTestUtils.setField(getInstance(), "name", name);
+
+        assertEquals(name, embargo.getControlledName(), "Controlled Name does not match.");
+    }
+
+    @Test
+    public void testGetControlledDefinition() {
+        String description = "description";
+
+        ReflectionTestUtils.setField(getInstance(), "description", description);
+
+        assertEquals(description, embargo.getControlledDefinition(), "Controlled Definition does not match.");
+    }
+
+    @Test
+    public void testGetControlledIdentifier() {
+        Long id = 1L;
+
+        ReflectionTestUtils.setField(getInstance(), "id", id);
+
+        assertEquals(String.valueOf(id), embargo.getControlledIdentifier(), "Controlled Identifier does not match.");
+    }
+
+    @Test
+    public void testGetControlledContacts() {
+        assertNotNull(embargo.getControlledContacts(), "Controlled Contacts is null.");
+    }
+
+    @Test
+    public void testInstanceDoesNotEqual() {
+        Embargo embargo1 = new Embargo();
+        embargo.setId(1L);
+
+        Embargo embargo2 = new Embargo();
+        embargo2.setId(2L);
+
+        assertFalse(embargo1.equals(embargo2), "Embargos must not match.");
+    }
+
+    @Test
+    public void testInstanceEquals() {
+        Embargo embargo1 = new Embargo();
+        embargo1.setId(1L);
+        embargo1.setName("name");
+        embargo1.setDescription("description");
+        embargo1.setGuarantor(EmbargoGuarantor.DEFAULT);
+        embargo1.setDuration(1);
+
+        assertTrue(embargo1.equals((Embargo) embargo1), "Embargos must match.");
+    }
+
+    @Override
+    protected Embargo getInstance() {
+        return embargo;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isActive", "isActive", true),
+            Arguments.of("isActive", "isActive", false),
+            Arguments.of("getSystemRequired", "systemRequired", true),
+            Arguments.of("getSystemRequired", "systemRequired", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isActive", "isActive", true),
+            Arguments.of("isActive", "isActive", false),
+            Arguments.of("setSystemRequired", "systemRequired", true),
+            Arguments.of("setSystemRequired", "systemRequired", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("description", "value"),
+            Arguments.of("duration", 123),
+            Arguments.of("guarantor", EmbargoGuarantor.DEFAULT),
+            Arguments.of("guarantor", EmbargoGuarantor.PROQUEST)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/EntityCVFilterTest.java
+++ b/src/test/java/org/tdl/vireo/model/EntityCVFilterTest.java
@@ -1,0 +1,32 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class EntityCVFilterTest extends AbstractModelTest<EntityCVFilter> {
+
+    @InjectMocks
+    private EntityCVFilter entityCVFilter;
+
+    @Override
+    protected EntityCVFilter getInstance() {
+        return entityCVFilter;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("path", "value"),
+            Arguments.of("value", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/FieldPredicateTest.java
+++ b/src/test/java/org/tdl/vireo/model/FieldPredicateTest.java
@@ -1,0 +1,101 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FieldPredicateTest extends AbstractModelCustomMethodTest<FieldPredicate> {
+
+    @InjectMocks
+    private FieldPredicate fieldPredicate;
+
+    @ParameterizedTest
+    @MethodSource("provideSchemaTest")
+    public void testGetSchema(String value, String expect) {
+        ReflectionTestUtils.setField(getInstance(), "value", value);
+
+        assertEquals(expect, fieldPredicate.getSchema(), GETTER_MESSAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideElementTest")
+    public void testGetElement(String value, String expect) {
+        ReflectionTestUtils.setField(getInstance(), "value", value);
+
+        assertEquals(expect, fieldPredicate.getElement(), GETTER_MESSAGE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideQualifierTest")
+    public void testGetQualifier(String value, String expect) {
+        ReflectionTestUtils.setField(getInstance(), "value", value);
+
+        assertEquals(expect, fieldPredicate.getQualifier(), GETTER_MESSAGE);
+    }
+
+    @Override
+    protected FieldPredicate getInstance() {
+        return fieldPredicate;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getDocumentTypePredicate", "documentTypePredicate", true),
+            Arguments.of("getDocumentTypePredicate", "documentTypePredicate", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setDocumentTypePredicate", "documentTypePredicate", true),
+            Arguments.of("setDocumentTypePredicate", "documentTypePredicate", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("value", "value")
+        );
+    }
+
+    private static Stream<Arguments> provideSchemaTest() {
+        return Stream.of(
+            Arguments.of("has.all.three", "has"),
+            Arguments.of("has.two", "has"),
+            Arguments.of("one", "one"),
+            Arguments.of("", "")
+        );
+    }
+
+    private static Stream<Arguments> provideElementTest() {
+        return Stream.of(
+            Arguments.of("has.all.three", "all"),
+            Arguments.of("has.two", "two"),
+            Arguments.of("one", null),
+            Arguments.of("", null)
+        );
+    }
+
+    private static Stream<Arguments> provideQualifierTest() {
+        return Stream.of(
+            Arguments.of("has.all.three", "three"),
+            Arguments.of("has.two", null),
+            Arguments.of("one", null),
+            Arguments.of("", null)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/FieldProfileTest.java
+++ b/src/test/java/org/tdl/vireo/model/FieldProfileTest.java
@@ -1,0 +1,78 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class FieldProfileTest  extends AbstractModelCustomMethodTest<FieldProfile> {
+
+    @InjectMocks
+    private FieldProfile fieldProfile;
+
+    @Override
+    protected FieldProfile getInstance() {
+        return fieldProfile;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getRepeatable", "repeatable", true),
+            Arguments.of("getRepeatable", "repeatable", false),
+            Arguments.of("getOptional", "optional", true),
+            Arguments.of("getOptional", "optional", false),
+            Arguments.of("getHidden", "hidden", true),
+            Arguments.of("getHidden", "hidden", false),
+            Arguments.of("getLogged", "logged", true),
+            Arguments.of("getLogged", "logged", false),
+            Arguments.of("getFlagged", "flagged", true),
+            Arguments.of("getFlagged", "flagged", false),
+            Arguments.of("getEnabled", "enabled", true),
+            Arguments.of("getEnabled", "enabled", false),
+            Arguments.of("getOverrideable", "overrideable", true),
+            Arguments.of("getOverrideable", "overrideable", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setRepeatable", "repeatable", true),
+            Arguments.of("setRepeatable", "repeatable", false),
+            Arguments.of("setOptional", "optional", true),
+            Arguments.of("setOptional", "optional", false),
+            Arguments.of("setHidden", "hidden", true),
+            Arguments.of("setHidden", "hidden", false),
+            Arguments.of("setLogged", "logged", true),
+            Arguments.of("setLogged", "logged", false),
+            Arguments.of("setFlagged", "flagged", true),
+            Arguments.of("setFlagged", "flagged", false),
+            Arguments.of("setEnabled", "enabled", true),
+            Arguments.of("setEnabled", "enabled", false),
+            Arguments.of("setOverrideable", "overrideable", true),
+            Arguments.of("setOverrideable", "overrideable", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("fieldPredicate", new FieldPredicate()),
+            Arguments.of("inputType", new InputType()),
+            Arguments.of("usage", "value"),
+            Arguments.of("help", "value"),
+            Arguments.of("gloss", "value"),
+            Arguments.of("controlledVocabulary", new ControlledVocabulary()),
+            Arguments.of("mappedShibAttribute", new ManagedConfiguration()),
+            Arguments.of("defaultValue", "value"),
+            Arguments.of("originating", new FieldProfile()),
+            Arguments.of("originatingWorkflowStep", new WorkflowStep())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/FieldValueTest.java
+++ b/src/test/java/org/tdl/vireo/model/FieldValueTest.java
@@ -1,0 +1,171 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class FieldValueTest extends AbstractModelTest<FieldValue> {
+
+    @InjectMocks
+    private FieldValue fieldValue;
+
+    @Test
+    public void testFieldValueInstantiation() {
+        ReflectionTestUtils.setField(fieldValue, "fieldPredicate", new FieldPredicate());
+        ReflectionTestUtils.setField(fieldValue, "contacts", new ArrayList<String>());
+
+        FieldValue newFieldValue = new FieldValue(fieldValue.getFieldPredicate(), fieldValue.getContacts());
+
+        assertEquals(newFieldValue.getFieldPredicate(), fieldValue.getFieldPredicate(), "Field Predicate does not match.");
+        assertEquals(newFieldValue.getContacts(), fieldValue.getContacts(), "Contacts does not match.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGetFileParameters")
+    public void testGetFileName(String value, String expect, int row) {
+        List<VocabularyWord> dictionary = new ArrayList<>();
+        VocabularyWord vocabularyWord = new VocabularyWord();
+
+        vocabularyWord.setId(1L);
+        dictionary.add(vocabularyWord);
+
+        ReflectionTestUtils.setField(fieldValue, "value", value);
+
+        assertEquals(expect, fieldValue.getFileName(), GETTER_MESSAGE + "value on row " + row + ".");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideGetExportFileParameters")
+    public void testGetExportFileName(String value, String expect, int row) {
+        List<VocabularyWord> dictionary = new ArrayList<>();
+        VocabularyWord vocabularyWord = new VocabularyWord();
+
+        vocabularyWord.setId(1L);
+        dictionary.add(vocabularyWord);
+
+        ReflectionTestUtils.setField(fieldValue, "value", value);
+
+        assertEquals(expect, fieldValue.getExportFileName(), GETTER_MESSAGE + "value on row " + row + ".");
+    }
+
+    @Override
+    protected FieldValue getInstance() {
+        return fieldValue;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<String> contactsEmpty = new ArrayList<>();
+        List<String> contactsNotEmpty = new ArrayList<>();
+        contactsNotEmpty.add("contact");
+
+        return Stream.of(
+            Arguments.of("value", "value"),
+            Arguments.of("identifier", "value"),
+            Arguments.of("definition", "value"),
+            Arguments.of("contacts", contactsEmpty),
+            Arguments.of("contacts", contactsNotEmpty),
+            Arguments.of("fieldPredicate", new FieldPredicate())
+        );
+    }
+
+    private static Stream<Arguments> provideGetFileParameters() {
+        // Warning: This matches the behavior of getFileName(), some of these, such as 'PRIMARYno_slash' which may or may not be incorrect.  
+        return Stream.of(
+            Arguments.of("no_slash", "no_slash", 0),
+            Arguments.of("with-dash", "dash", 1),
+            Arguments.of("with_slash/no_dash", "no_dash", 2),
+            Arguments.of("with_slash/with-dash", "dash", 3),
+            Arguments.of("/many//-/slashes/with_slash/no_dash", "no_dash", 4),
+            Arguments.of("/many//-/slashes/with_slash/with-dash", "dash", 5),
+            Arguments.of("PRIMARYno_slash", "PRIMARYno_slash", 6),
+            Arguments.of("PRIMARYwith-dash", "dash", 7),
+            Arguments.of("PRIMARY-no_slash", "no_slash", 8),
+            Arguments.of("PRIMARY-with-dash", "with-dash", 9),
+            Arguments.of("with_slash/PRIMARYno_slash", "PRIMARYno_slash", 10),
+            Arguments.of("with_slash/PRIMARYwith-dash", "dash", 11),
+            Arguments.of("with_slash/PRIMARY-no_slash", "no_slash", 12),
+            Arguments.of("with_slash/PRIMARY-with-dash", "with-dash", 13),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARYno_slash", "PRIMARYno_slash", 14),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARYwith-dash", "dash", 15),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARY-no_slash", "no_slash", 16),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARY-with-dash", "with-dash", 17),
+            Arguments.of("archivedPRIMARYno_slash", "archivedPRIMARYno_slash", 18),
+            Arguments.of("archivedPRIMARYwith-dash", "dash", 19),
+            Arguments.of("archivedPRIMARY-no_slash", "no_slash", 20),
+            Arguments.of("archivedPRIMARY-with-dash", "with-dash", 21),
+            Arguments.of("archivedwith_slash/PRIMARYno_slash", "PRIMARYno_slash", 22),
+            Arguments.of("archivedwith_slash/PRIMARYwith-dash", "dash", 23),
+            Arguments.of("archivedwith_slash/PRIMARY-no_slash", "no_slash", 24),
+            Arguments.of("archivedwith_slash/PRIMARY-with-dash", "with-dash", 25),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARYno_slash", "PRIMARYno_slash", 26),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARYwith-dash", "dash", 27),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARY-no_slash", "no_slash", 28),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARY-with-dash", "with-dash", 29),
+            Arguments.of("no_slash.txt", "no_slash.txt", 30),
+            Arguments.of("with-dash.txt", "dash.txt", 31),
+            Arguments.of("with_slash/no_dash.txt", "no_dash.txt", 32),
+            Arguments.of("with_slash/with-dash.txt", "dash.txt", 33),
+            Arguments.of("/many//-/slashes/with_slash/no_dash.txt", "no_dash.txt", 34),
+            Arguments.of("/many//-/slashes/with_slash/with-dash.txt", "dash.txt", 35)
+        );
+    }
+
+    private static Stream<Arguments> provideGetExportFileParameters() {
+        // Warning: This matches the behavior of getFileName(), some of these, such as 'PRIMARYno_slash' which may or may not be incorrect.  
+        return Stream.of(
+            Arguments.of("no_slash", "no_slash", 0),
+            Arguments.of("with-dash", "with-dash", 1),
+            Arguments.of("with_slash/no_dash", "no_dash", 2),
+            Arguments.of("with_slash/with-dash", "with-dash", 3),
+            Arguments.of("/many//-/slashes/with_slash/no_dash", "no_dash", 4),
+            Arguments.of("/many//-/slashes/with_slash/with-dash", "with-dash", 5),
+            Arguments.of("PRIMARYno_slash", "PRIMARYno_slash", 6),
+            Arguments.of("PRIMARYwith-dash", "dash", 7),
+            Arguments.of("PRIMARY-no_slash", "no_slash", 8),
+            Arguments.of("PRIMARY-with-dash", "with-dash", 9),
+            Arguments.of("with_slash/PRIMARYno_slash", "PRIMARYno_slash", 10),
+            Arguments.of("with_slash/PRIMARYwith-dash", "dash", 11),
+            Arguments.of("with_slash/PRIMARY-no_slash", "no_slash", 12),
+            Arguments.of("with_slash/PRIMARY-with-dash", "with-dash", 13),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARYno_slash", "PRIMARYno_slash", 14),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARYwith-dash", "dash", 15),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARY-no_slash", "no_slash", 16),
+            Arguments.of("/many//-/slashes/with_slash/PRIMARY-with-dash", "with-dash", 17),
+            Arguments.of("archivedPRIMARYno_slash", "archivedPRIMARYno_slash", 18),
+            Arguments.of("archivedPRIMARYwith-dash", "archivedPRIMARYwith-dash", 19),
+            Arguments.of("archivedPRIMARY-no_slash", "archivedPRIMARY-no_slash", 20),
+            Arguments.of("archivedPRIMARY-with-dash", "archivedPRIMARY-with-dash", 21),
+            Arguments.of("archivedwith_slash/PRIMARYno_slash", "PRIMARYno_slash", 22),
+            Arguments.of("archivedwith_slash/PRIMARYwith-dash", "dash", 23),
+            Arguments.of("archivedwith_slash/PRIMARY-no_slash", "no_slash", 24),
+            Arguments.of("archivedwith_slash/PRIMARY-with-dash", "with-dash", 25),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARYno_slash", "PRIMARYno_slash", 26),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARYwith-dash", "dash", 27),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARY-no_slash", "no_slash", 28),
+            Arguments.of("/archivedmany//-/slashes/with_slash/PRIMARY-with-dash", "with-dash", 29),
+            Arguments.of("no_slash.txt", "no_slash.txt", 30),
+            Arguments.of("with-dash.txt", "dash.txt", 31),
+            Arguments.of("with_slash/no_dash.txt", "no_dash.txt", 32),
+            Arguments.of("with_slash/with-dash.txt", "dash.txt", 33),
+            Arguments.of("/many//-/slashes/with_slash/no_dash.txt", "no_dash.txt", 34),
+            Arguments.of("/many//-/slashes/with_slash/with-dash.txt", "dash.txt", 35)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/FilterActionTest.java
+++ b/src/test/java/org/tdl/vireo/model/FilterActionTest.java
@@ -1,0 +1,19 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class FilterActionTest extends AbstractEnumTest<FilterAction> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(FilterAction.CLEAR, "CLEAR", 0),
+            Arguments.of(FilterAction.REFRESH, "REFRESH", 1),
+            Arguments.of(FilterAction.REMOVE, "REMOVE", 2),
+            Arguments.of(FilterAction.SAVE, "SAVE", 3),
+            Arguments.of(FilterAction.SET, "SET", 4),
+            Arguments.of(FilterAction.SORT, "SORT", 5)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/FilterCriterionTest.java
+++ b/src/test/java/org/tdl/vireo/model/FilterCriterionTest.java
@@ -1,0 +1,56 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class FilterCriterionTest extends AbstractModelTest<FilterCriterion> {
+
+    @InjectMocks
+    private FilterCriterion filterCriterion;
+
+    @Test
+    public void testFilterCriterionInstantiation1() {
+        filterCriterion.setValue("value");
+        filterCriterion.setGloss("gloss");
+
+        FilterCriterion newFilterCriterion = new FilterCriterion(filterCriterion.getValue());
+
+        assertEquals(newFilterCriterion.getValue(), filterCriterion.getValue(), "Value does not match.");
+    }
+
+    @Test
+    public void testFilterCriterionInstantiation2() {
+        filterCriterion.setValue("value");
+        filterCriterion.setGloss("gloss");;
+
+        FilterCriterion newFilterCriterion = new FilterCriterion(filterCriterion.getValue(), filterCriterion.getGloss());
+
+        assertEquals(newFilterCriterion.getValue(), filterCriterion.getValue(), "Value does not match.");
+        assertEquals(newFilterCriterion.getGloss(), filterCriterion.getGloss(), "Gloss does not match.");
+    }
+
+    @Override
+    protected FilterCriterion getInstance() {
+        return filterCriterion;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("value", "value"),
+            Arguments.of("gloss", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/GraduationMonthTest.java
+++ b/src/test/java/org/tdl/vireo/model/GraduationMonthTest.java
@@ -1,0 +1,60 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class GraduationMonthTest extends AbstractModelTest<GraduationMonth> {
+
+    @InjectMocks
+    private GraduationMonth graduationMonth;
+
+    @Test
+    public void testGetControlledName() {
+        int month = 123;
+
+        ReflectionTestUtils.setField(getInstance(), "month", month);
+
+        assertEquals(String.valueOf(month), graduationMonth.getControlledName(), "Controlled Name does not match.");
+    }
+
+    @Test
+    public void testGetControlledDefinition() {
+        assertEquals("", graduationMonth.getControlledDefinition(), "Controlled Definition does not match.");
+    }
+
+    @Test
+    public void testGetControlledIdentifier() {
+        assertEquals("", graduationMonth.getControlledIdentifier(), "Controlled Identifier does not match.");
+    }
+
+    @Test
+    public void testGetControlledContacts() {
+        assertNotNull(graduationMonth.getControlledContacts(), "Controlled Contacts is null.");
+    }
+
+    @Override
+    protected GraduationMonth getInstance() {
+        return graduationMonth;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("month", 123)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/InputTypeTest.java
+++ b/src/test/java/org/tdl/vireo/model/InputTypeTest.java
@@ -1,0 +1,189 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class InputTypeTest extends AbstractModelTest<InputType> {
+
+    @InjectMocks
+    private InputType inputType;
+
+    @Test
+    public void testGetValidationMessage() {
+        Map<String, Validation> validations = new HashMap<>();
+        Validation validation1 = new Validation();
+        Validation validation2 = new Validation();
+        String name = "name";
+
+        validation1.setPattern("Some Pattern.");
+        validation1.setMessage("something");
+
+        validation2.setPattern("Another Pattern.");
+        validation2.setMessage("another");
+
+        validations.put("other", validation1);
+        validations.put(name, validation2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "validation", validations);
+
+        assertEquals(validation2.getMessage(), inputType.getValidationMessage(name), GETTER_MESSAGE + "validation.");
+    }
+
+    @Test
+    public void testGetValidationMessageReturnsNull() {
+        Map<String, Validation> validations = new HashMap<>();
+        Validation validation1 = new Validation();
+        Validation validation2 = new Validation();
+        String name = "name";
+
+        validation1.setPattern("Some Pattern.");
+        validation1.setMessage("something");
+
+        validation2.setPattern("Another Pattern.");
+        validation2.setMessage("another");
+
+        validations.put("other", validation1);
+        validations.put(name, validation2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "validation", validations);
+
+        assertNull(inputType.getValidationMessage("Not Found"), "Null must be returned for unknown map name.");
+    }
+
+    @Test
+    public void testGetValidationPattern() {
+        Map<String, Validation> validations = new HashMap<>();
+        Validation validation1 = new Validation();
+        Validation validation2 = new Validation();
+        String name = "name";
+
+        validation1.setPattern("Some Pattern.");
+        validation1.setMessage("something");
+
+        validation2.setPattern("Another Pattern.");
+        validation2.setMessage("another");
+
+        validations.put("other", validation1);
+        validations.put(name, validation2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "validation", validations);
+
+        assertEquals(validation2.getPattern(), inputType.getValidationPattern(name), GETTER_MESSAGE + "validation.");
+    }
+
+    /**
+     * The setValidationMessage() does not work via setParameterStream() and is manually tested here.
+     */
+    @Test
+    public void testSetValidationMessage1() {
+        String message = "message";
+
+        inputType.setValidationMessage(message);
+
+        assertEquals(message, ReflectionTestUtils.getField(getInstance(), "validationMessage"), SETTER_MESSAGE + "validationMessage.");
+    }
+
+    @Test
+    public void testSetValidationMessage2() {
+        Map<String, Validation> validations = new HashMap<>();
+        Validation validation1 = new Validation();
+        Validation validation2 = new Validation();
+        String message = "message";
+        String name = "name";
+
+        validation1.setPattern("Some Pattern.");
+        validation1.setMessage("something");
+
+        validation2.setPattern("Another Pattern.");
+        validation2.setMessage("another");
+
+        validations.put("other", validation1);
+        validations.put(name, validation2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "validation", validations);
+
+        inputType.setValidationMessage(message, name);
+
+        assertEquals(message, validation2.getMessage(), SETTER_MESSAGE + "validation.");
+    }
+
+    /**
+     * The setValidationPattern() does not work via setParameterStream() and is manually tested here.
+     */
+    @Test
+    public void testSetValidationPattern1() {
+        String pattern = "pattern";
+
+        inputType.setValidationPattern(pattern);
+
+        assertEquals(pattern, ReflectionTestUtils.getField(getInstance(), "validationPattern"), SETTER_MESSAGE + "validationPattern.");
+    }
+
+    @Test
+    public void testSetValidationPattern2() {
+        Map<String, Validation> validations = new HashMap<>();
+        Validation validation1 = new Validation();
+        Validation validation2 = new Validation();
+        String pattern = "pattern";
+        String name = "name";
+
+        validation1.setMessage("Some Message.");
+        validation1.setPattern("something");
+
+        validation2.setMessage("Another Message.");
+        validation2.setPattern("another");
+
+        validations.put("other", validation1);
+        validations.put(name, validation2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "validation", validations);
+
+        inputType.setValidationPattern(pattern, name);
+
+        assertEquals(pattern, validation2.getPattern(), SETTER_MESSAGE + "validation.");
+    }
+
+    @Override
+    protected InputType getInstance() {
+        return inputType;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        Map<String, Validation> validationMap = new HashMap<>();
+        Validation validation = new Validation();
+
+        validation.setMessage("message");
+        validation.setMessage("pattern");
+        validationMap.put("key", validation);
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("validationPattern", "pattern"),
+            Arguments.of("validationMessage", "message"),
+            Arguments.of("validation", validationMap)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        Map<String, Validation> validationMap = new HashMap<>();
+        Validation validation = new Validation();
+
+        validation.setMessage("message");
+        validation.setMessage("pattern");
+        validationMap.put("key", validation);
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("validation", validationMap)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/LanguageTest.java
+++ b/src/test/java/org/tdl/vireo/model/LanguageTest.java
@@ -1,0 +1,60 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class LanguageTest extends AbstractModelTest<Language> {
+
+    @InjectMocks
+    private Language language;
+
+    @Test
+    public void testGetControlledName() {
+        String name = "name";
+
+        ReflectionTestUtils.setField(getInstance(), "name", name);
+
+        assertEquals(name, language.getControlledName(), "Controlled Name does not match.");
+    }
+
+    @Test
+    public void testGetControlledDefinition() {
+        assertEquals("", language.getControlledDefinition(), "Controlled Definition does not match.");
+    }
+
+    @Test
+    public void testGetControlledIdentifier() {
+        assertEquals("", language.getControlledIdentifier(), "Controlled Identifier does not match.");
+    }
+
+    @Test
+    public void testGetControlledContacts() {
+        assertNotNull(language.getControlledContacts(), "Controlled Contacts is null.");
+    }
+
+    @Override
+    protected Language getInstance() {
+        return language;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/ManagedConfigurationTest.java
+++ b/src/test/java/org/tdl/vireo/model/ManagedConfigurationTest.java
@@ -1,0 +1,33 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class ManagedConfigurationTest extends AbstractModelTest<ManagedConfiguration> {
+
+    @InjectMocks
+    private ManagedConfiguration managedConfiguration;
+
+    @Override
+    protected ManagedConfiguration getInstance() {
+        return managedConfiguration;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("value", "value"),
+            Arguments.of("type", "value"),
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/NamedSearchFilterGroupTest.java
+++ b/src/test/java/org/tdl/vireo/model/NamedSearchFilterGroupTest.java
@@ -1,0 +1,217 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class NamedSearchFilterGroupTest extends AbstractModelCustomMethodTest<NamedSearchFilterGroup> {
+
+    @InjectMocks
+    private NamedSearchFilterGroup namedSearchFilterGroup;
+
+    @Test
+    public void testAddSavedColumnWhenNotInArray() {
+        List<SubmissionListColumn> savedColumns = new ArrayList<>();
+        SubmissionListColumn submissionListColumn1 = new SubmissionListColumn();
+        SubmissionListColumn submissionListColumn2 = new SubmissionListColumn();
+
+        submissionListColumn1.setId(1L);
+        submissionListColumn2.setId(2L);
+
+        savedColumns.add(submissionListColumn1);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "savedColumns", savedColumns);
+
+        namedSearchFilterGroup.addSavedColumn(submissionListColumn2);
+
+        assertTrue(savedColumns.contains(submissionListColumn2), "Submission List Column is not added to the Saved Columns array.");
+    }
+
+    @Test
+    public void testAddSavedColumnWhenInArray() {
+        List<SubmissionListColumn> savedColumns = new ArrayList<>();
+        SubmissionListColumn submissionListColumn1 = new SubmissionListColumn();
+        SubmissionListColumn submissionListColumn2 = new SubmissionListColumn();
+
+        submissionListColumn1.setId(1L);
+        submissionListColumn2.setId(2L);
+
+        savedColumns.add(submissionListColumn1);
+        savedColumns.add(submissionListColumn2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "savedColumns", savedColumns);
+
+        namedSearchFilterGroup.addSavedColumn(submissionListColumn2);
+
+        assertEquals(2, savedColumns.size(), "Submission List Column is added to the Saved Columns array multiple times.");
+    }
+
+    @Test
+    public void testRemoveSavedColumn() {
+        List<SubmissionListColumn> savedColumns = new ArrayList<>();
+        SubmissionListColumn submissionListColumn1 = new SubmissionListColumn();
+        SubmissionListColumn submissionListColumn2 = new SubmissionListColumn();
+
+        submissionListColumn1.setId(1L);
+        submissionListColumn2.setId(2L);
+
+        savedColumns.add(submissionListColumn1);
+        savedColumns.add(submissionListColumn2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "savedColumns", savedColumns);
+
+        namedSearchFilterGroup.removeSavedColumn(submissionListColumn2);
+
+        assertFalse(savedColumns.contains(submissionListColumn2), "Submission List Column is still in the Saved Columns array.");
+    }
+
+    @Test
+    public void testAddNamedSearchFilterWhenNotInArray() {
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        NamedSearchFilter filterCriterion1 = new NamedSearchFilter();
+        NamedSearchFilter filterCriterion2 = new NamedSearchFilter();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+
+        namedSearchFilters.add(filterCriterion1);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "namedSearchFilters", namedSearchFilters);
+
+        namedSearchFilterGroup.addFilterCriterion(filterCriterion2);
+
+        assertTrue(namedSearchFilters.contains(filterCriterion2), "Filter Criterion is not added to the Named Search Filters array.");
+    }
+
+    @Test
+    public void testAddNamedSearchFilterWhenInArray() {
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        NamedSearchFilter filterCriterion1 = new NamedSearchFilter();
+        NamedSearchFilter filterCriterion2 = new NamedSearchFilter();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+
+        namedSearchFilters.add(filterCriterion1);
+        namedSearchFilters.add(filterCriterion2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "namedSearchFilters", namedSearchFilters);
+
+        namedSearchFilterGroup.addFilterCriterion(filterCriterion2);
+
+        assertEquals(2, namedSearchFilters.size(), "Filter Criterion is added to the Named Search Filters array multiple times.");
+    }
+
+    @Test
+    public void testRemoveNamedSearchFilter() {
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        NamedSearchFilter filterCriterion1 = new NamedSearchFilter();
+        NamedSearchFilter filterCriterion2 = new NamedSearchFilter();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+
+        namedSearchFilters.add(filterCriterion1);
+        namedSearchFilters.add(filterCriterion2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "namedSearchFilters", namedSearchFilters);
+
+        namedSearchFilterGroup.removeNamedSearchFilter(filterCriterion2);
+
+        assertFalse(namedSearchFilters.contains(filterCriterion2), "Filter Criterion is still in the Named Search Filters array.");
+    }
+
+    @Test
+    public void testGetNamedSearchFilterWhenInArray() {
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        NamedSearchFilter filterCriterion1 = new NamedSearchFilter();
+        NamedSearchFilter filterCriterion2 = new NamedSearchFilter();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+
+        namedSearchFilters.add(filterCriterion1);
+        namedSearchFilters.add(filterCriterion2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "namedSearchFilters", namedSearchFilters);
+
+        assertEquals(filterCriterion2, namedSearchFilterGroup.getNamedSearchFilter(filterCriterion2.getId()), "Filter Criterion is not returned.");
+    }
+
+    @Test
+    public void testGetNamedSearchFilterWhenNotInArray() {
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        NamedSearchFilter filterCriterion1 = new NamedSearchFilter();
+        NamedSearchFilter filterCriterion2 = new NamedSearchFilter();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+
+        namedSearchFilters.add(filterCriterion1);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "namedSearchFilters", namedSearchFilters);
+
+        assertNull(namedSearchFilterGroup.getNamedSearchFilter(filterCriterion2.getId()), "Filter Criterion is returned.");
+    }
+
+    @Override
+    protected NamedSearchFilterGroup getInstance() {
+        return namedSearchFilterGroup;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getPublicFlag", "publicFlag", true),
+            Arguments.of("getPublicFlag", "publicFlag", false),
+            Arguments.of("getColumnsFlag", "columnsFlag", true),
+            Arguments.of("getColumnsFlag", "columnsFlag", false),
+            Arguments.of("getUmiRelease", "umiRelease", true),
+            Arguments.of("getUmiRelease", "umiRelease", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setPublicFlag", "publicFlag", true),
+            Arguments.of("setPublicFlag", "publicFlag", false),
+            Arguments.of("setColumnsFlag", "columnsFlag", true),
+            Arguments.of("setColumnsFlag", "columnsFlag", false),
+            Arguments.of("setUmiRelease", "umiRelease", true),
+            Arguments.of("setUmiRelease", "umiRelease", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<SubmissionListColumn> savedColumns = new ArrayList<>();
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("user", new User()),
+            Arguments.of("name", "value"),
+            Arguments.of("sortColumnTitle", "value"),
+            Arguments.of("sortDirection", Sort.ASC),
+            Arguments.of("savedColumns", savedColumns),
+            Arguments.of("namedSearchFilters", namedSearchFilters)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/NamedSearchFilterTest.java
+++ b/src/test/java/org/tdl/vireo/model/NamedSearchFilterTest.java
@@ -1,0 +1,149 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class NamedSearchFilterTest extends AbstractModelCustomMethodTest<NamedSearchFilter> {
+
+    @InjectMocks
+    private NamedSearchFilter namedSearchFilter;
+
+    @Test
+    public void testAddFilterCriterion() {
+        Set<FilterCriterion> filters = new HashSet<>();
+        FilterCriterion filterCriterion1 = new FilterCriterion();
+        FilterCriterion filterCriterion2 = new FilterCriterion();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+        filters.add(filterCriterion1);
+
+        ReflectionTestUtils.setField(namedSearchFilter, "filterCriteria", filters);
+
+        namedSearchFilter.addFilter(filterCriterion2);
+
+        assertTrue(filters.contains(filterCriterion2), "Filter Criterion 2 is not found.");
+    }
+
+    @Test
+    public void testRemoveFilterCriterion() {
+        Set<FilterCriterion> filters = new HashSet<>();
+        FilterCriterion filterCriterion1 = new FilterCriterion();
+        FilterCriterion filterCriterion2 = new FilterCriterion();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+        filters.add(filterCriterion1);
+        filters.add(filterCriterion2);
+
+        ReflectionTestUtils.setField(namedSearchFilter, "filterCriteria", filters);
+
+        namedSearchFilter.removeFilter(filterCriterion2);
+
+        assertFalse(filters.contains(filterCriterion2), "Filter Criterion 2 is found.");
+    }
+
+    @Test
+    public void testGetFilterValues() {
+        Set<FilterCriterion> filters = new HashSet<>();
+        FilterCriterion filterCriterion1 = new FilterCriterion();
+        FilterCriterion filterCriterion2 = new FilterCriterion();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+        filterCriterion1.setValue("value1");
+        filterCriterion2.setValue("value2");
+        filters.add(filterCriterion1);
+        filters.add(filterCriterion2);
+
+        ReflectionTestUtils.setField(namedSearchFilter, "filterCriteria", filters);
+
+        Set<String> filterValues = namedSearchFilter.getFilterValues();
+
+        assertNotNull(filterValues, "Returned Filter Values array is null.");
+        assertEquals(filters.size(), filterValues.size(), "Returned Filter Values array is of the wrong size.");
+        assertTrue(filterValues.contains(filterCriterion1.getValue()), "Filter Criterion 1 value is not found.");
+        assertTrue(filterValues.contains(filterCriterion2.getValue()), "Filter Criterion 2 value is not found.");
+    }
+
+    @Test
+    public void testGetFilterGlosses() {
+        Set<FilterCriterion> filters = new HashSet<>();
+        FilterCriterion filterCriterion1 = new FilterCriterion();
+        FilterCriterion filterCriterion2 = new FilterCriterion();
+
+        filterCriterion1.setId(1L);
+        filterCriterion2.setId(2L);
+        filterCriterion1.setGloss("gloss1");
+        filterCriterion2.setGloss("gloss2");
+        filters.add(filterCriterion1);
+        filters.add(filterCriterion2);
+
+        ReflectionTestUtils.setField(namedSearchFilter, "filterCriteria", filters);
+
+        Set<String> filterGlosses = namedSearchFilter.getFilterGlosses();
+
+        assertNotNull(filterGlosses, "Returned Filter Glosses array is null.");
+        assertEquals(filters.size(), filterGlosses.size(), "Returned Filter Glosses array is of the wrong size.");
+        assertTrue(filterGlosses.contains(filterCriterion1.getGloss()), "Filter Criterion 1 gloss is not found.");
+        assertTrue(filterGlosses.contains(filterCriterion2.getGloss()), "Filter Criterion 2 gloss is not found.");
+    }
+
+    @Override
+    protected NamedSearchFilter getInstance() {
+        return namedSearchFilter;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        Set<FilterCriterion> filters = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("getAllColumnSearch", "allColumnSearch", true),
+            Arguments.of("getAllColumnSearch", "allColumnSearch", false),
+            Arguments.of("getExactMatch", "exactMatch", true),
+            Arguments.of("getExactMatch", "exactMatch", false),
+            Arguments.of("getFilters", "filterCriteria", filters) // Warning: This function is identical to getFilterCriteria().
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        Set<FilterCriterion> filters = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("setAllColumnSearch", "allColumnSearch", true),
+            Arguments.of("setAllColumnSearch", "allColumnSearch", false),
+            Arguments.of("setExactMatch", "exactMatch", true),
+            Arguments.of("setExactMatch", "exactMatch", false),
+            Arguments.of("setFilters", "filterCriteria", filters) // Warning: This function is identical to setFilterCriteria().
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        Set<FilterCriterion> filterCriteria = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("submissionListColumn", new SubmissionListColumn()),
+            Arguments.of("filterCriteria", filterCriteria)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/NoteTest.java
+++ b/src/test/java/org/tdl/vireo/model/NoteTest.java
@@ -1,0 +1,50 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class NoteTest extends AbstractModelCustomMethodTest<Note> {
+
+    @InjectMocks
+    private Note note;
+
+    @Override
+    protected Note getInstance() {
+        return note;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getOverrideable", "overrideable", true),
+            Arguments.of("getOverrideable", "overrideable", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setOverrideable", "overrideable", true),
+            Arguments.of("setOverrideable", "overrideable", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        WorkflowStep workflowStep = new WorkflowStep();
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("text", "value"),
+            Arguments.of("originating", new Note(workflowStep, "name", "text", false)),
+            Arguments.of("originatingWorkflowStep", workflowStep)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/OrganizationCategoryTest.java
+++ b/src/test/java/org/tdl/vireo/model/OrganizationCategoryTest.java
@@ -1,0 +1,31 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class OrganizationCategoryTest extends AbstractModelTest<OrganizationCategory> {
+
+    @InjectMocks
+    private OrganizationCategory organizationCategory;
+
+    @Override
+    protected OrganizationCategory getInstance() {
+        return organizationCategory;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/OrganizationTest.java
+++ b/src/test/java/org/tdl/vireo/model/OrganizationTest.java
@@ -1,0 +1,219 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class OrganizationTest extends AbstractModelCustomMethodTest<Organization> {
+
+    @InjectMocks
+    private Organization organization;
+
+    @Test
+    public void testAddEmail() {
+        List<String> emails = new ArrayList<>();
+        String email1 = "email1";
+        String email2 = "email2";
+
+        emails.add(email1);
+
+        ReflectionTestUtils.setField(organization, "emails", emails);
+
+        organization.addEmail(email2);
+
+        assertTrue(emails.contains(email2), "E-mail 2 is not found.");
+    }
+
+    @Test
+    public void testRemoveEmail() {
+        List<String> emails = new ArrayList<>();
+        String email1 = "email1";
+        String email2 = "email2";
+
+        emails.add(email1);
+        emails.add(email2);
+
+        ReflectionTestUtils.setField(organization, "emails", emails);
+
+        organization.removeEmail(email2);
+
+        assertFalse(emails.contains(email2), "E-mail 2 is found.");
+    }
+
+    @Test
+    public void testReplaceOriginalWorkflowStep() {
+        List<WorkflowStep> originalWorkflowSteps = new ArrayList<>();
+        List<WorkflowStep> aggregateWorkflowSteps = new ArrayList<>();
+        WorkflowStep workflowStep1 = new WorkflowStep();
+        WorkflowStep workflowStep2 = new WorkflowStep();
+        WorkflowStep workflowStep3 = new WorkflowStep();
+
+        workflowStep1.setId(1L);
+        workflowStep2.setId(2L);
+        workflowStep3.setId(3L);
+        originalWorkflowSteps.add(workflowStep1);
+        originalWorkflowSteps.add(workflowStep2);
+        aggregateWorkflowSteps.add(workflowStep1);
+        aggregateWorkflowSteps.add(workflowStep2);
+
+        ReflectionTestUtils.setField(organization, "originalWorkflowSteps", originalWorkflowSteps);
+        ReflectionTestUtils.setField(organization, "aggregateWorkflowSteps", aggregateWorkflowSteps);
+
+        organization.replaceOriginalWorkflowStep(workflowStep1, workflowStep3);
+
+        assertTrue(originalWorkflowSteps.contains(workflowStep3), "Workflow Step 3 is not found in Original Workflow Steps array.");
+        assertFalse(originalWorkflowSteps.contains(workflowStep1), "Workflow Step 1 is found in Original Workflow Steps array.");
+
+        assertTrue(aggregateWorkflowSteps.contains(workflowStep3), "Workflow Step 3 is not found in Aggregate Workflow Steps array.");
+        assertFalse(aggregateWorkflowSteps.contains(workflowStep1), "Workflow Step 1 is found in Aggregate Workflow Steps array.");
+    }
+
+    @Test
+    public void testGetAggregateEmailWorkflowRules() {
+        List<EmailWorkflowRule> emailWorkflowRules = new ArrayList<>();
+        List<EmailWorkflowRule> parentEmailWorkflowRules = new ArrayList<>();
+        EmailWorkflowRule emailWorkflowRule1 = new EmailWorkflowRule();
+        EmailWorkflowRule emailWorkflowRule2 = new EmailWorkflowRule();
+        EmailWorkflowRule emailWorkflowRule3 = new EmailWorkflowRule();
+        EmailRecipient emailRecipient1 = new EmailRecipientPlainAddress("email@Recipient1.nowhere");
+        EmailRecipient emailRecipient2 = new EmailRecipientPlainAddress("email@Recipient2.nowhere");
+        EmailRecipient emailRecipient3 = new EmailRecipientPlainAddress("email@Recipient3.nowhere");
+        EmailTemplate emailTemplate1 = new EmailTemplate();
+        EmailTemplate emailTemplate2 = new EmailTemplate();
+        EmailTemplate emailTemplate3 = new EmailTemplate();
+        Organization parentOrganization = new Organization();
+
+        parentOrganization.setId(1L);
+        emailTemplate1.setId(1L);
+        emailTemplate2.setId(2L);
+        emailTemplate3.setId(3L);
+        emailTemplate1.setName("name1");
+        emailTemplate2.setName("name2");
+        emailTemplate3.setName("name3");
+        emailWorkflowRule1.setId(1L);
+        emailWorkflowRule2.setId(2L);
+        emailWorkflowRule3.setId(3L);
+        emailWorkflowRule1.setEmailRecipient(emailRecipient1);
+        emailWorkflowRule2.setEmailRecipient(emailRecipient2);
+        emailWorkflowRule3.setEmailRecipient(emailRecipient3);
+        emailWorkflowRule1.setEmailTemplate(emailTemplate1);
+        emailWorkflowRule2.setEmailTemplate(emailTemplate2);
+        emailWorkflowRule3.setEmailTemplate(emailTemplate3);
+        emailWorkflowRules.add(emailWorkflowRule1);
+        emailWorkflowRules.add(emailWorkflowRule2);
+        parentEmailWorkflowRules.add(emailWorkflowRule2);
+        parentEmailWorkflowRules.add(emailWorkflowRule3);
+        parentOrganization.setEmailWorkflowRules(parentEmailWorkflowRules);
+
+        ReflectionTestUtils.setField(organization, "id", 2L);
+        ReflectionTestUtils.setField(organization, "emailWorkflowRules", emailWorkflowRules);
+        ReflectionTestUtils.setField(organization, "parentOrganization", parentOrganization);
+
+        List<EmailWorkflowRule> got = organization.getAggregateEmailWorkflowRules();
+
+        assertTrue(got.contains(emailWorkflowRule1), "E-mail Workflow Rule 1 is not found in Aggregate E-mail Workflow Rules array.");
+        assertTrue(got.contains(emailWorkflowRule2), "E-mail Workflow Rule 2 is not found in Aggregate E-mail Workflow Rules array.");
+        assertTrue(got.contains(emailWorkflowRule3), "E-mail Workflow Rule 3 is not found in Aggregate E-mail Workflow Rules array.");
+    }
+
+    @Test
+    public void testGetAggregateEmailWorkflowRulesWithoutParentOrganization() {
+        List<EmailWorkflowRule> emailWorkflowRules = new ArrayList<>();
+        EmailWorkflowRule emailWorkflowRule1 = new EmailWorkflowRule();
+        EmailWorkflowRule emailWorkflowRule2 = new EmailWorkflowRule();
+
+        emailWorkflowRule1.setId(1L);
+        emailWorkflowRule2.setId(2L);
+        emailWorkflowRules.add(emailWorkflowRule1);
+        emailWorkflowRules.add(emailWorkflowRule2);
+
+        ReflectionTestUtils.setField(organization, "id", 2L);
+        ReflectionTestUtils.setField(organization, "emailWorkflowRules", emailWorkflowRules);
+
+        List<EmailWorkflowRule> got = organization.getAggregateEmailWorkflowRules();
+
+        assertTrue(got.contains(emailWorkflowRule1), "E-mail Workflow Rule 1 is not found in Aggregate E-mail Workflow Rules array.");
+        assertTrue(got.contains(emailWorkflowRule2), "E-mail Workflow Rule 2 is not found in Aggregate E-mail Workflow Rules array.");
+    }
+
+    @Test
+    public void testGetAncestorOrganizations() {
+        Organization parentOrganization = new Organization();
+
+        parentOrganization.setId(1L);
+
+        ReflectionTestUtils.setField(organization, "id", 2L);
+        ReflectionTestUtils.setField(organization, "parentOrganization", parentOrganization);
+
+        assertEquals(1, organization.getAncestorOrganizations().size(), "Ancestor Organizations array has wrong length.");
+    }
+
+    @Test
+    public void testGetAncestorOrganizationsParentOrganization() {
+        assertTrue(organization.getAncestorOrganizations().isEmpty(), "Ancestor Organizations array is not empty.");
+    }
+
+    @Test
+    public void testGetAncestorOrganizationsParentOrganizationIsSelf() {
+        ReflectionTestUtils.setField(organization, "parentOrganization", organization);
+
+        assertTrue(organization.getAncestorOrganizations().isEmpty(), "Ancestor Organizations array is not empty.");
+    }
+
+    @Override
+    protected Organization getInstance() {
+        return organization;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getAcceptsSubmissions", "acceptsSubmissions", true),
+            Arguments.of("getAcceptsSubmissions", "acceptsSubmissions", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setAcceptsSubmissions", "acceptsSubmissions", true),
+            Arguments.of("setAcceptsSubmissions", "acceptsSubmissions", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<SubmissionWorkflowStep> originalWorkflowSteps = new ArrayList<>();
+        List<SubmissionWorkflowStep> aggregateWorkflowSteps = new ArrayList<>();
+        List<String> emails = new ArrayList<>();
+        List<EmailWorkflowRule> emailWorkflowRules = new ArrayList<>();
+        Set<Organization> childrenOrganizations = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("category", new OrganizationCategory()),
+            Arguments.of("originalWorkflowSteps", originalWorkflowSteps),
+            Arguments.of("aggregateWorkflowSteps", aggregateWorkflowSteps),
+            Arguments.of("parentOrganization", new Organization()),
+            Arguments.of("childrenOrganizations", childrenOrganizations),
+            Arguments.of("emails", emails),
+            Arguments.of("emailWorkflowRules", emailWorkflowRules)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/RoleTest.java
+++ b/src/test/java/org/tdl/vireo/model/RoleTest.java
@@ -1,0 +1,18 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class RoleTest extends AbstractEnumTest<Role> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(Role.ROLE_ADMIN, "ROLE_ADMIN", 0),
+            Arguments.of(Role.ROLE_MANAGER, "ROLE_MANAGER", 1),
+            Arguments.of(Role.ROLE_REVIEWER, "ROLE_REVIEWER", 2),
+            Arguments.of(Role.ROLE_STUDENT, "ROLE_STUDENT", 3),
+            Arguments.of(Role.ROLE_ANONYMOUS, "ROLE_ANONYMOUS", 4) 
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SortTest.java
+++ b/src/test/java/org/tdl/vireo/model/SortTest.java
@@ -1,0 +1,16 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class SortTest extends AbstractEnumTest<Sort> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(Sort.ASC, "ASC", 0),
+            Arguments.of(Sort.DESC, "DESC", 1),
+            Arguments.of(Sort.NONE, "NONE", 2) 
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionFieldProfileTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionFieldProfileTest.java
@@ -1,0 +1,71 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class SubmissionFieldProfileTest extends AbstractModelCustomMethodTest<SubmissionFieldProfile> {
+
+    @InjectMocks
+    private SubmissionFieldProfile submissionFieldProfile;
+
+    @Override
+    protected SubmissionFieldProfile getInstance() {
+        return submissionFieldProfile;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getRepeatable", "repeatable", true),
+            Arguments.of("getRepeatable", "repeatable", false),
+            Arguments.of("getOptional", "optional", true),
+            Arguments.of("getOptional", "optional", false),
+            Arguments.of("getHidden", "hidden", true),
+            Arguments.of("getHidden", "hidden", false),
+            Arguments.of("getLogged", "logged", true),
+            Arguments.of("getLogged", "logged", false),
+            Arguments.of("getFlagged", "flagged", true),
+            Arguments.of("getFlagged", "flagged", false),
+            Arguments.of("getEnabled", "enabled", true),
+            Arguments.of("getEnabled", "enabled", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setRepeatable", "repeatable", true),
+            Arguments.of("setRepeatable", "repeatable", false),
+            Arguments.of("setOptional", "optional", true),
+            Arguments.of("setOptional", "optional", false),
+            Arguments.of("setHidden", "hidden", true),
+            Arguments.of("setHidden", "hidden", false),
+            Arguments.of("setLogged", "logged", true),
+            Arguments.of("setLogged", "logged", false),
+            Arguments.of("setFlagged", "flagged", true),
+            Arguments.of("setFlagged", "flagged", false),
+            Arguments.of("setEnabled", "enabled", true),
+            Arguments.of("setEnabled", "enabled", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("fieldPredicate", new FieldPredicate()),
+            Arguments.of("inputType", new InputType()),
+            Arguments.of("usage", "value"),
+            Arguments.of("help", "value"),
+            Arguments.of("gloss", "value"),
+            Arguments.of("controlledVocabulary", new ControlledVocabulary()),
+            Arguments.of("mappedShibAttribute", new ManagedConfiguration())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionListColumnTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionListColumnTest.java
@@ -1,0 +1,136 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SubmissionListColumnTest extends AbstractModelCustomMethodTest<SubmissionListColumn> {
+
+    @InjectMocks
+    private SubmissionListColumn submissionListColumn;
+
+    @Test
+    public void testAddFilter() {
+        Set<String> filters = new HashSet<>();
+        String filter = "filter";
+
+        ReflectionTestUtils.setField(submissionListColumn, "filters", filters);
+
+        submissionListColumn.addFilter(filter);
+
+        assertTrue(filters.contains(filter), "The Filter is not added.");
+    }
+
+    @Test
+    public void testAddFilterWithExisting() {
+        Set<String> filters = new HashSet<>();
+        String filter = "filter";
+
+        ReflectionTestUtils.setField(submissionListColumn, "filters", filters);
+
+        submissionListColumn.addFilter(filter);
+        submissionListColumn.addFilter(filter);
+
+        assertEquals(1, filters.size(), "The Filter is not added twice.");
+    }
+
+    @Test
+    public void testAddAllFilters() {
+        Set<String> filters = new HashSet<>();
+        Set<String> newFilters = new HashSet<>();
+        String filter1 = "filter1";
+        String filter2 = "filter2";
+        String filter3 = "filter3";
+        String filter4 = "filter4";
+
+        filters.add(filter1);
+        filters.add(filter2);
+        newFilters.add(filter2);
+        newFilters.add(filter3);
+        newFilters.add(filter4);
+
+        ReflectionTestUtils.setField(submissionListColumn, "filters", filters);
+
+        submissionListColumn.addAllFilters(newFilters);
+
+        assertEquals(4, filters.size(), "The Filters array has an incorrect size.");
+    }
+
+    @Test
+    public void testRemoveFilter() {
+        Set<String> filters = new HashSet<>();
+        String filter1 = "filter1";
+        String filter2 = "filter2";
+
+        filters.add(filter1);
+        filters.add(filter2);
+
+        ReflectionTestUtils.setField(submissionListColumn, "filters", filters);
+
+        submissionListColumn.removeFilter(filter2);
+
+        assertFalse(filters.contains(filter2), "The Filter is not removed.");
+    }
+
+    @Override
+    protected SubmissionListColumn getInstance() {
+        return submissionListColumn;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getVisible", "visible", true),
+            Arguments.of("getVisible", "visible", false),
+            Arguments.of("getExactMatch", "exactMatch", true),
+            Arguments.of("getExactMatch", "exactMatch", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setVisible", "visible", true),
+            Arguments.of("setVisible", "visible", false),
+            Arguments.of("setExactMatch", "exactMatch", true),
+            Arguments.of("setExactMatch", "exactMatch", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<String> valuePath = new ArrayList<>();
+        valuePath.add("value");
+
+        Set<String> filters = new HashSet<>();
+        filters.add("value");
+
+        return Stream.of(
+            Arguments.of("inputType", new InputType()),
+            Arguments.of("title", "value"),
+            Arguments.of("predicate", "value"),
+            Arguments.of("valuePath", valuePath),
+            Arguments.of("filters", filters),
+            Arguments.of("sortOrder", 123),
+            Arguments.of("sort", Sort.ASC),
+            Arguments.of("sort", Sort.DESC),
+            Arguments.of("status", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionNoteTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionNoteTest.java
@@ -1,0 +1,32 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class SubmissionNoteTest extends AbstractModelTest<SubmissionNote> {
+
+    @InjectMocks
+    private SubmissionNote submissionNote;
+
+    @Override
+    protected SubmissionNote getInstance() {
+        return submissionNote;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("text", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionStateTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionStateTest.java
@@ -1,0 +1,42 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SubmissionStateTest extends AbstractEnumTest<SubmissionState> {
+
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testGetValue(SubmissionState enumeration, String name, int ordinal) {
+        assertEquals(ordinal, enumeration.getValue(), "Value is incorrect.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideEnumParameters")
+    public void testToString(SubmissionState enumeration, String name, int ordinal) {
+        assertEquals(name, enumeration.toString(), "Name is incorrect.");
+    }
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(SubmissionState.NONE, "NONE", 0),
+            Arguments.of(SubmissionState.IN_PROGRESS, "IN_PROGRESS", 1),
+            Arguments.of(SubmissionState.SUBMITTED, "SUBMITTED", 2),
+            Arguments.of(SubmissionState.UNDER_REVIEW, "UNDER_REVIEW", 3),
+            Arguments.of(SubmissionState.NEEDS_CORRECTIONS, "NEEDS_CORRECTIONS", 4),
+            Arguments.of(SubmissionState.CORRECTIONS_RECIEVED, "CORRECTIONS_RECIEVED", 5),
+            Arguments.of(SubmissionState.WAITING_ON_REQUIREMENTS, "WAITING_ON_REQUIREMENTS", 6),
+            Arguments.of(SubmissionState.APPROVED, "APPROVED", 7),
+            Arguments.of(SubmissionState.PENDING_PUBLICATION, "PENDING_PUBLICATION", 8),
+            Arguments.of(SubmissionState.PUBLISHED, "PUBLISHED", 9),
+            Arguments.of(SubmissionState.ON_HOLD, "ON_HOLD", 10),
+            Arguments.of(SubmissionState.WITHDRAWN, "WITHDRAWN", 11),
+            Arguments.of(SubmissionState.CANCELED, "CANCELED", 12)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionStatusTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionStatusTest.java
@@ -1,0 +1,116 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SubmissionStatusTest extends AbstractModelCustomMethodTest<SubmissionStatus> {
+
+    @InjectMocks
+    private SubmissionStatus submissionStatus;
+
+    @Test
+    public void testAddSubmissionStatusWhenInArray() {
+        List<SubmissionStatus> submissionStatuses = new ArrayList<>();
+        SubmissionStatus submissionStatus1 = new SubmissionStatus();
+        SubmissionStatus submissionStatus2 = new SubmissionStatus();
+
+        submissionStatus1.setId(1L);
+        submissionStatus2.setId(2L);
+
+        submissionStatuses.add(submissionStatus1);
+        submissionStatuses.add(submissionStatus2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "transitionSubmissionStatuses", submissionStatuses);
+
+        submissionStatus.addTransitionSubmissionStatus(submissionStatus2);
+
+        assertEquals(3, submissionStatuses.size(), "Submission Status is not added to the Submission Statuseses array.");
+    }
+
+    @Test
+    public void testRemoveSubmissionStatus() {
+        List<SubmissionStatus> submissionStatuses = new ArrayList<>();
+        SubmissionStatus submissionStatus1 = new SubmissionStatus();
+        SubmissionStatus submissionStatus2 = new SubmissionStatus();
+
+        submissionStatus1.setId(1L);
+        submissionStatus2.setId(2L);
+
+        submissionStatuses.add(submissionStatus1);
+        submissionStatuses.add(submissionStatus2);
+
+        ReflectionTestUtils.invokeSetterMethod(getInstance(), "transitionSubmissionStatuses", submissionStatuses);
+
+        submissionStatus.removeTransitionSubmissionStatus(submissionStatus2);
+
+        assertFalse(submissionStatuses.contains(submissionStatus2), "Submission Status is still in the Submission Statuses array.");
+    }
+
+    @Override
+    protected SubmissionStatus getInstance() {
+        return submissionStatus;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isArchived", "isArchived", true),
+            Arguments.of("isArchived", "isArchived", false),
+            Arguments.of("isPublishable", "isPublishable", true),
+            Arguments.of("isPublishable", "isPublishable", false),
+            Arguments.of("isDeletable", "isDeletable", true),
+            Arguments.of("isDeletable", "isDeletable", false),
+            Arguments.of("isEditableByReviewer", "isEditableByReviewer", true),
+            Arguments.of("isEditableByReviewer", "isEditableByReviewer", false),
+            Arguments.of("isEditableByStudent", "isEditableByStudent", true),
+            Arguments.of("isEditableByStudent", "isEditableByStudent", false),
+            Arguments.of("isActive", "isActive", true),
+            Arguments.of("isActive", "isActive", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("isArchived", "isArchived", true),
+            Arguments.of("isArchived", "isArchived", false),
+            Arguments.of("isPublishable", "isPublishable", true),
+            Arguments.of("isPublishable", "isPublishable", false),
+            Arguments.of("isDeletable", "isDeletable", true),
+            Arguments.of("isDeletable", "isDeletable", false),
+            Arguments.of("isEditableByReviewer", "isEditableByReviewer", true),
+            Arguments.of("isEditableByReviewer", "isEditableByReviewer", false),
+            Arguments.of("isEditableByStudent", "isEditableByStudent", true),
+            Arguments.of("isEditableByStudent", "isEditableByStudent", false),
+            Arguments.of("isActive", "isActive", true),
+            Arguments.of("isActive", "isActive", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<SubmissionStatus> transitionSubmissionStatuses = new ArrayList<>();
+        transitionSubmissionStatuses.add(new SubmissionStatus());
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("submissionState", SubmissionState.APPROVED),
+            Arguments.of("submissionState", SubmissionState.CANCELED),
+            Arguments.of("transitionSubmissionStatuses", transitionSubmissionStatuses)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionTest.java
@@ -1,0 +1,189 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class SubmissionTest extends AbstractModelCustomMethodTest<Submission> {
+
+    @InjectMocks
+    private Submission submission;
+
+    @Test
+    public void testClearApproveApplication() {
+        ReflectionTestUtils.setField(submission, "approveApplicationDate", Calendar.getInstance());
+        ReflectionTestUtils.setField(submission, "approveApplication", true);
+
+        submission.clearApproveApplication();
+
+        assertEquals(false, ReflectionTestUtils.getField(getInstance(), "approveApplication"), "Approve Application is not false.");
+        assertNull(ReflectionTestUtils.getField(getInstance(), "approveApplicationDate"), "Approve Application Date is not null.");
+    }
+
+    @Test
+    public void testClearApproveAdvisor() {
+        ReflectionTestUtils.setField(submission, "approveAdvisorDate", Calendar.getInstance());
+        ReflectionTestUtils.setField(submission, "approveAdvisor", true);
+
+        submission.clearApproveAdvisor();
+
+        assertEquals(false, ReflectionTestUtils.getField(getInstance(), "approveAdvisor"), "Approve Advisor is not false.");
+        assertNull(ReflectionTestUtils.getField(getInstance(), "approveAdvisorDate"), "Approve Advisor Date is not null.");
+    }
+
+    @Test
+    public void testClearApproveEmbargo() {
+        ReflectionTestUtils.setField(submission, "approveEmbargoDate", Calendar.getInstance());
+        ReflectionTestUtils.setField(submission, "approveEmbargo", true);
+
+        submission.clearApproveEmbargo();
+
+        assertEquals(false, ReflectionTestUtils.getField(getInstance(), "approveEmbargo"), "Approve Embargo is not false.");
+        assertNull(ReflectionTestUtils.getField(getInstance(), "approveEmbargoDate"), "Approve Embargo Date is not null.");
+    }
+
+    @Test
+    public void testGenerateAdvisorAccessHash() {
+        ReflectionTestUtils.setField(getInstance(), "advisorAccessHash", "");
+
+        ReflectionTestUtils.invokeGetterMethod(submission, "generateAdvisorAccessHash");
+
+        String got = (String) ReflectionTestUtils.getField(getInstance(), "advisorAccessHash");
+
+        assertNotNull(got, "Advisor Access Hash is null.");
+        assertTrue(got.length() > 0, "Advisor Access Hash is an empty string.");
+    }
+
+    @Test
+    public void testGetCommitteeContactEmail() {
+        Set<FieldValue> fieldValues = new HashSet<>();
+        List<String> contacts = new ArrayList<>();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+        FieldValue fieldValue1 = new FieldValue();
+        FieldValue fieldValue2 = new FieldValue();
+
+        contacts.add("contact");
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(1L);
+        fieldPredicate1.setValue("dc.contributor.advisor");
+        fieldPredicate2.setValue("not.advisor");
+        fieldValue1.setId(1L);
+        fieldValue2.setId(2L);
+        fieldValue1.setContacts(contacts);
+        fieldValue1.setValue("value1");
+        fieldValue2.setValue("value2");
+        fieldValue1.setFieldPredicate(fieldPredicate1);
+        fieldValue2.setFieldPredicate(fieldPredicate2);
+        fieldValues.add(fieldValue1);
+        fieldValues.add(fieldValue2);
+
+        ReflectionTestUtils.setField(submission, "fieldValues", fieldValues);
+
+        assertNotNull(submission.getCommitteeContactEmail(), "Committee Contact E-mail is null.");
+        assertEquals(contacts.get(0), submission.getCommitteeContactEmail(), "Committee Contact E-mail does not match.");
+    }
+
+    @Test
+    public void testGetCommitteeContactEmailReturnsNull() {
+        Set<FieldValue> fieldValues = new HashSet<>();
+        List<String> contacts = new ArrayList<>();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+        FieldValue fieldValue1 = new FieldValue();
+        FieldValue fieldValue2 = new FieldValue();
+
+        contacts.add("contact");
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(1L);
+        fieldPredicate1.setValue("not.advisor");
+        fieldPredicate2.setValue("not.advisor");
+        fieldValue1.setId(1L);
+        fieldValue2.setId(2L);
+        fieldValue1.setContacts(contacts);
+        fieldValue1.setValue("value1");
+        fieldValue2.setValue("value2");
+        fieldValue1.setFieldPredicate(fieldPredicate1);
+        fieldValue2.setFieldPredicate(fieldPredicate2);
+        fieldValues.add(fieldValue1);
+        fieldValues.add(fieldValue2);
+
+        ReflectionTestUtils.setField(submission, "fieldValues", fieldValues);
+
+        assertNull(submission.getCommitteeContactEmail(), "Committee Contact E-mail is not null.");
+    }
+
+    @Override
+    protected Submission getInstance() {
+        return submission;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getApproveEmbargo", "approveEmbargo", true),
+            Arguments.of("getApproveEmbargo", "approveEmbargo", false),
+            Arguments.of("isApproveApplication", "approveApplication", true),
+            Arguments.of("isApproveApplication", "approveApplication", false),
+            Arguments.of("getApproveAdvisor", "approveAdvisor", true),
+            Arguments.of("getApproveAdvisor", "approveAdvisor", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setApproveEmbargo", "approveEmbargo", true),
+            Arguments.of("setApproveEmbargo", "approveEmbargo", false),
+            Arguments.of("setApproveApplication", "approveApplication", true),
+            Arguments.of("setApproveApplication", "approveApplication", false),
+            Arguments.of("setApproveAdvisor", "approveAdvisor", true),
+            Arguments.of("setApproveAdvisor", "approveAdvisor", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        Set<FieldValue> fieldValues = new HashSet<>();
+        List<SubmissionWorkflowStep> submissionWorkflowSteps = new ArrayList<>();
+        Set<CustomActionValue> customActionValues = new HashSet<>();
+        Set<ActionLog> actionLogs = new HashSet<>();
+
+        return Stream.of(
+            Arguments.of("submitter", new User()),
+            Arguments.of("assignee", new User()),
+            Arguments.of("submissionStatus", new SubmissionStatus()),
+            Arguments.of("organization", new Organization()),
+            Arguments.of("fieldValues", fieldValues),
+            Arguments.of("submissionWorkflowSteps", submissionWorkflowSteps),
+            Arguments.of("approveEmbargoDate", Calendar.getInstance()),
+            Arguments.of("approveApplicationDate", Calendar.getInstance()),
+            Arguments.of("submissionDate", Calendar.getInstance()),
+            Arguments.of("approveAdvisorDate", Calendar.getInstance()),
+            Arguments.of("customActionValues", customActionValues),
+            Arguments.of("actionLogs", actionLogs),
+            Arguments.of("reviewerNotes", "value"),
+            Arguments.of("advisorAccessHash", "value"),
+            Arguments.of("advisorReviewURL", "value"),
+            Arguments.of("depositURL", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/SubmissionWorkflowStepTest.java
+++ b/src/test/java/org/tdl/vireo/model/SubmissionWorkflowStepTest.java
@@ -1,0 +1,161 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.tamu.weaver.data.model.WeaverEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.model.inheritance.HeritableComponent;
+
+public class SubmissionWorkflowStepTest extends AbstractModelCustomMethodTest<SubmissionWorkflowStep> {
+
+    @InjectMocks
+    private SubmissionWorkflowStep submissionWorkflowStep;
+
+    @Test
+    public void testReorderAggregateFieldProfile() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        FieldProfile fieldProfile1 = new FieldProfile();
+        FieldProfile fieldProfile2 = new FieldProfile();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+
+        fieldProfile1.setId(1L);
+        fieldProfile2.setId(2L);
+
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(2L);
+
+        fieldPredicate1.setValue("value1");
+        fieldPredicate2.setValue("value2");
+
+        fieldProfile1.setFieldPredicate(fieldPredicate1);
+        fieldProfile2.setFieldPredicate(fieldPredicate2);
+
+        fieldProfiles.add(fieldProfile1);
+        fieldProfiles.add(fieldProfile2);
+
+        ReflectionTestUtils.setField(getInstance(), "aggregateFieldProfiles", fieldProfiles);
+
+        // Warning: The re-order parameters use index + 1 location logic such that 1 represents index 0 and 2 represents index 1.
+        submissionWorkflowStep.reorderAggregateFieldProfile(1, 2);
+
+        assertEquals(fieldProfiles.get(0), fieldProfile2, "Did not correctly re-order Aggregate Field Profile.");
+        assertEquals(fieldProfiles.get(1), fieldProfile1, "Did not correctly re-order Aggregate Field Profile.");
+    }
+
+    @Test
+    public void testReorderAggregateNote() {
+        List<Note> notes = new ArrayList<>();
+        Note note1 = new Note();
+        Note note2 = new Note();
+
+        note1.setId(1L);
+        note2.setId(2L);
+
+        notes.add(note1);
+        notes.add(note2);
+
+        ReflectionTestUtils.setField(getInstance(), "aggregateNotes", notes);
+
+        // Warning: The re-order parameters use index + 1 location logic such that 1 represents index 0 and 2 represents index 1.
+        submissionWorkflowStep.reorderAggregateNote(1, 2);
+
+        assertEquals(notes.get(0), note2, "Did not correctly re-order Aggregate Note.");
+        assertEquals(notes.get(1), note1, "Did not correctly re-order Aggregate Note.");
+    }
+
+    @Override
+    protected SubmissionWorkflowStep getInstance() {
+        return submissionWorkflowStep;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getOverrideable", "overrideable", true),
+            Arguments.of("getOverrideable", "overrideable", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setOverrideable", "overrideable", true),
+            Arguments.of("setOverrideable", "overrideable", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        fieldProfiles.add(new FieldProfile());
+
+        List<Note> notes = new ArrayList<>();
+        notes.add(new Note());
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("aggregateFieldProfiles", fieldProfiles),
+            Arguments.of("aggregateNotes", notes),
+            Arguments.of("instructions", "instruction")
+        );
+    }
+
+    protected class OtherComponent implements HeritableComponent<Object> {
+        private Long id = 0L;
+
+        @Override
+        public int compareTo(WeaverEntity arg0) {
+            return 0;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public void setId(Long arg0) {
+            this.id = arg0;
+        }
+
+        @Override
+        public void setOriginating(Object originatingHeritableModel) {
+        }
+
+        @Override
+        public Object getOriginating() {
+            return null;
+        }
+
+        @Override
+        public void setOriginatingWorkflowStep(WorkflowStep originatingWorkflowStep) {
+        }
+
+        @Override
+        public WorkflowStep getOriginatingWorkflowStep() {
+            return null;
+        }
+
+        @Override
+        public Boolean getOverrideable() {
+            return null;
+        }
+
+        @Override
+        public Object clone() {
+            return new Object();
+        }
+    }
+}

--- a/src/test/java/org/tdl/vireo/model/UserTest.java
+++ b/src/test/java/org/tdl/vireo/model/UserTest.java
@@ -1,0 +1,239 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class UserTest extends AbstractModelTest<User> {
+
+    @InjectMocks
+    private User user;
+
+    @Test
+    public void testUserInstantiation() {
+        user.setEmail("email");
+        user.setFirstName("firstName");
+        user.setLastName("lastName");
+        user.setRole(Role.ROLE_ADMIN);
+
+        User newUser = new User(user);
+
+        assertEquals(newUser.getEmail(), user.getEmail(), "E-mail does not match.");
+        assertEquals(newUser.getFirstName(), user.getFirstName(), "First Name does not match.");
+        assertEquals(newUser.getLastName(), user.getLastName(), "Last Name does not match.");
+        assertEquals(newUser.getRole(), user.getRole(), "Role does not match.");
+    }
+
+    /**
+     * The getSettings() does not work via getParameterStream() and is manually tested here.
+     */
+    @Test
+    public void testGetSettings() {
+        Map<String, String> settings = new HashMap<>();
+
+        ReflectionTestUtils.setField(user, "settings", settings);
+
+        assertEquals(settings, user.getSettings(), GETTER_MESSAGE + "settings.");
+    }
+
+    /**
+     * The setSettings() does not work via setParameterStream() and is manually tested here.
+     */
+    @Test
+    public void testSetSettings() {
+        Map<String, String> settings = new HashMap<>();
+
+        user.setSettings(settings);
+
+        assertEquals(settings, ReflectionTestUtils.getField(getInstance(), "settings"), SETTER_MESSAGE + "settings.");
+    }
+
+    @Test
+    public void testPutSetting() {
+        Map<String, String> settings = new HashMap<>();
+        String key = "key";
+        String value = "value";
+
+        ReflectionTestUtils.setField(user, "settings", settings);
+
+        user.putSetting(key, value);
+
+        assertTrue(settings.containsKey(key), "Could not find key in the settings.");
+        assertEquals(settings.get(key), value, "The value for the key does not match the expected value.");
+    }
+
+    @Test
+    public void testRemoveShibbolethAffiliation() {
+        TreeSet<String> shibbolethAffiliations = new TreeSet<>();
+        String shibbolethAffiliation = "affiliation";
+        shibbolethAffiliations.add(shibbolethAffiliation);
+
+        ReflectionTestUtils.setField(user, "shibbolethAffiliations", shibbolethAffiliations);
+
+        user.removeShibbolethAffiliation(shibbolethAffiliation);
+
+        assertFalse(shibbolethAffiliations.contains(shibbolethAffiliation), "The Shibboleth Affiliation is not removed.");
+    }
+
+    @Test
+    public void testAddSubmissionViewColumn() {
+        List<SubmissionListColumn> submissionViewColumns = new ArrayList<>();
+        SubmissionListColumn submissionListColumn = new SubmissionListColumn();
+
+        submissionListColumn.setId(1L);
+
+        ReflectionTestUtils.setField(user, "submissionViewColumns", submissionViewColumns);
+
+        user.addSubmissionViewColumn(submissionListColumn);
+
+        assertTrue(submissionViewColumns.contains(submissionListColumn), "The Submission View Column is not added.");
+    }
+
+    @Test
+    public void testRemoveSubmissionViewColumn() {
+        List<SubmissionListColumn> submissionViewColumns = new ArrayList<>();
+        SubmissionListColumn submissionListColumn = new SubmissionListColumn();
+
+        submissionListColumn.setId(1L);
+        submissionViewColumns.add(submissionListColumn);
+
+        ReflectionTestUtils.setField(user, "submissionViewColumns", submissionViewColumns);
+
+        user.removeSubmissionViewColumn(submissionListColumn);
+
+        assertFalse(submissionViewColumns.contains(submissionListColumn), "The Submission View Column is not removed.");
+    }
+
+    @Test
+    public void testAddSavedFilter() {
+        List<NamedSearchFilterGroup> savedFilters = new ArrayList<>();
+        NamedSearchFilterGroup namedSearchFilterGroup = new NamedSearchFilterGroup();
+
+        namedSearchFilterGroup.setId(1L);
+
+        ReflectionTestUtils.setField(user, "savedFilters", savedFilters);
+
+        user.addSavedFilter(namedSearchFilterGroup);
+
+        assertTrue(savedFilters.contains(namedSearchFilterGroup), "The Saved Filter is not added.");
+    }
+
+    @Test
+    public void testRemoveSavedFilter() {
+        List<NamedSearchFilterGroup> savedFilters = new ArrayList<>();
+        NamedSearchFilterGroup namedSearchFilterGroup = new NamedSearchFilterGroup();
+
+        namedSearchFilterGroup.setId(1L);
+        savedFilters.add(namedSearchFilterGroup);
+
+        ReflectionTestUtils.setField(user, "savedFilters", savedFilters);
+
+        user.removeSavedFilter(namedSearchFilterGroup);
+
+        assertFalse(savedFilters.contains(namedSearchFilterGroup), "The Saved Filter is not removed.");
+    }
+
+    @Test
+    public void testLoadActiveFilter() {
+        NamedSearchFilterGroup activeFilter = new NamedSearchFilterGroup();
+        NamedSearchFilterGroup namedSearchFilterGroup = new NamedSearchFilterGroup();
+        List<SubmissionListColumn> savedColumns = new ArrayList<SubmissionListColumn>();
+        Set<NamedSearchFilter> namedSearchFilters = new HashSet<>();
+        SubmissionListColumn submissionListColumn = new SubmissionListColumn();
+        NamedSearchFilter namedSearchFilter = new NamedSearchFilter();
+
+        submissionListColumn.setId(1L);
+        savedColumns.add(submissionListColumn);
+
+        namedSearchFilter.setId(1L);
+        namedSearchFilters.add(namedSearchFilter);
+
+        activeFilter.setId(1L);
+        activeFilter.setPublicFlag(false);
+        activeFilter.setColumnsFlag(false);
+
+        namedSearchFilterGroup.setId(2L);
+        namedSearchFilterGroup.setSavedColumns(savedColumns);
+        namedSearchFilterGroup.setNamedSearchFilters(namedSearchFilters);
+        namedSearchFilterGroup.setPublicFlag(true);
+        namedSearchFilterGroup.setColumnsFlag(true);
+
+        ReflectionTestUtils.setField(user, "activeFilter", activeFilter);
+
+        user.loadActiveFilter(namedSearchFilterGroup);
+
+        assertEquals(activeFilter.getSavedColumns(), savedColumns, "The Saved Columns is not added.");
+        assertEquals(activeFilter.getNamedSearchFilters(), namedSearchFilters, "The Named Search Filters is not added.");
+        assertEquals(activeFilter.getPublicFlag(), namedSearchFilterGroup.getPublicFlag(), "The Public Flag is not set correctly.");
+        assertEquals(activeFilter.getColumnsFlag(), namedSearchFilterGroup.getColumnsFlag(), "The Columns Flag is not set correctly.");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testGetAuthorities() {
+        Role role = Role.ROLE_MANAGER;
+        user.setRole(role);
+
+        List<GrantedAuthority> authority = (List<GrantedAuthority>) user.getAuthorities();
+
+        assertEquals(authority.get(0).getAuthority(), role.toString(), "The expected role is not set as the authority.");
+    }
+
+    @Override
+    protected User getInstance() {
+        return user;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        Set<String> shibbolethAffiliations = new HashSet<>();
+        List<SubmissionListColumn> submissionViewColumns = new ArrayList<>();
+        List<SubmissionListColumn> filterColumns = new ArrayList<>();
+        List<NamedSearchFilterGroup> savedFilters = new ArrayList<>();
+        shibbolethAffiliations.add("value");
+
+        return Stream.of(
+            Arguments.of("netid", "value"),
+            Arguments.of("email", "value"),
+            Arguments.of("password", "value"),
+            Arguments.of("firstName", "value"),
+            Arguments.of("lastName", "value"),
+            Arguments.of("middleName", "value"),
+            Arguments.of("name", "value"),
+            Arguments.of("birthYear", 123),
+            Arguments.of("shibbolethAffiliations", shibbolethAffiliations),
+            Arguments.of("currentContactInfo", new ContactInfo()),
+            Arguments.of("permanentContactInfo", new ContactInfo()),
+            Arguments.of("role", Role.ROLE_ADMIN),
+            Arguments.of("role", Role.ROLE_ANONYMOUS),
+            Arguments.of("orcid", "value"),
+            Arguments.of("pageSize", 123),
+            Arguments.of("submissionViewColumns", submissionViewColumns),
+            Arguments.of("filterColumns", filterColumns),
+            Arguments.of("activeFilter", new NamedSearchFilterGroup()),
+            Arguments.of("savedFilters", savedFilters)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/ValidationTest.java
+++ b/src/test/java/org/tdl/vireo/model/ValidationTest.java
@@ -1,0 +1,32 @@
+package org.tdl.vireo.model;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+
+public class ValidationTest extends AbstractModelTest<Validation> {
+
+    @InjectMocks
+    private Validation validation;
+
+    @Override
+    protected Validation getInstance() {
+        return validation;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("pattern", "value"),
+            Arguments.of("message", "value")
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/VocabularyWordTest.java
+++ b/src/test/java/org/tdl/vireo/model/VocabularyWordTest.java
@@ -1,0 +1,97 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class VocabularyWordTest extends AbstractModelTest<VocabularyWord> {
+
+    @InjectMocks
+    private VocabularyWord vocabularyWord;
+
+    @Test
+    public void testVocabularyWordInstantiation1() {
+        List<String> contacts = new ArrayList<>();
+        contacts.add("contact");
+
+        vocabularyWord.setName("name");
+        vocabularyWord.setDefinition("definition");
+        vocabularyWord.setIdentifier("identifier");
+        vocabularyWord.setContacts(contacts);
+
+        VocabularyWord newVocabularyWord = new VocabularyWord(vocabularyWord.getName(), vocabularyWord.getDefinition(), vocabularyWord.getIdentifier(), vocabularyWord.getContacts());
+
+        assertEquals(newVocabularyWord.getName(), vocabularyWord.getName(), "Name does not match.");
+        assertEquals(newVocabularyWord.getDefinition(), vocabularyWord.getDefinition(), "Definition does not match.");
+        assertEquals(newVocabularyWord.getIdentifier(), vocabularyWord.getIdentifier(), "Identifier does not match.");
+        assertEquals(newVocabularyWord.getContacts(), vocabularyWord.getContacts(), "Contacts does not match.");
+    }
+
+    @Test
+    public void testVocabularyWordInstantiation2() {
+        ControlledVocabulary controlledVocabulary = new ControlledVocabulary();
+        List<String> contacts = new ArrayList<>();
+
+        controlledVocabulary.setId(1L);
+        contacts.add("contact");
+
+        vocabularyWord.setControlledVocabulary(controlledVocabulary);
+        vocabularyWord.setName("name");
+        vocabularyWord.setDefinition("definition");
+        vocabularyWord.setIdentifier("identifier");
+        vocabularyWord.setContacts(contacts);
+
+        VocabularyWord newVocabularyWord = new VocabularyWord(controlledVocabulary, vocabularyWord.getName(), vocabularyWord.getDefinition(), vocabularyWord.getIdentifier(), vocabularyWord.getContacts());
+
+        assertEquals(newVocabularyWord.getControlledVocabulary(), vocabularyWord.getControlledVocabulary(), "Controlled Vocabulary does not match.");
+        assertEquals(newVocabularyWord.getName(), vocabularyWord.getName(), "Name does not match.");
+        assertEquals(newVocabularyWord.getDefinition(), vocabularyWord.getDefinition(), "Definition does not match.");
+        assertEquals(newVocabularyWord.getIdentifier(), vocabularyWord.getIdentifier(), "Identifier does not match.");
+        assertEquals(newVocabularyWord.getContacts(), vocabularyWord.getContacts(), "Contacts does not match.");
+    }
+
+    @Test
+    public void testSetContactsPassingNull() {
+        List<String> contacts = Mockito.spy(new ArrayList<>());
+
+        ReflectionTestUtils.setField(vocabularyWord, "contacts", contacts);
+
+        vocabularyWord.setContacts(null);
+
+        Mockito.verifyNoInteractions(contacts);
+    }
+
+    @Override
+    protected VocabularyWord getInstance() {
+        return vocabularyWord;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<String> contacts = new ArrayList<>();
+        contacts.add("contact");
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("definition", "value"),
+            Arguments.of("identifier", "value"),
+            Arguments.of("contacts", contacts),
+            Arguments.of("controlledVocabulary", new ControlledVocabulary())
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/WorkflowStepTest.java
+++ b/src/test/java/org/tdl/vireo/model/WorkflowStepTest.java
@@ -1,0 +1,502 @@
+package org.tdl.vireo.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.tamu.weaver.data.model.WeaverEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.model.inheritance.HeritableComponent;
+
+public class WorkflowStepTest extends AbstractModelCustomMethodTest<WorkflowStep> {
+
+    @InjectMocks
+    private WorkflowStep workflowStep;
+
+    @Test
+    public void testReplaceOriginalFieldProfileOnFound() {
+        List<FieldProfile> originalFPs = new ArrayList<>();
+        FieldProfile originalFP1 = new FieldProfile();
+        FieldProfile originalFP2 = new FieldProfile();
+        FieldProfile newFP = new FieldProfile();
+
+        originalFP1.setId(1L);
+        originalFP2.setId(2L);
+        newFP.setId(3L);
+
+        originalFPs.add(originalFP1);
+        originalFPs.add(originalFP2);
+
+        workflowStep.setOriginalFieldProfiles(originalFPs);
+        workflowStep.setAggregateFieldProfiles(originalFPs);
+
+        Boolean found = workflowStep.replaceOriginalFieldProfile(originalFP2, newFP);
+
+        assertTrue(found, "The Field Profile did not get replaced.");
+
+        assertTrue(workflowStep.getOriginalFieldProfiles().contains(newFP), "The new Field Profile is not found.");
+        assertFalse(workflowStep.getOriginalFieldProfiles().contains(originalFP2), "The old Field Profile is found.");
+
+        assertTrue(workflowStep.getAggregateFieldProfiles().contains(newFP), "The new Field Profile is not found in the Aggregate Field Profiles.");
+        assertFalse(workflowStep.getAggregateFieldProfiles().contains(originalFP2), "The old Field Profile is found in the Aggregate Field Profiles.");
+    }
+
+    @Test
+    public void testReplaceOriginalFieldProfileOnNotFound() {
+        List<FieldProfile> originalFPs = new ArrayList<>();
+        FieldProfile originalFP1 = new FieldProfile();
+        FieldProfile originalFP2 = new FieldProfile();
+        FieldProfile newFP = new FieldProfile();
+        FieldProfile otherFP = new FieldProfile();
+
+        originalFP1.setId(1L);
+        originalFP2.setId(2L);
+        newFP.setId(3L);
+        otherFP.setId(4L);
+
+        originalFPs.add(originalFP1);
+        originalFPs.add(originalFP2);
+
+        workflowStep.setOriginalFieldProfiles(originalFPs);
+        workflowStep.setAggregateFieldProfiles(originalFPs);
+
+        Boolean found = workflowStep.replaceOriginalFieldProfile(otherFP, newFP);
+
+        assertFalse(found, "The Field Profile did get replaced.");
+
+        assertFalse(workflowStep.getOriginalFieldProfiles().contains(newFP), "The new Field Profile is found.");
+        assertFalse(workflowStep.getOriginalFieldProfiles().contains(otherFP), "The old Field Profile is found.");
+
+        assertFalse(workflowStep.getAggregateFieldProfiles().contains(newFP), "The new Field Profile is found in the Aggregate Field Profiles.");
+        assertFalse(workflowStep.getAggregateFieldProfiles().contains(otherFP), "The old Field Profile is found in the Aggregate Field Profiles.");
+    }
+
+    @Test
+    public void testGetFieldProfileByPredicateOnFound() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        FieldProfile fieldProfile1 = new FieldProfile();
+        FieldProfile fieldProfile2 = new FieldProfile();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+
+        fieldProfile1.setId(1L);
+        fieldProfile2.setId(2L);
+
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(2L);
+
+        fieldPredicate1.setValue("value1");
+        fieldPredicate2.setValue("value2");
+
+        fieldProfile1.setFieldPredicate(fieldPredicate1);
+        fieldProfile2.setFieldPredicate(fieldPredicate2);
+
+        fieldProfiles.add(fieldProfile1);
+        fieldProfiles.add(fieldProfile2);
+
+        workflowStep.setOriginalFieldProfiles(fieldProfiles);
+        workflowStep.setAggregateFieldProfiles(fieldProfiles);
+
+        FieldProfile got = workflowStep.getFieldProfileByPredicate(fieldPredicate2);
+
+        assertEquals(got, fieldProfile2, "Did not correctly find Field Profile.");
+    }
+
+    @Test
+    public void testGetFieldProfileByPredicateOnNotFound() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        FieldProfile fieldProfile1 = new FieldProfile();
+        FieldProfile fieldProfile2 = new FieldProfile();
+        FieldProfile fieldProfile3 = new FieldProfile();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+        FieldPredicate fieldPredicate3 = new FieldPredicate();
+
+        fieldProfile1.setId(1L);
+        fieldProfile2.setId(2L);
+        fieldProfile3.setId(3L);
+
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(2L);
+        fieldPredicate3.setId(3L);
+
+        fieldPredicate1.setValue("value1");
+        fieldPredicate2.setValue("value2");
+        fieldPredicate3.setValue("value3");
+
+        fieldProfile1.setFieldPredicate(fieldPredicate1);
+        fieldProfile2.setFieldPredicate(fieldPredicate2);
+        fieldProfile3.setFieldPredicate(fieldPredicate3);
+
+        fieldProfiles.add(fieldProfile1);
+        fieldProfiles.add(fieldProfile2);
+
+        workflowStep.setOriginalFieldProfiles(fieldProfiles);
+        workflowStep.setAggregateFieldProfiles(fieldProfiles);
+
+        FieldProfile got = workflowStep.getFieldProfileByPredicate(fieldPredicate3);
+
+        assertNull(got, "Must not find Field Profile.");
+    }
+
+    @Test
+    public void testReplaceOriginalNoteOnFound() {
+        List<Note> originalNotes = new ArrayList<>();
+        Note originalNote1 = new Note();
+        Note originalNote2 = new Note();
+        Note newNote = new Note();
+
+        originalNote1.setId(1L);
+        originalNote2.setId(2L);
+        newNote.setId(3L);
+
+        originalNotes.add(originalNote1);
+        originalNotes.add(originalNote2);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(originalNotes);
+
+        Boolean found = workflowStep.replaceOriginalNote(originalNote2, newNote);
+
+        assertTrue(found, "The Field Profile did not get replaced.");
+
+        assertTrue(workflowStep.getOriginalNotes().contains(newNote), "The new Note is not found.");
+        assertFalse(workflowStep.getOriginalNotes().contains(originalNote2), "The old Note is found.");
+
+        assertTrue(workflowStep.getAggregateNotes().contains(newNote), "The new Note is not found in the Aggregate Notes.");
+        assertFalse(workflowStep.getAggregateNotes().contains(originalNote2), "The old Note is found in the Aggregate Notes.");
+    }
+
+    @Test
+    public void testReplaceOriginalNoteOnNotFound() {
+        List<Note> originalNotes = new ArrayList<>();
+        Note originalNote1 = new Note();
+        Note originalNote2 = new Note();
+        Note newNote = new Note();
+        Note otherNote = new Note();
+
+        originalNote1.setId(1L);
+        originalNote2.setId(2L);
+        newNote.setId(3L);
+        otherNote.setId(4L);
+
+        originalNotes.add(originalNote1);
+        originalNotes.add(originalNote2);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(originalNotes);
+
+        Boolean found = workflowStep.replaceOriginalNote(otherNote, newNote);
+
+        assertFalse(found, "The Note did get replaced.");
+
+        assertFalse(workflowStep.getOriginalNotes().contains(newNote), "The new Note is found.");
+        assertFalse(workflowStep.getOriginalNotes().contains(otherNote), "The old Note is found.");
+
+        assertFalse(workflowStep.getAggregateNotes().contains(newNote), "The new Note is found in the Aggregate Notes.");
+        assertFalse(workflowStep.getAggregateNotes().contains(otherNote), "The old Note is found in the Aggregate Notes.");
+    }
+
+    @Test
+    public void testAddOriginalHeritableModelUsingNote() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        Note newNote = new Note();
+
+        newNote.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addOriginalHeritableModel(newNote);
+
+        assertTrue(workflowStep.getOriginalNotes().contains(newNote), "The new Note is not found.");
+        assertEquals(workflowStep.getOriginalFieldProfiles().size(), 0, "The Original Field Profiles have a non-zero length.");
+
+        assertTrue(workflowStep.getAggregateNotes().contains(newNote), "The new Note is not found in the Aggregate Notes.");
+        assertEquals(workflowStep.getAggregateFieldProfiles().size(), 0, "The Aggregate Field Profiles have a non-zero length.");
+    }
+
+    @Test
+    public void testAddOriginalHeritableModelUsingFieldProfile() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        FieldProfile newFieldProfile = new FieldProfile();
+
+        newFieldProfile.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addOriginalHeritableModel(newFieldProfile);
+
+        assertTrue(workflowStep.getOriginalFieldProfiles().contains(newFieldProfile), "The new Note is not found.");
+        assertEquals(workflowStep.getOriginalNotes().size(), 0, "The Original Notes have a non-zero length.");
+
+        assertTrue(workflowStep.getAggregateFieldProfiles().contains(newFieldProfile), "The new Note is not found in the Aggregate Notes.");
+        assertEquals(workflowStep.getAggregateNotes().size(), 0, "The Aggregate Notes have a non-zero length.");
+    }
+
+    @Test
+    public void testAddOriginalHeritableModelUsingOther() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        OtherComponent newComponent = new OtherComponent();
+
+        newComponent.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addOriginalHeritableModel(newComponent);
+
+        assertEquals(workflowStep.getOriginalFieldProfiles().size(), 0, "The Original Field Profiles have a non-zero length.");
+        assertEquals(workflowStep.getOriginalNotes().size(), 0, "The Original Notes have a non-zero length.");
+
+        assertEquals(workflowStep.getAggregateFieldProfiles().size(), 0, "The Aggregate Field Profiles have a non-zero length.");
+        assertEquals(workflowStep.getAggregateNotes().size(), 0, "The Aggregate Notes have a non-zero length.");
+    }
+
+    @Test
+    public void testAddAggregateHeritableModelUsingNote() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        Note newNote = new Note();
+
+        newNote.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addAggregateHeritableModel(newNote);
+
+        assertEquals(workflowStep.getOriginalNotes().size(), 0, "The Original Notes have a non-zero length.");
+        assertEquals(workflowStep.getOriginalFieldProfiles().size(), 0, "The Original Field Profiles have a non-zero length.");
+
+        assertTrue(workflowStep.getAggregateNotes().contains(newNote), "The new Note is not found in the Aggregate Notes.");
+        assertEquals(workflowStep.getAggregateFieldProfiles().size(), 0, "The Aggregate Field Profiles have a non-zero length.");
+    }
+
+    @Test
+    public void testAddAggregateHeritableModelUsingFieldProfile() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        FieldProfile newFieldProfile = new FieldProfile();
+
+        newFieldProfile.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addAggregateHeritableModel(newFieldProfile);
+
+        assertEquals(workflowStep.getOriginalFieldProfiles().size(), 0, "The Original Field Profiles have a non-zero length.");
+        assertEquals(workflowStep.getOriginalNotes().size(), 0, "The Original Notes have a non-zero length.");
+
+        assertTrue(workflowStep.getAggregateFieldProfiles().contains(newFieldProfile), "The new Note is not found in the Aggregate Notes.");
+        assertEquals(workflowStep.getAggregateNotes().size(), 0, "The Aggregate Notes have a non-zero length.");
+    }
+
+    @Test
+    public void testAddAggregateHeritableModelUsingOther() {
+        List<Note> originalNotes = new ArrayList<>();
+        List<Note> aggregateNotes = new ArrayList<>();
+        List<FieldProfile> originalFieldProfiles = new ArrayList<>();
+        List<FieldProfile> aggregateFieldProfiles = new ArrayList<>();
+        OtherComponent newComponent = new OtherComponent();
+
+        newComponent.setId(1L);
+
+        workflowStep.setOriginalNotes(originalNotes);
+        workflowStep.setAggregateNotes(aggregateNotes);
+
+        workflowStep.setOriginalFieldProfiles(originalFieldProfiles);
+        workflowStep.setAggregateFieldProfiles(aggregateFieldProfiles);
+
+        workflowStep.addAggregateHeritableModel(newComponent);
+
+        assertEquals(workflowStep.getOriginalFieldProfiles().size(), 0, "The Original Field Profiles have a non-zero length.");
+        assertEquals(workflowStep.getOriginalNotes().size(), 0, "The Original Notes have a non-zero length.");
+
+        assertEquals(workflowStep.getAggregateFieldProfiles().size(), 0, "The Aggregate Field Profiles have a non-zero length.");
+        assertEquals(workflowStep.getAggregateNotes().size(), 0, "The Aggregate Notes have a non-zero length.");
+    }
+
+    @Test
+    public void testReorderAggregateFieldProfile() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        FieldProfile fieldProfile1 = new FieldProfile();
+        FieldProfile fieldProfile2 = new FieldProfile();
+        FieldPredicate fieldPredicate1 = new FieldPredicate();
+        FieldPredicate fieldPredicate2 = new FieldPredicate();
+
+        fieldProfile1.setId(1L);
+        fieldProfile2.setId(2L);
+
+        fieldPredicate1.setId(1L);
+        fieldPredicate2.setId(2L);
+
+        fieldPredicate1.setValue("value1");
+        fieldPredicate2.setValue("value2");
+
+        fieldProfile1.setFieldPredicate(fieldPredicate1);
+        fieldProfile2.setFieldPredicate(fieldPredicate2);
+
+        fieldProfiles.add(fieldProfile1);
+        fieldProfiles.add(fieldProfile2);
+
+        ReflectionTestUtils.setField(getInstance(), "aggregateFieldProfiles", fieldProfiles);
+
+        // Warning: The re-order parameters use index + 1 location logic such that 1 represents index 0 and 2 represents index 1.
+        workflowStep.reorderAggregateFieldProfile(1, 2);
+
+        assertEquals(fieldProfiles.get(0), fieldProfile2, "Did not correctly re-order Aggregate Field Profile.");
+        assertEquals(fieldProfiles.get(1), fieldProfile1, "Did not correctly re-order Aggregate Field Profile.");
+    }
+
+    @Test
+    public void testReorderAggregateNote() {
+        List<Note> notes = new ArrayList<>();
+        Note note1 = new Note();
+        Note note2 = new Note();
+
+        note1.setId(1L);
+        note2.setId(2L);
+
+        notes.add(note1);
+        notes.add(note2);
+
+        ReflectionTestUtils.setField(getInstance(), "aggregateNotes", notes);
+
+        // Warning: The re-order parameters use index + 1 location logic such that 1 represents index 0 and 2 represents index 1.
+        workflowStep.reorderAggregateNote(1, 2);
+
+        assertEquals(notes.get(0), note2, "Did not correctly re-order Aggregate Note.");
+        assertEquals(notes.get(1), note1, "Did not correctly re-order Aggregate Note.");
+    }
+
+    @Override
+    protected WorkflowStep getInstance() {
+        return workflowStep;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideGetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("getOverrideable", "overrideable", true),
+            Arguments.of("getOverrideable", "overrideable", false)
+        );
+    }
+
+    protected static Stream<Arguments> provideSetterMethodParameters() {
+        return Stream.of(
+            Arguments.of("setOverrideable", "overrideable", true),
+            Arguments.of("setOverrideable", "overrideable", false)
+        );
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<FieldProfile> fieldProfiles = new ArrayList<>();
+        fieldProfiles.add(new FieldProfile());
+
+        List<Note> notes = new ArrayList<>();
+        notes.add(new Note());
+
+        return Stream.of(
+            Arguments.of("name", "value"),
+            Arguments.of("aggregateFieldProfiles", fieldProfiles),
+            Arguments.of("aggregateNotes", notes),
+            Arguments.of("instructions", "instruction"),
+            Arguments.of("originatingOrganization", new Organization()),
+            Arguments.of("originatingWorkflowStep", new WorkflowStep()),
+            Arguments.of("originalFieldProfiles", fieldProfiles),
+            Arguments.of("originalNotes", notes)
+        );
+    }
+
+    protected class OtherComponent implements HeritableComponent<Object> {
+        private Long id = 0L;
+
+        @Override
+        public int compareTo(WeaverEntity arg0) {
+            return 0;
+        }
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        @Override
+        public void setId(Long arg0) {
+            this.id = arg0;
+        }
+
+        @Override
+        public void setOriginating(Object originatingHeritableModel) {
+        }
+
+        @Override
+        public Object getOriginating() {
+            return null;
+        }
+
+        @Override
+        public void setOriginatingWorkflowStep(WorkflowStep originatingWorkflowStep) {
+        }
+
+        @Override
+        public WorkflowStep getOriginatingWorkflowStep() {
+            return null;
+        }
+
+        @Override
+        public Boolean getOverrideable() {
+            return null;
+        }
+
+        @Override
+        public Object clone() {
+            return new Object();
+        }
+    }
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/DSpaceMetsKeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/DSpaceMetsKeyTest.java
@@ -1,0 +1,28 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class DSpaceMetsKeyTest extends AbstractEnumTest<DSpaceMETSKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(DSpaceMETSKey.AGENT, "AGENT", 0),
+            Arguments.of(DSpaceMETSKey.STUDENT_SHORT_NAME, "STUDENT_SHORT_NAME", 1),
+            Arguments.of(DSpaceMETSKey.STUDENT_FULL_NAME_WITH_BIRTH_YEAR, "STUDENT_FULL_NAME_WITH_BIRTH_YEAR", 2),
+            Arguments.of(DSpaceMETSKey.SUBMISSION_TYPE, "SUBMISSION_TYPE", 3),
+            Arguments.of(DSpaceMETSKey.DEPOSIT_URL, "DEPOSIT_URL", 4),
+            Arguments.of(DSpaceMETSKey.PRIMARY_DOCUMENT_MIMETYPE, "PRIMARY_DOCUMENT_MIMETYPE", 5),
+            Arguments.of(DSpaceMETSKey.PRIMARY_DOCUMENT_FIELD_VALUE, "PRIMARY_DOCUMENT_FIELD_VALUE", 6),
+            Arguments.of(DSpaceMETSKey.SUPPLEMENTAL_AND_SOURCE_DOCUMENT_FIELD_VALUES, "SUPPLEMENTAL_AND_SOURCE_DOCUMENT_FIELD_VALUES", 7),
+            Arguments.of(DSpaceMETSKey.LICENSE_DOCUMENT_FIELD_VALUES, "LICENSE_DOCUMENT_FIELD_VALUES", 8),
+            Arguments.of(DSpaceMETSKey.METS_FIELD_VALUES, "METS_FIELD_VALUES", 9),
+            Arguments.of(DSpaceMETSKey.GRADUATION_MONTH_YEAR, "GRADUATION_MONTH_YEAR", 10),
+            Arguments.of(DSpaceMETSKey.GRADUATION_YEAR_MONTH, "GRADUATION_YEAR_MONTH", 11),
+            Arguments.of(DSpaceMETSKey.GRANTOR, "GRANTOR", 12),
+            Arguments.of(DSpaceMETSKey.EMBARGO_LIFT_DATE, "EMBARGO_LIFT_DATE", 13)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/DSpaceSimpleKeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/DSpaceSimpleKeyTest.java
@@ -1,0 +1,38 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class DSpaceSimpleKeyTest extends AbstractEnumTest<DSpaceSimpleKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(DSpaceSimpleKey.STUDENT_FULL_NAME_WITH_BIRTH_YEAR, "STUDENT_FULL_NAME_WITH_BIRTH_YEAR", 0),
+            Arguments.of(DSpaceSimpleKey.USER_ORCID, "USER_ORCID", 1),
+            Arguments.of(DSpaceSimpleKey.TITLE, "TITLE", 2),
+            Arguments.of(DSpaceSimpleKey.ABSTRACT, "ABSTRACT", 3),
+            Arguments.of(DSpaceSimpleKey.ABSTRACT_LINES, "ABSTRACT_LINES", 4),
+            Arguments.of(DSpaceSimpleKey.SUBJECT_FIELD_VALUES, "SUBJECT_FIELD_VALUES", 5),
+            Arguments.of(DSpaceSimpleKey.COMMITTEE_CHAIR_FIELD_VALUES, "COMMITTEE_CHAIR_FIELD_VALUES", 6),
+            Arguments.of(DSpaceSimpleKey.COMMITTEE_MEMBER_FIELD_VALUES, "COMMITTEE_MEMBER_FIELD_VALUES", 7),
+            Arguments.of(DSpaceSimpleKey.GRADUATION_DATE_YEAR_MONTH_STRING, "GRADUATION_DATE_YEAR_MONTH_STRING", 8),
+            Arguments.of(DSpaceSimpleKey.GRADUATION_DATE_MONTH_YEAR_STRING, "GRADUATION_DATE_MONTH_YEAR_STRING", 9),
+            Arguments.of(DSpaceSimpleKey.APPROVAL_DATE_STRING, "APPROVAL_DATE_STRING", 10),
+            Arguments.of(DSpaceSimpleKey.PRIMARY_DOCUMENT_MIMETYPE, "PRIMARY_DOCUMENT_MIMETYPE", 11),
+            Arguments.of(DSpaceSimpleKey.PROQUEST_LANGUAGE_CODE, "PROQUEST_LANGUAGE_CODE", 12),
+            Arguments.of(DSpaceSimpleKey.SUBMISSION_TYPE, "SUBMISSION_TYPE", 13),
+            Arguments.of(DSpaceSimpleKey.DEPOSIT_URL, "DEPOSIT_URL", 14),
+            Arguments.of(DSpaceSimpleKey.STUDENT_SHORT_NAME, "STUDENT_SHORT_NAME", 15),
+            Arguments.of(DSpaceSimpleKey.DEGREE_NAME, "DEGREE_NAME", 16),
+            Arguments.of(DSpaceSimpleKey.DEGREE_LEVEL, "DEGREE_LEVEL", 17),
+            Arguments.of(DSpaceSimpleKey.DEGREE_MAJOR, "DEGREE_MAJOR", 18),
+            Arguments.of(DSpaceSimpleKey.DEPARTMENT, "DEPARTMENT", 19),
+            Arguments.of(DSpaceSimpleKey.DEGREE_COLLEGE, "DEGREE_COLLEGE", 20),
+            Arguments.of(DSpaceSimpleKey.DEGREE_SCHOOL, "DEGREE_SCHOOL", 21),
+            Arguments.of(DSpaceSimpleKey.DEGREE_PROGRAM, "DEGREE_PROGRAM", 22),
+            Arguments.of(DSpaceSimpleKey.FORMATTED_COMMITTEE_APPROVED_EMBARGO_LIFT_DATE, "FORMATTED_COMMITTEE_APPROVED_EMBARGO_LIFT_DATE", 23)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/DefaultSettingTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/DefaultSettingTest.java
@@ -1,0 +1,24 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class DefaultSettingTest extends AbstractEnumTest<DefaultSettingKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(DefaultSettingKey.APPLICATION_GRANTOR, "APPLICATION_GRANTOR", 0),
+            Arguments.of(DefaultSettingKey.EXPORT_RELEASE_STUDENT_CONTACT_INFORMATION, "EXPORT_RELEASE_STUDENT_CONTACT_INFORMATION", 1),
+            Arguments.of(DefaultSettingKey.PROQUEST_INDEXING, "PROQUEST_INDEXING", 2),
+            Arguments.of(DefaultSettingKey.PROQUEST_EXTERNAL_ID, "PROQUEST_EXTERNAL_ID", 3),
+            Arguments.of(DefaultSettingKey.PROQUEST_INSTITUTION_CODE, "PROQUEST_INSTITUTION_CODE", 4),
+            Arguments.of(DefaultSettingKey.PROQUEST_APPLY_FOR_COPYRIGHT, "PROQUEST_APPLY_FOR_COPYRIGHT", 5),
+            Arguments.of(DefaultSettingKey.PROQUEST_SALE_RESTRICTION_CODE, "PROQUEST_SALE_RESTRICTION_CODE", 6),
+            Arguments.of(DefaultSettingKey.PROQUEST_SALE_RESTRICTION_REMOVE, "PROQUEST_SALE_RESTRICTION_REMOVE", 7),
+            Arguments.of(DefaultSettingKey.PROQUEST_FORMAT_RESTRICTION_CODE, "PROQUEST_FORMAT_RESTRICTION_CODE", 8),
+            Arguments.of(DefaultSettingKey.PROQUEST_FORMAT_RESTRICTION_REMOVE, "PROQUEST_FORMAT_RESTRICTION_REMOVE", 9)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/GeneralKeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/GeneralKeyTest.java
@@ -1,0 +1,18 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class GeneralKeyTest extends AbstractEnumTest<GeneralKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(GeneralKey.TIME, "TIME", 0),
+            Arguments.of(GeneralKey.FILE_HELPER, "FILE_HELPER", 1),
+            Arguments.of(GeneralKey.SUBMISSION_HELPER, "SUBMISSION_HELPER", 2),
+            Arguments.of(GeneralKey.SUBMISSION, "SUBMISSION", 3)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/MarcXML21KeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/MarcXML21KeyTest.java
@@ -1,0 +1,28 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class MarcXML21KeyTest extends AbstractEnumTest<MarcXML21Key> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(MarcXML21Key.SUBMITTER_GRADUATION_YEAR, "SUBMITTER_GRADUATION_YEAR", 0),
+            Arguments.of(MarcXML21Key.STUDENT_FULL_NAME_WITH_BIRTH_YEAR, "STUDENT_FULL_NAME_WITH_BIRTH_YEAR", 1),
+            Arguments.of(MarcXML21Key.TITLE, "TITLE", 2),
+            Arguments.of(MarcXML21Key.TITLE_IND2, "TITLE_IND2", 3),
+            Arguments.of(MarcXML21Key.DEGREE_LEVEL, "DEGREE_LEVEL", 4),
+            Arguments.of(MarcXML21Key.DEGREE_NAME, "DEGREE_NAME", 5),
+            Arguments.of(MarcXML21Key.MAJOR, "MAJOR", 6),
+            Arguments.of(MarcXML21Key.DEPOSIT_URL, "DEPOSIT_URL", 7),
+            Arguments.of(MarcXML21Key.ABSTRACT, "ABSTRACT", 8),
+            Arguments.of(MarcXML21Key.KEYWORD_FIELD_VALUES, "KEYWORD_FIELD_VALUES", 9),
+            Arguments.of(MarcXML21Key.DEPARTMENT, "DEPARTMENT", 10),
+            Arguments.of(MarcXML21Key.COMMITTEE_CHAIR_FIELD_VALUES, "COMMITTEE_CHAIR_FIELD_VALUES", 11),
+            Arguments.of(MarcXML21Key.COMMITTEE_MEMBER_FIELD_VALUES, "COMMITTEE_MEMBER_FIELD_VALUES", 12),
+            Arguments.of(MarcXML21Key.PRIMARY_DOCUMENT_MIMETYPE, "PRIMARY_DOCUMENT_MIMETYPE", 13)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/ProQuestUMIKeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/ProQuestUMIKeyTest.java
@@ -1,0 +1,45 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class ProQuestUMIKeyTest extends AbstractEnumTest<ProQuestUMIKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(ProQuestUMIKey.AGENT, "AGENT", 0),
+            Arguments.of(ProQuestUMIKey.EMBARGO_CODE, "EMBARGO_CODE", 1),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_LAST_NAME, "SUBMITTER_LAST_NAME", 2),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_FIRST_NAME, "SUBMITTER_FIRST_NAME", 3),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_MIDDLE_NAME, "SUBMITTER_MIDDLE_NAME", 4),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_CURRENT_PHONE_NUMBER, "SUBMITTER_CURRENT_PHONE_NUMBER", 5),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_CURRENT_ADDRESS, "SUBMITTER_CURRENT_ADDRESS", 6),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_EMAIL, "SUBMITTER_EMAIL", 7),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_GRADUATION_DATE, "SUBMITTER_GRADUATION_DATE", 8),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_GRADUATION_YEAR, "SUBMITTER_GRADUATION_YEAR", 9),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_PERMANENT_PHONE_NUMBER, "SUBMITTER_PERMANENT_PHONE_NUMBER", 10),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_PERMANENT_ADDRESS, "SUBMITTER_PERMANENT_ADDRESS", 11),
+            Arguments.of(ProQuestUMIKey.SUBMITTER_PERMANENT_EMAIL, "SUBMITTER_PERMANENT_EMAIL", 12),
+            Arguments.of(ProQuestUMIKey.PROQUEST_DEGREE_CODE, "PROQUEST_DEGREE_CODE", 13),
+            Arguments.of(ProQuestUMIKey.PROQUEST_LANGUAGE_CODE, "PROQUEST_LANGUAGE_CODE", 14),
+            Arguments.of(ProQuestUMIKey.DEGREE_LEVEL, "DEGREE_LEVEL", 15),
+            Arguments.of(ProQuestUMIKey.DEPARTMENT, "DEPARTMENT", 16),
+            Arguments.of(ProQuestUMIKey.TITLE, "TITLE", 17),
+            Arguments.of(ProQuestUMIKey.COMMITTEE_CHAIR_FIELD_VALUES, "COMMITTEE_CHAIR_FIELD_VALUES", 18),
+            Arguments.of(ProQuestUMIKey.COMMITTEE_MEMBER_FIELD_VALUES, "COMMITTEE_MEMBER_FIELD_VALUES", 19),
+            Arguments.of(ProQuestUMIKey.SUBJECT_FIELD_VALUES, "SUBJECT_FIELD_VALUES", 20),
+            Arguments.of(ProQuestUMIKey.KEYWORD_FIELD_VALUES, "KEYWORD_FIELD_VALUES", 21),
+            Arguments.of(ProQuestUMIKey.ABSTRACT, "ABSTRACT", 22),
+            Arguments.of(ProQuestUMIKey.ABSTRACT_LINES, "ABSTRACT_LINES", 23),
+            Arguments.of(ProQuestUMIKey.PRIMARY_DOCUMENT_MIMETYPE, "PRIMARY_DOCUMENT_MIMETYPE", 24),
+            Arguments.of(ProQuestUMIKey.PRIMARY_DOCUMENT_FIELD_VALUE, "PRIMARY_DOCUMENT_FIELD_VALUE", 25),
+            Arguments.of(ProQuestUMIKey.SUPPLEMENTAL_DOCUMENT_FIELD_VALUES, "SUPPLEMENTAL_DOCUMENT_FIELD_VALUES", 26),
+            Arguments.of(ProQuestUMIKey.PROQUEST_PERSON_FILENAME, "PROQUEST_PERSON_FILENAME", 27),
+            Arguments.of(ProQuestUMIKey.DEGREE_LEVEL_STR, "DEGREE_LEVEL_STR", 28),
+            Arguments.of(ProQuestUMIKey.DEGREE_CODE_STR, "DEGREE_CODE_STR", 29),
+            Arguments.of(ProQuestUMIKey.DEGREE_LEVEL_PQ_PROCCODE, "DEGREE_LEVEL_PQ_PROCCODE", 30)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/export/enums/SubmissionPropertyKeyTest.java
+++ b/src/test/java/org/tdl/vireo/model/export/enums/SubmissionPropertyKeyTest.java
@@ -1,0 +1,27 @@
+package org.tdl.vireo.model.export.enums;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.tdl.vireo.model.AbstractEnumTest;
+
+public class SubmissionPropertyKeyTest extends AbstractEnumTest<SubmissionPropertyKey> {
+
+    protected static Stream<Arguments> provideEnumParameters() {
+        return Stream.of(
+            Arguments.of(SubmissionPropertyKey.SUBMISSION_ID, "SUBMISSION_ID", 0),
+            Arguments.of(SubmissionPropertyKey.FIELD_VALUES, "FIELD_VALUES", 1),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_APPLICATION_APPROVAL_DATE, "FORMATTED_APPLICATION_APPROVAL_DATE", 2),
+            Arguments.of(SubmissionPropertyKey.LICENSE_AGREEMENT_DATE, "LICENSE_AGREEMENT_DATE", 3),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_LICENSE_AGREEMENT_DATE, "FORMATTED_LICENSE_AGREEMENT_DATE", 4),
+            Arguments.of(SubmissionPropertyKey.SUBMISSION_DATE, "SUBMISSION_DATE", 5),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_SUBMISSION_DATE, "FORMATTED_SUBMISSION_DATE", 6),
+            Arguments.of(SubmissionPropertyKey.COMMITTEE_APPROVAL_DATE, "COMMITTEE_APPROVAL_DATE", 7),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_COMMITTEE_APPROVAL_DATE, "FORMATTED_COMMITTEE_APPROVAL_DATE", 8),
+            Arguments.of(SubmissionPropertyKey.COMMITTEE_EMBARGO_APPROVAL_DATE, "COMMITTEE_EMBARGO_APPROVAL_DATE", 9),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_COMMITTEE_EMBARGO_APPROVAL_DATE, "FORMATTED_COMMITTEE_EMBARGO_APPROVAL_DATE", 10),
+            Arguments.of(SubmissionPropertyKey.APPROVAL_DATE, "APPROVAL_DATE", 11),
+            Arguments.of(SubmissionPropertyKey.FORMATTED_APPROVAL_DATE, "FORMATTED_APPROVAL_DATE", 12)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/repo/AbstractRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/AbstractRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import edu.tamu.weaver.auth.model.Credentials;
 import java.util.Calendar;
@@ -10,48 +10,37 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.Application;
 import org.tdl.vireo.config.constant.ConfigurationName;
+import org.tdl.vireo.model.ActionLog;
+import org.tdl.vireo.model.Address;
+import org.tdl.vireo.model.ControlledVocabulary;
+import org.tdl.vireo.model.CustomActionDefinition;
+import org.tdl.vireo.model.CustomActionValue;
+import org.tdl.vireo.model.DegreeLevel;
+import org.tdl.vireo.model.EmailRecipient;
+import org.tdl.vireo.model.EmailTemplate;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.Embargo;
+import org.tdl.vireo.model.EmbargoGuarantor;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.FieldValue;
+import org.tdl.vireo.model.InputType;
+import org.tdl.vireo.model.Language;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.Role;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.SubmissionStatus;
+import org.tdl.vireo.model.SubmissionWorkflowStep;
+import org.tdl.vireo.model.User;
+import org.tdl.vireo.model.VocabularyWord;
+import org.tdl.vireo.model.WorkflowStep;
 import org.tdl.vireo.model.packager.Packager;
-import org.tdl.vireo.model.repo.AbstractEmailRecipientRepo;
-import org.tdl.vireo.model.repo.AbstractPackagerRepo;
-import org.tdl.vireo.model.repo.ActionLogRepo;
-import org.tdl.vireo.model.repo.AddressRepo;
-import org.tdl.vireo.model.repo.ConfigurationRepo;
-import org.tdl.vireo.model.repo.ContactInfoRepo;
-import org.tdl.vireo.model.repo.ControlledVocabularyRepo;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
-import org.tdl.vireo.model.repo.CustomActionValueRepo;
-import org.tdl.vireo.model.repo.DegreeLevelRepo;
-import org.tdl.vireo.model.repo.DegreeRepo;
-import org.tdl.vireo.model.repo.DepositLocationRepo;
-import org.tdl.vireo.model.repo.DocumentTypeRepo;
-import org.tdl.vireo.model.repo.EmailTemplateRepo;
-import org.tdl.vireo.model.repo.EmailWorkflowRuleRepo;
-import org.tdl.vireo.model.repo.EmbargoRepo;
-import org.tdl.vireo.model.repo.FieldPredicateRepo;
-import org.tdl.vireo.model.repo.FieldProfileRepo;
-import org.tdl.vireo.model.repo.FieldValueRepo;
-import org.tdl.vireo.model.repo.FilterCriterionRepo;
-import org.tdl.vireo.model.repo.GraduationMonthRepo;
-import org.tdl.vireo.model.repo.InputTypeRepo;
-import org.tdl.vireo.model.repo.LanguageRepo;
-import org.tdl.vireo.model.repo.NamedSearchFilterGroupRepo;
-import org.tdl.vireo.model.repo.NamedSearchFilterRepo;
-import org.tdl.vireo.model.repo.NoteRepo;
-import org.tdl.vireo.model.repo.OrganizationCategoryRepo;
-import org.tdl.vireo.model.repo.OrganizationRepo;
-import org.tdl.vireo.model.repo.SubmissionFieldProfileRepo;
-import org.tdl.vireo.model.repo.SubmissionListColumnRepo;
-import org.tdl.vireo.model.repo.SubmissionRepo;
-import org.tdl.vireo.model.repo.SubmissionStatusRepo;
-import org.tdl.vireo.model.repo.SubmissionWorkflowStepRepo;
-import org.tdl.vireo.model.repo.UserRepo;
-import org.tdl.vireo.model.repo.VocabularyWordRepo;
-import org.tdl.vireo.model.repo.WorkflowStepRepo;
 import org.tdl.vireo.service.EntityControlledVocabularyService;
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = { Application.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public abstract class AbstractEntityTest {
+public abstract class AbstractRepoTest {
 
     protected static final boolean TEST_SUBMISSION_STATUS_ARCHIVED = true;
     protected static final boolean TEST_SUBMISSION_STATUS_PUBLISHABLE = true;

--- a/src/test/java/org/tdl/vireo/model/repo/ActionLogRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/ActionLogRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -8,10 +8,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
+import org.tdl.vireo.model.ActionLog;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class ActionLogTest extends AbstractEntityTest {
+public class ActionLogRepoTest extends AbstractRepoTest {
 
     @Autowired
     private CustomActionDefinitionRepo customActionDefinitionRepo;

--- a/src/test/java/org/tdl/vireo/model/repo/AddressRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/AddressRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tdl.vireo.model.Address;
 
-public class AddressTest extends AbstractEntityTest {
+public class AddressRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/ConfigurationRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/ConfigurationRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.tdl.vireo.config.constant.ConfigurationName;
+import org.tdl.vireo.model.ManagedConfiguration;
 
-public class ConfigurationTest extends AbstractEntityTest {
+public class ConfigurationRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/ContactInfoRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/ContactInfoRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tdl.vireo.model.ContactInfo;
 
-public class ContactInfoTest extends AbstractEntityTest {
+public class ContactInfoRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/ControlledVocabularyRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/ControlledVocabularyRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -7,9 +7,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.model.ControlledVocabulary;
+import org.tdl.vireo.model.Embargo;
+import org.tdl.vireo.model.EmbargoGuarantor;
+import org.tdl.vireo.model.VocabularyWord;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class ControlledVocabularyTest extends AbstractEntityTest {
+public class ControlledVocabularyRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/CustomActionDefinitionRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/CustomActionDefinitionRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.CustomActionDefinition;
 
-public class CustomActionDefinitionTest extends AbstractEntityTest {
+public class CustomActionDefinitionRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/CustomActionValueRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/CustomActionValueRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
+import org.tdl.vireo.model.CustomActionValue;
+import org.tdl.vireo.model.Organization;
 
-public class CustomActionValueTest extends AbstractEntityTest {
+public class CustomActionValueRepoTest extends AbstractRepoTest {
 
     @Autowired
     private CustomActionDefinitionRepo customActionDefinitionRepo;

--- a/src/test/java/org/tdl/vireo/model/repo/DegreeLevelRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/DegreeLevelRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.DegreeLevel;
 
-public class DegreeLevelTest extends AbstractEntityTest {
+public class DegreeLevelRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/DegreeRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/DegreeRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
-public class DegreeTest extends AbstractEntityTest {
+import org.tdl.vireo.model.Degree;
+
+public class DegreeRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/tdl/vireo/model/repo/DepositLocationRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/DepositLocationRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,9 +6,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.DepositLocation;
 import org.tdl.vireo.model.formatter.DSpaceMetsFormatter;
 
-public class DepositLocationTest extends AbstractEntityTest {
+public class DepositLocationRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/tdl/vireo/model/repo/DocumentTypeRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/DocumentTypeRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,10 +12,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
+import org.tdl.vireo.model.DocumentType;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class DocumentTypeTest extends AbstractEntityTest {
+public class DocumentTypeRepoTest extends AbstractRepoTest {
 
     @Autowired
     private CustomActionDefinitionRepo customActionDefinitionRepo;

--- a/src/test/java/org/tdl/vireo/model/repo/EmailTemplateRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/EmailTemplateRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,8 +7,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.EmailTemplate;
 
-public class EmailTemplateTest extends AbstractEntityTest {
+public class EmailTemplateRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/EmailWorkflowRuleRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/EmailWorkflowRuleRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -6,8 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.tdl.vireo.model.EmailWorkflowRule;
 
-public class EmailWorkflowRuleTest extends AbstractEntityTest {
+public class EmailWorkflowRuleRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/EmbargoRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/EmbargoRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.Embargo;
+import org.tdl.vireo.model.EmbargoGuarantor;
 
-public class EmbargoTest extends AbstractEntityTest {
+public class EmbargoRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/FieldPredicateRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/FieldPredicateRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.FieldPredicate;
 
-public class FieldPredicateTest extends AbstractEntityTest {
+public class FieldPredicateRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/FieldProfileRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/FieldProfileRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -13,8 +13,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
 import org.tdl.vireo.exception.HeritableModelNonOverrideableException;
 import org.tdl.vireo.exception.WorkflowStepNonOverrideableException;
+import org.tdl.vireo.model.ControlledVocabulary;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.WorkflowStep;
 
-public class FieldProfileTest extends AbstractEntityTest {
+public class FieldProfileRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/FieldValueRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/FieldValueRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,8 +6,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.model.FieldValue;
 
-public class FieldValueTest extends AbstractEntityTest {
+public class FieldValueRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/tdl/vireo/model/repo/GraduationMonthRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/GraduationMonthRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.GraduationMonth;
 
-public class GraduationMonthTest extends AbstractEntityTest {
+public class GraduationMonthRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/InputTypeRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/InputTypeRepoTest.java
@@ -1,12 +1,13 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.tdl.vireo.model.InputType;
 
-public class InputTypeTest extends AbstractEntityTest {
+public class InputTypeRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/LanguageRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/LanguageRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.tdl.vireo.model.repo.LanguageRepo;
+import org.tdl.vireo.model.Language;
 
-public class LanguageTest extends AbstractEntityTest {
+public class LanguageRepoTest extends AbstractRepoTest {
 
     @Autowired
     private LanguageRepo languageRepo;

--- a/src/test/java/org/tdl/vireo/model/repo/NamedSearchFilterRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/NamedSearchFilterRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -10,9 +10,15 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.model.FilterCriterion;
+import org.tdl.vireo.model.InputType;
+import org.tdl.vireo.model.NamedSearchFilter;
+import org.tdl.vireo.model.NamedSearchFilterGroup;
+import org.tdl.vireo.model.Sort;
+import org.tdl.vireo.model.SubmissionListColumn;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class NamedSearchFilterTest extends AbstractEntityTest {
+public class NamedSearchFilterRepoTest extends AbstractRepoTest {
 
     // TODO: write missing tests!!
 

--- a/src/test/java/org/tdl/vireo/model/repo/NoteRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/NoteRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,8 +12,11 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
 import org.tdl.vireo.exception.HeritableModelNonOverrideableException;
 import org.tdl.vireo.exception.WorkflowStepNonOverrideableException;
+import org.tdl.vireo.model.Note;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.WorkflowStep;
 
-public class NoteTest extends AbstractEntityTest {
+public class NoteRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/OrganizationCategoryRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/OrganizationCategoryRepoTest.java
@@ -1,12 +1,14 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.OrganizationCategory;
 
-public class OrganizationCategoryTest extends AbstractEntityTest {
+public class OrganizationCategoryRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/OrganizationRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/OrganizationRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -10,8 +10,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.OrganizationCategory;
+import org.tdl.vireo.model.WorkflowStep;
 
-public class OrganizationTest extends AbstractEntityTest {
+public class OrganizationRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/org/tdl/vireo/model/repo/SubmissionRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/SubmissionRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -11,10 +11,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
-import org.tdl.vireo.model.repo.CustomActionDefinitionRepo;
+import org.tdl.vireo.model.ActionLog;
+import org.tdl.vireo.model.CustomActionDefinition;
+import org.tdl.vireo.model.CustomActionValue;
+import org.tdl.vireo.model.FieldValue;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.SubmissionFieldProfile;
+import org.tdl.vireo.model.SubmissionWorkflowStep;
+import org.tdl.vireo.model.WorkflowStep;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class SubmissionTest extends AbstractEntityTest {
+public class SubmissionRepoTest extends AbstractRepoTest {
 
     @Autowired
     private CustomActionDefinitionRepo customActionDefinitionRepo;

--- a/src/test/java/org/tdl/vireo/model/repo/SubmissionStatusRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/SubmissionStatusRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -6,8 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.tdl.vireo.model.SubmissionStatus;
 
-public class SubmissionStatusTest extends AbstractEntityTest {
+public class SubmissionStatusRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/SubmissionWorkflowStepRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/SubmissionWorkflowStepRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -6,10 +6,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.tdl.vireo.model.repo.SubmissionFieldProfileRepo;
-import org.tdl.vireo.model.repo.SubmissionNoteRepo;
 
-public class SubmissionWorkflowStepTest extends AbstractEntityTest {
+public class SubmissionWorkflowStepRepoTest extends AbstractRepoTest {
 
     // private User anotherUser;
     // private Credentials credentials;

--- a/src/test/java/org/tdl/vireo/model/repo/UserRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/UserRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -8,9 +8,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.tdl.vireo.model.Address;
+import org.tdl.vireo.model.ContactInfo;
+import org.tdl.vireo.model.User;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class UserTest extends AbstractEntityTest {
+public class UserRepoTest extends AbstractRepoTest {
 
     @Override
     @Test

--- a/src/test/java/org/tdl/vireo/model/repo/VocabularyWordRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/VocabularyWordRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(propagation = Propagation.REQUIRES_NEW)
-public class VocabularyWordTest extends AbstractEntityTest {
+public class VocabularyWordRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/tdl/vireo/model/repo/WorkflowStepRepoTest.java
+++ b/src/test/java/org/tdl/vireo/model/repo/WorkflowStepRepoTest.java
@@ -1,4 +1,4 @@
-package org.tdl.vireo.model;
+package org.tdl.vireo.model.repo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -10,8 +10,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
 import org.tdl.vireo.exception.WorkflowStepNonOverrideableException;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.Note;
+import org.tdl.vireo.model.Organization;
+import org.tdl.vireo.model.WorkflowStep;
 
-public class WorkflowStepTest extends AbstractEntityTest {
+public class WorkflowStepRepoTest extends AbstractRepoTest {
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/org/tdl/vireo/model/request/DirectionSortTest.java
+++ b/src/test/java/org/tdl/vireo/model/request/DirectionSortTest.java
@@ -1,0 +1,35 @@
+package org.tdl.vireo.model.request;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.Sort;
+import org.tdl.vireo.model.AbstractModelTest;
+
+public class DirectionSortTest extends AbstractModelTest<DirectionSort> {
+
+    @InjectMocks
+    private DirectionSort directionSort;
+
+    @Override
+    protected DirectionSort getInstance() {
+        return directionSort;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        return Stream.of(
+            Arguments.of("property", "value"),
+            Arguments.of("direction", Sort.Direction.ASC),
+            Arguments.of("direction", Sort.Direction.DESC)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/request/FilteredPageRequestTest.java
+++ b/src/test/java/org/tdl/vireo/model/request/FilteredPageRequestTest.java
@@ -1,0 +1,79 @@
+package org.tdl.vireo.model.request;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.InjectMocks;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.tdl.vireo.model.AbstractModelTest;
+
+public class FilteredPageRequestTest extends AbstractModelTest<FilteredPageRequest> {
+
+    @InjectMocks
+    private FilteredPageRequest filteredPageRequest;
+
+    @Test
+    public void testGetPageRequest() {
+        List<DirectionSort> sort = new ArrayList<>();
+        sort.add(new DirectionSort("property", Sort.Direction.ASC));
+
+        ReflectionTestUtils.setField(filteredPageRequest, "pageNumber", 0);
+        ReflectionTestUtils.setField(filteredPageRequest, "pageSize", 1);
+        ReflectionTestUtils.setField(filteredPageRequest, "sort", sort);
+
+        PageRequest pageRequest = filteredPageRequest.getPageRequest();
+
+        assertNotEquals(Sort.unsorted(), pageRequest.getSort(), "Page Request is unsorted.");
+    }
+
+    @Test
+    public void testGetPageRequestWithoutSort() {
+        List<DirectionSort> sort = new ArrayList<>();
+
+        ReflectionTestUtils.setField(filteredPageRequest, "pageNumber", 0);
+        ReflectionTestUtils.setField(filteredPageRequest, "pageSize", 1);
+        ReflectionTestUtils.setField(filteredPageRequest, "sort", sort);
+
+        PageRequest pageRequest = filteredPageRequest.getPageRequest();
+
+        assertEquals(Sort.unsorted(), pageRequest.getSort(), "Page Request is sorted.");
+    }
+
+    @Override
+    protected FilteredPageRequest getInstance() {
+        return filteredPageRequest;
+    }
+
+    protected static Stream<Arguments> provideGetterParameters() {
+        return getParameterStream();
+    }
+
+    protected static Stream<Arguments> provideSetterParameters() {
+        return getParameterStream();
+    }
+
+    private static Stream<Arguments> getParameterStream() {
+        List<DirectionSort> sort = new ArrayList<>();
+        Map<String, String[]> filters = new HashMap<>();
+
+        sort.add(new DirectionSort());
+        filters.put("a", new String[] { "b" });
+
+        return Stream.of(
+            Arguments.of("pageNumber", 123),
+            Arguments.of("pageSize", 123),
+            Arguments.of("sort", sort),
+            Arguments.of("filters", filters)
+        );
+    }
+
+}

--- a/src/test/java/org/tdl/vireo/model/response/ViewsTest.java
+++ b/src/test/java/org/tdl/vireo/model/response/ViewsTest.java
@@ -1,0 +1,53 @@
+package org.tdl.vireo.model.response;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.tamu.weaver.response.ApiView;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.tdl.vireo.model.response.Views.Partial;
+import org.tdl.vireo.model.response.Views.SubmissionIndividual;
+import org.tdl.vireo.model.response.Views.SubmissionIndividualActionLogs;
+import org.tdl.vireo.model.response.Views.SubmissionList;
+
+@ActiveProfiles("test")
+public class ViewsTest {
+
+    @Test
+    public void testViewsInstantiation() {
+        assertNotNull(new Views(), "View is null.");
+    }
+
+    @Test
+    public void testSubmissionIndividualActionLogsInstantiation() {
+        SubmissionIndividualActionLogs view = new Views.SubmissionIndividualActionLogs();
+
+        assertNotNull(view, "View is null.");
+        assertTrue(view instanceof ApiView.Partial);
+    }
+
+    @Test
+    public void testSubmissionIndividualInstantiation() {
+        SubmissionIndividual view = new Views.SubmissionIndividual();
+
+        assertNotNull(view, "View is null.");
+        assertTrue(view instanceof ApiView.Partial);
+    }
+
+    @Test
+    public void testPartialInstantiation() {
+        Partial view = new Views.Partial();
+
+        assertNotNull(view, "View is null.");
+        assertTrue(view instanceof ApiView.Partial);
+    }
+
+    @Test
+    public void testSubmissionListInstantiation() {
+        SubmissionList view = new Views.SubmissionList();
+
+        assertNotNull(view, "View is null.");
+        assertTrue(view instanceof ApiView.Partial);
+    }
+}


### PR DESCRIPTION
### Rename repo tests as a repo test and relocate them in a newly created repo sub-directory.

The model tests need to be named the same name as the model.
Naming the repo tests with the same name as the model is misleading and conflicts when writing a model test.

### Add AbstractModelTest, AbstractEnumTest, AbstractModelCustomMethodTest classes for model and enumeration testing.

This slightly simplifies creating the model and enum tests by providing otherwise redundant aspects in an abstract class.
    
The AbstractModelCustomMethodTest is added because getter and setter tests on Boolean and boolean types tend to succeed or fail inconsistently.
The AbstractModelCustomMethodTest, unlike AbstractModelTest, uses the more generic method call rather than the explicit getter and explicit setter calls.

### Don't use both `@Spy` and `@InjectMocks` on same property and make simpMessagingTemplate and env protected rather than private.

This could be causing a race conditionition during the loading of the `@Spy`.
The `@InjectMocks` likely does everything needed and the `@Spy` is probably not needed in this case.

Both simpMessagingTemplate and env are mocked.
An implementing class needs to utilize the mock then the implementing class needs access to the property

### Add several Model and Enumeration unit tests and add or update existing Controller unit tests.

A lot of the Models and Enumerations are not directly tested.
This adds a whole new testing methodology that helps automatically test the getter and setters with significantly reduced work by using existing test functionality to automate much of the process.

The Controller tests have been updated to increase coverage.
Some new Controller tests are added.

The Model, Enumeration, and Controller tests are improved but this is not a complete solution.
I've only spent the amount of time I had available to improve the test coverage.

### Links Showing Improvements
- Before: https://coveralls.io/builds/61455400
- After: https://coveralls.io/builds/61455483
