### PR TITLE
Issue 1842: Major Performance bottleneck in Workflow Step at significant XHRLoad cost.

### DIFF
--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -985,6 +985,7 @@ var apiMapping = {
         }
     },
     WorkflowStep: {
+        lazy: true,
         validations: true,
         channel: '/channel/workflow-step',
         all: {


### PR DESCRIPTION
Partially resolves #1842

The `XHRLoad` is processing too much data and can take as long as 4000ms.
This causes problems on the organization load pages.
This causes huge problems on less efficient browsers or low-resource/low-spec hardware (such as a phone).

This does not solve the primary problem with the Triptych and the Organizations, which still takes 1 to 2 seconds.
However, this stops the massive JS-time performance hit resulting from the `XHRLoad` of this data.

The `getAll()` is being called automatically, likely through weaver-ui-core.
There are no direct calls to this information via a getAll as far as I can tell.
This getAll is therefore not directly needed (but more testing and QA is needed to confirm this).

Setting `lazy` to `true` seems to tell weaver-ui-core to not auto-load this.

After this change, the `XHRLoad` goes down from **~4000ms** to **~1500ms**.
Chrome based browsers do a good job of showing this performance statistic.