### PR TITLE
Issue 1842: Submission create is taking longer by processing unneeded data.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -240,7 +240,7 @@ public class SubmissionController {
     );
     actionLogRepo.createPublicLog(submission, user, "Submission created.");
 
-    return new ApiResponse(SUCCESS, submission);
+    return new ApiResponse(SUCCESS, submission.getId());
   }
 
   @Transactional

--- a/src/main/webapp/app/controllers/submission/newSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/newSubmissionController.js
@@ -56,10 +56,8 @@ vireo.controller('NewSubmissionController', function ($controller, $location, $q
             }).then(function (response) {
                 $scope.creatingSubmission = false;
                 var apiRes = angular.fromJson(response.body);
-                if (apiRes.meta.status === 'SUCCESS') {
-                    var submission = apiRes.payload.Submission;
-                    StudentSubmissionRepo.add(submission);
-                    $location.path("/submission/" + submission.id);
+                if (apiRes.meta.status === 'SUCCESS' && !!apiRes.payload.Long) {
+                    $location.path("/submission/" + apiRes.payload.Long);
                 }
             });
         };


### PR DESCRIPTION
Partially resolves #1842

The Submission create takes a long time because the back end is returning the full created Submission model. The front end then processing the entire Submission model. This takes a long time.

The processed model is added to the Submission repo but then a redirect is performed on the ID. All of that just created Submission model data is lost due to the redirect. Loading and processing that data is a waste of time.

Redesign the back end to instead return an ID on create rather than the full model. Instead, return just the newly created Submission ID. On redirect, the new Submission is fully loaded anyway and so only getting the ID is not a problem.

This saves ~2000ms in my local test case.