### PR TITLE
Issue 1841: Delete Organization by ID.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/OrganizationController.java
+++ b/src/main/java/org/tdl/vireo/controller/OrganizationController.java
@@ -8,11 +8,19 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 import static org.springframework.beans.BeanUtils.copyProperties;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiView;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 import java.util.Map;
-
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,15 +43,6 @@ import org.tdl.vireo.model.repo.OrganizationRepo;
 import org.tdl.vireo.model.repo.SubmissionRepo;
 import org.tdl.vireo.model.repo.SubmissionStatusRepo;
 import org.tdl.vireo.model.repo.WorkflowStepRepo;
-
-import com.fasterxml.jackson.annotation.JsonView;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import edu.tamu.weaver.response.ApiResponse;
-import edu.tamu.weaver.response.ApiView;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
-import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
 
 @RestController
 @RequestMapping("/organization")
@@ -114,6 +113,19 @@ public class OrganizationController {
     public ApiResponse deleteOrganization(@WeaverValidatedModel Organization organization) {
         organizationRepo.delete(organizationRepo.read(organization.getId()));
         return new ApiResponse(SUCCESS, "Organization " + organization.getName() + " has been deleted!");
+    }
+
+    @PostMapping(value = "/delete/{id}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public ApiResponse deleteOrganizationById(@PathVariable Long id) {
+        Optional<Organization> organization = organizationRepo.findById(id);
+
+        if (organization.isEmpty()) {
+            return new ApiResponse(ERROR, "Cannot delete unknown Organization.");
+        }
+
+        organizationRepo.delete(organization.get());
+        return new ApiResponse(SUCCESS, "Organization " + organization.get().getName() + " has been deleted!");
     }
 
     @RequestMapping(value = "/restore-defaults", method = POST)

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -49,7 +49,7 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
         };
 
         $scope.deleteOrganization = function (organization) {
-            organization.delete().then(function (res) {
+            $scope.organizationRepo.deleteById(organization.id).then(function (res) {
                 var apiRes = angular.fromJson(res.body);
                 if (apiRes.meta.status !== 'INVALID') {
                     $scope.closeModal();

--- a/src/main/webapp/app/repo/organizationRepo.js
+++ b/src/main/webapp/app/repo/organizationRepo.js
@@ -127,6 +127,16 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
         return promise;
     };
 
+    this.deleteById = function (organizationId) {
+        organizationRepo.clearValidationResults();
+
+        var endpoint = angular.copy(this.mapping.remove);
+        endpoint.method += '/' + organizationId;
+        endpoint.data = ''; // Provide empty data to force this to be a POST.
+
+        return WsApi.fetch(endpoint);
+    };
+
     this.reorderWorkflowSteps = function (upOrDown, workflowStepID) {
         organizationRepo.clearValidationResults();
         angular.extend(this.mapping.reorderWorkflowStep, {

--- a/src/main/webapp/tests/mocks/repos/mockOrganizationRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockOrganizationRepo.js
@@ -48,6 +48,12 @@ angular.module("mock.organizationRepo", []).service("OrganizationRepo", function
         return payloadPromise($q.defer(), model);
     };
 
+    repo.deleteById = function (orgId) {
+        var payload = {};
+
+        return payloadPromise($q.defer(), payload);
+    };
+
     repo.deleteWorkflowStep = function (workflowStep) {
         var payload = {};
         repo.clearValidationResults();

--- a/src/main/webapp/tests/unit/repos/organizationRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/organizationRepoTest.js
@@ -59,6 +59,10 @@ describe("service: organizationRepo", function () {
             expect(repo.countSubmissions).toBeDefined();
             expect(typeof repo.countSubmissions).toEqual("function");
         });
+        it("deleteById should be defined", function () {
+            expect(repo.deleteById).toBeDefined();
+            expect(typeof repo.deleteById).toEqual("function");
+        });
         it("deleteWorkflowStep should be defined", function () {
             expect(repo.deleteWorkflowStep).toBeDefined();
             expect(typeof repo.deleteWorkflowStep).toEqual("function");
@@ -142,6 +146,21 @@ describe("service: organizationRepo", function () {
             scope.$digest();
 
             // TODO
+        });
+        it("deleteById should delete an organization", function () {
+            var organization = new mockOrganization(q);
+
+            WsApi.mockFetchResponse({ type: "payload" });
+
+            repo.deleteById(organization.id).then(function (res) {
+                var resObj = angular.fromJson(res.body);
+
+                expect(typeof resObj).toEqual("object");
+                expect(typeof resObj.meta).toEqual("object");
+                expect(resObj.meta.status).toEqual("SUCCESS");
+            });
+
+            scope.$digest();
         });
         it("deleteWorkflowStep should delete a step", function () {
             var workflowStep = new mockWorkflowStep(q);

--- a/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
@@ -191,7 +191,7 @@ public class OrganizationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testDeletOrganizationById() {
+    public void testDeleteOrganizationById() {
         when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
         doNothing().when(organizationRepo).delete(any(Organization.class));
 
@@ -202,7 +202,7 @@ public class OrganizationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testDeletOrganizationByIdWithUnknownOrganization() {
+    public void testDeleteOrganizationByIdWithUnknownOrganization() {
         when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.empty());
 
         ApiResponse response = organizationController.deleteOrganizationById(organization1.getId());

--- a/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -179,7 +180,7 @@ public class OrganizationControllerTest extends AbstractControllerTest {
     }
 
     @Test
-    public void testRemoveOrganization() {
+    public void testDeleteOrganization() {
         when(organizationRepo.read(any(Long.class))).thenReturn(organization1);
         doNothing().when(organizationRepo).delete(any(Organization.class));
 
@@ -187,6 +188,27 @@ public class OrganizationControllerTest extends AbstractControllerTest {
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
 
         verify(organizationRepo).delete(any(Organization.class));
+    }
+
+    @Test
+    public void testDeletOrganizationById() {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.of(organization1));
+        doNothing().when(organizationRepo).delete(any(Organization.class));
+
+        ApiResponse response = organizationController.deleteOrganizationById(organization1.getId());
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        verify(organizationRepo).delete(any(Organization.class));
+    }
+
+    @Test
+    public void testDeletOrganizationByIdWithUnknownOrganization() {
+        when(organizationRepo.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        ApiResponse response = organizationController.deleteOrganizationById(organization1.getId());
+        assertEquals(ApiStatus.ERROR, response.getMeta().getStatus());
+
+        verify(organizationRepo, never()).delete(any(Organization.class));
     }
 
     @Test


### PR DESCRIPTION
resolves #1841

Add a new end point rather than replacing the existing one. The existing end point is unused but is present for backwards compatibility.

Change the behavior in the UI to use an ID rather than a full object. Add error checking and returning ERROR as appropriate.