### PR TITLE
Issue 1842: Use JPA and include order by on vocabulary when ordering Controlled Vocabulary dictionary and revert input select.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
+++ b/src/main/java/org/tdl/vireo/model/ControlledVocabulary.java
@@ -12,10 +12,10 @@ import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.annotations.OrderBy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -38,7 +38,7 @@ public class ControlledVocabulary extends ValidatingOrderedBaseEntity {
     @OneToMany(cascade = { ALL }, fetch = LAZY, mappedBy = "controlledVocabulary", orphanRemoval = true)
     @Fetch(FetchMode.SELECT)
     @BatchSize(size=1000)
-    @OrderBy(clause = "name ASC")
+    @OrderBy("controlledVocabulary ASC, name ASC")
     private List<VocabularyWord> dictionary;
 
     @JsonView(Views.SubmissionIndividual.class)

--- a/src/main/webapp/app/views/inputtype/input-select.html
+++ b/src/main/webapp/app/views/inputtype/input-select.html
@@ -9,7 +9,7 @@
     <li class="select-option"
       role="menuitem"
       ng-click="fieldValue.value = word.name; fieldProfileForm.$dirty = true; saveWithCV(fieldValue, word);"
-      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord">
+      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:'name'">
       <a href="#">{{word.name}}</a>
     </li>
   </ul>


### PR DESCRIPTION
Relates #1851

Use JPA instead of Hibernate to perform the OrderBy. The Hibernate uses SQL and JPA is the preferred approach.

The Degree information still needs sorting, add back orderBy for input select.

At least if most of the information is sorted already, then there will still be a performance boost of not having to move anything around in the case of the input select.