### PR TITLE
Issue 1842: Reduce amount of JS-side order by, relocating such logic into the back end.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/ControlledVocabularyController.java
+++ b/src/main/java/org/tdl/vireo/controller/ControlledVocabularyController.java
@@ -349,7 +349,7 @@ public class ControlledVocabularyController {
     @PreAuthorize("hasRole('STUDENT')")
     @PostMapping(value = "/typeahead-vocabulary-word/{cvId}")
     public ApiResponse typeaheadVocabularyWord(@PathVariable Long cvId, @RequestBody String search) {
-        return new ApiResponse(SUCCESS, vocabularyWordRepo.findAllByNameContainsIgnoreCaseAndControlledVocabularyId(search, cvId, ContactsVocabularyWordView.class));
+        return new ApiResponse(SUCCESS, vocabularyWordRepo.findAllByNameContainsIgnoreCaseAndControlledVocabularyIdOrderByName(search, cvId, ContactsVocabularyWordView.class));
     }
 
     private Map<String, Object> cacheImport(ControlledVocabulary controlledVocabulary, MultipartFile file) throws IOException {

--- a/src/main/java/org/tdl/vireo/controller/WorkflowStepController.java
+++ b/src/main/java/org/tdl/vireo/controller/WorkflowStepController.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
+++ b/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
@@ -15,6 +15,7 @@ import javax.persistence.OneToMany;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
+import org.hibernate.annotations.OrderBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -37,6 +38,7 @@ public class ControlledVocabulary extends ValidatingOrderedBaseEntity {
     @OneToMany(cascade = { ALL }, fetch = LAZY, mappedBy = "controlledVocabulary", orphanRemoval = true)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size=1000)
+    @OrderBy(clause = "name ASC")
     private List<VocabularyWord> dictionary;
 
     @JsonView(Views.SubmissionIndividual.class)

--- a/src/main/java/org/tdl/vireo/model/repo/VocabularyWordRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/VocabularyWordRepo.java
@@ -10,6 +10,6 @@ public interface VocabularyWordRepo extends WeaverRepo<VocabularyWord>, Vocabula
 
     VocabularyWord findByNameAndControlledVocabulary(String name, ControlledVocabulary controlledVocabulary);
 
-    <T> List<T>findAllByNameContainsIgnoreCaseAndControlledVocabularyId(String name, Long controlledVocabularyId, Class<T> type);
+    <T> List<T>findAllByNameContainsIgnoreCaseAndControlledVocabularyIdOrderByName(String name, Long controlledVocabularyId, Class<T> type);
 
 }

--- a/src/main/webapp/app/views/admin/info/edit/input-email.html
+++ b/src/main/webapp/app/views/admin/info/edit/input-email.html
@@ -1,6 +1,6 @@
 <div class="input-group">
   <input class="form-control" type="text"
-    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue } | orderBy:'name'"
+    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue }"
     typeahead-wait-ms="400"
     ng-model="field.value"
   />

--- a/src/main/webapp/app/views/admin/info/edit/input-text.html
+++ b/src/main/webapp/app/views/admin/info/edit/input-text.html
@@ -1,6 +1,6 @@
 <div class="input-group">
   <input class="form-control" type="text"
-    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue } | orderBy:'name'"
+    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue }"
     typeahead-wait-ms="400"
     typeahead-on-select="saveWithCV(field, $item)"
     ng-model="field.value"

--- a/src/main/webapp/app/views/admin/info/edit/input-url.html
+++ b/src/main/webapp/app/views/admin/info/edit/input-url.html
@@ -1,6 +1,6 @@
 <div class="input-group">
   <input class="form-control" type="text"
-    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue } | orderBy:'name'"
+    uib-typeahead="word.name as word.name for word in fieldProfile.controlledVocabulary.dictionary | filter: { name: $viewValue }"
     typeahead-wait-ms="400"
     typeahead-on-select="saveWithCV(field, $item)"
     ng-model="field.value"

--- a/src/main/webapp/app/views/inputtype/input-contact_select.html
+++ b/src/main/webapp/app/views/inputtype/input-contact_select.html
@@ -9,7 +9,7 @@
     <li class="select-option"
       role="menuitem"
       ng-click="fieldValue.value = word.name; fieldProfileForm.$dirty = true; saveWithCV(fieldValue, word);"
-      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:'name'">
+      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord">
       <a href="#">{{word.name}}</a>
     </li>
   </ul>

--- a/src/main/webapp/app/views/inputtype/input-select.html
+++ b/src/main/webapp/app/views/inputtype/input-select.html
@@ -9,7 +9,7 @@
     <li class="select-option"
       role="menuitem"
       ng-click="fieldValue.value = word.name; fieldProfileForm.$dirty = true; saveWithCV(fieldValue, word);"
-      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:'name'">
+      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord">
       <a href="#">{{word.name}}</a>
     </li>
   </ul>

--- a/src/main/webapp/app/views/inputtype/input-text.html
+++ b/src/main/webapp/app/views/inputtype/input-text.html
@@ -6,7 +6,7 @@
     ng-model="fieldValue.value"
     ng-blur="save(fieldValue)"
     ng-disabled="fieldValue.updating"
-    uib-typeahead="word.name as word.name for word in profile.controlledVocabulary.dictionary | filter: { name: $viewValue } | orderBy:'name'"
+    uib-typeahead="word.name as word.name for word in profile.controlledVocabulary.dictionary | filter: { name: $viewValue }"
     typeahead-wait-ms="400"
     typeahead-on-select="saveWithCV(fieldValue, $item)"
   />

--- a/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/ControlledVocabularyControllerTest.java
@@ -436,7 +436,7 @@ public class ControlledVocabularyControllerTest extends AbstractControllerTest {
 
     @Test
     public void testTypeaheadVocabularyWord() {
-        when(vocabularyWordRepo.findAllByNameContainsIgnoreCaseAndControlledVocabularyId(anyString(), anyLong(), Mockito.<Class<VocabularyWord>>any())).thenReturn(dictionaries1);
+        when(vocabularyWordRepo.findAllByNameContainsIgnoreCaseAndControlledVocabularyIdOrderByName(anyString(), anyLong(), Mockito.<Class<VocabularyWord>>any())).thenReturn(dictionaries1);
 
         ApiResponse response = controlledVocabularyController.typeaheadVocabularyWord(vocabularyWord1.getId(), "test");
         assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
@@ -444,7 +444,7 @@ public class ControlledVocabularyControllerTest extends AbstractControllerTest {
         List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<VocabularyWord>");
         assertEquals(dictionaries1, got, "Did not get expected Vocabulary Words array in the response.");
 
-        verify(vocabularyWordRepo).findAllByNameContainsIgnoreCaseAndControlledVocabularyId(anyString(), anyLong(), any());
+        verify(vocabularyWordRepo).findAllByNameContainsIgnoreCaseAndControlledVocabularyIdOrderByName(anyString(), anyLong(), any());
     }
 
 }


### PR DESCRIPTION
Partially resolves #1842

The order by on a huge set is an expensive task on the browser/client side.
This is particular bad when there are multiple fields each with their own ng-repeat over the same large data set.
Relocate the order by logic to the back end.