### PR TITLE
Issue 1840: Delete Field Profile by ID.

### DIFF
--- a/src/main/webapp/app/repo/workflowStepRepo.js
+++ b/src/main/webapp/app/repo/workflowStepRepo.js
@@ -43,8 +43,8 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
         OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
 
         var endpoint = angular.copy(this.mapping.removeFieldProfile);
-        endpoint.method = OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-field-profile';
-        endpoint.data = fieldProfile.id;
+        endpoint.method = OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-field-profile/' + fieldProfile.id;
+        endpoint.data = ''; // Provide empty data to force this to be a POST
 
         return WsApi.fetch(endpoint);
     };

--- a/src/main/webapp/app/repo/workflowStepRepo.js
+++ b/src/main/webapp/app/repo/workflowStepRepo.js
@@ -41,17 +41,12 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
     this.removeFieldProfile = function (workflowStep, fieldProfile) {
         workflowStepRepo.clearValidationResults();
         OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
-        angular.extend(this.mapping.removeFieldProfile, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-field-profile',
-            'data': fieldProfile
-        });
-        var promise = WsApi.fetch(this.mapping.removeFieldProfile);
-        promise.then(function (res) {
-            if (angular.fromJson(res.body).meta.status === "INVALID") {
-                angular.extend(workflowStepRepo, angular.fromJson(res.body).payload);
-            }
-        });
-        return promise;
+
+        var endpoint = angular.copy(this.mapping.removeFieldProfile);
+        endpoint.method = OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-field-profile';
+        endpoint.data = fieldProfile.id;
+
+        return WsApi.fetch(endpoint);
     };
 
     this.reorderFieldProfiles = function (workflowStep, src, dest) {

--- a/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
@@ -224,29 +224,55 @@ public class WorkflowStepControllerTest extends AbstractControllerTest {
 
     @Test
     public void testRemoveFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
         when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
-        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
         when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
-        doNothing().when(fieldProfileRepo).delete(any(FieldProfile.class));
         doNothing().when(organizationRepo).broadcast(anyList());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
     }
 
     @Test
     public void testRemoveFieldProfileWithDifferentProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
         when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
-        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
         when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
         doNothing().when(organizationRepo).broadcast(anyList());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileWithUnknownOrganization() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileWithUnknownFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileWithUnknownWorkflowStep() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
     }
 
     @Test

--- a/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/WorkflowStepControllerTest.java
@@ -231,7 +231,7 @@ public class WorkflowStepControllerTest extends AbstractControllerTest {
         when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
         doNothing().when(organizationRepo).broadcast(anyList());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
     }
 
@@ -244,34 +244,77 @@ public class WorkflowStepControllerTest extends AbstractControllerTest {
         when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
         doNothing().when(organizationRepo).broadcast(anyList());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1);
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
     }
 
     @Test
-    public void testRemoveFieldProfileWithUnknownOrganization() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+    public void testRemoveFieldProfileById() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
+        doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileWithMatchingOriginatingWorkflowStep() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        fieldProfile1.setOriginatingWorkflowStep(workflowStep1);
+        workflowStep1.setOriginatingOrganization(organization1);
+
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep1));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
+        doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(fieldProfileRepo).deleteById(anyLong());
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileByIdWithDifferentProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
+        when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.of(fieldProfile1));
+        doNothing().when(fieldProfileRepo).removeFromWorkflowStep(any(Organization.class), any(WorkflowStep.class), any(FieldProfile.class));
+        when(organizationRepo.findAllByOrderByIdAsc()).thenReturn(organizations);
+        doNothing().when(organizationRepo).broadcast(anyList());
+
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+    }
+
+    @Test
+    public void testRemoveFieldProfileByIdWithUnknownOrganization() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
         when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.empty());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
         assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
     }
 
     @Test
-    public void testRemoveFieldProfileWithUnknownFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+    public void testRemoveFieldProfileByIdWithUnknownFieldProfile() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
         when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.of(workflowStep2));
         when(fieldProfileRepo.findById(any(Long.class))).thenReturn(Optional.empty());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
         assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
     }
 
     @Test
-    public void testRemoveFieldProfileWithUnknownWorkflowStep() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
+    public void testRemoveFieldProfileByIdWithUnknownWorkflowStep() throws JsonProcessingException, WorkflowStepNonOverrideableException, HeritableModelNonOverrideableException, ComponentNotPresentOnOrgException {
         when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         when(workflowStepRepo.findById(any(Long.class))).thenReturn(Optional.empty());
 
-        ApiResponse response = fieldPredicateController.removeFieldProfile(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
+        ApiResponse response = fieldPredicateController.removeFieldProfileById(organization1.getId(), workflowStep1.getId(), fieldProfile1.getId());
         assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
     }
 


### PR DESCRIPTION
resolves #1840

Change the behavior to accept an ID.
Add error checking and returning ERROR as appropriate.

The old end point is preserved for compatibility reasons.

Removing confusing logic that extends the WorkflowStepRepo with the response data from an `INVALID` response. This logic does not make any sense to me.