### PR TITLE
Issue 1842: Submission load time is affected by fix for issue 1842.

### DIFF
--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -2,6 +2,7 @@
 var apiMapping = {
     ActionLog: {},
     ControlledVocabulary: {
+        lazy: true,
         validations: true,
         channel: '/channel/controlled-vocabulary',
         all: {


### PR DESCRIPTION
Relates #1842.
Solves regression from #1845

The PR 1845 (via commit f4494041060e5451df04e37aad0093eb8886f71e) introduced the `ControlledVocabularyRepo` onto the Field Profile directive. The result of this is that when the Student Submission view loads the submission for editing, the entire Controlled Vocabulary ends up being loaded. This has a notable performance hit.

Set the mapping to lazy to prevent this loading from happening and thereby improving performance.