### PR TITLE
Issue 1842: Redesign Organization and Triptych to use partial data.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Organization.java
+++ b/src/main/java/org/tdl/vireo/model/Organization.java
@@ -126,6 +126,10 @@ public class Organization extends ValidatingBaseEntity {
     }
 
     /**
+     * Returns TRUE to designate that the entire object is complete.
+     *
+     * This should only be returned with a value of TRUE when the full model is used.
+     *
      * @return True.
      */
     public boolean isComplete() {

--- a/src/main/java/org/tdl/vireo/model/repo/OrganizationRepo.java
+++ b/src/main/java/org/tdl/vireo/model/repo/OrganizationRepo.java
@@ -10,6 +10,12 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface OrganizationRepo extends WeaverRepo<Organization>, OrganizationRepoCustom {
 
+    public long countById(Long id);
+
+    public <T> T findViewById(Long id, Class<T> type);
+
+    public <T> List<T> findViewAllByOrderByIdAsc(Class<T> type);
+
     public List<Organization> findAllByOrderByIdAsc();
 
     public List<Organization> findByAggregateWorkflowStepsId(Long workflowStepId);

--- a/src/main/java/org/tdl/vireo/view/ContactsVocabularyWordView.java
+++ b/src/main/java/org/tdl/vireo/view/ContactsVocabularyWordView.java
@@ -2,7 +2,7 @@ package org.tdl.vireo.view;
 
 import java.util.List;
 
-public interface ContactsVocabularyWordView extends SimpleVocabularyWordView {
+public interface ContactsVocabularyWordView extends SimpleNamedModelView {
 
     public List<String> getContacts();
 

--- a/src/main/java/org/tdl/vireo/view/ShallowOrganizationView.java
+++ b/src/main/java/org/tdl/vireo/view/ShallowOrganizationView.java
@@ -1,0 +1,27 @@
+package org.tdl.vireo.view;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import java.util.List;
+import org.tdl.vireo.model.EmailWorkflowRule;
+import org.tdl.vireo.model.OrganizationCategory;
+
+public interface ShallowOrganizationView extends TreeOrganizationView {
+
+    public OrganizationCategory getCategory();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = SimpleWorkflowStepView.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public List<SimpleWorkflowStepView> getOriginalWorkflowSteps();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = SimpleWorkflowStepView.class, property = "id")
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public List<SimpleWorkflowStepView> getAggregateWorkflowSteps();
+
+    public List<String> getEmails();
+
+    public List<EmailWorkflowRule> getEmailWorkflowRules();
+
+}

--- a/src/main/java/org/tdl/vireo/view/SimpleModelView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleModelView.java
@@ -1,0 +1,6 @@
+package org.tdl.vireo.view;
+
+public interface SimpleModelView {
+
+    public Long getId();
+}

--- a/src/main/java/org/tdl/vireo/view/SimpleNamedModelView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleNamedModelView.java
@@ -1,6 +1,6 @@
 package org.tdl.vireo.view;
 
-public interface SimpleOrganizationView {
+public interface SimpleNamedModelView extends SimpleModelView {
 
     public Long getId();
 

--- a/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleSubmissionView.java
@@ -3,9 +3,7 @@ package org.tdl.vireo.view;
 import java.util.Calendar;
 import org.tdl.vireo.model.SubmissionStatus;
 
-public interface SimpleSubmissionView {
-
-    public Long getId();
+public interface SimpleSubmissionView extends SimpleModelView {
 
     public SimpleUserView getSubmitter();
 
@@ -13,7 +11,7 @@ public interface SimpleSubmissionView {
 
     public SubmissionStatus getSubmissionStatus();
 
-    public SimpleOrganizationView getOrganization();
+    public SimpleNamedModelView getOrganization();
 
     public Calendar getSubmissionDate();
 }

--- a/src/main/java/org/tdl/vireo/view/SimpleUserView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleUserView.java
@@ -2,9 +2,7 @@ package org.tdl.vireo.view;
 
 import edu.tamu.weaver.user.model.IRole;
 
-public interface SimpleUserView {
-
-    public Long getId();
+public interface SimpleUserView extends SimpleNamedModelView {
 
     public String getNetid();
 
@@ -15,8 +13,6 @@ public interface SimpleUserView {
     public String getLastName();
 
     public String getMiddleName();
-
-    public String getName();
 
     public IRole getRole();
 

--- a/src/main/java/org/tdl/vireo/view/SimpleVocabularyWordView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleVocabularyWordView.java
@@ -1,9 +1,0 @@
-package org.tdl.vireo.view;
-
-public interface SimpleVocabularyWordView {
-
-    public Long getId();
-
-    public String getName();
-
-}

--- a/src/main/java/org/tdl/vireo/view/SimpleWorkflowStepView.java
+++ b/src/main/java/org/tdl/vireo/view/SimpleWorkflowStepView.java
@@ -1,0 +1,36 @@
+package org.tdl.vireo.view;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import edu.tamu.weaver.data.resolver.BaseEntityIdResolver;
+import java.util.List;
+import org.tdl.vireo.model.FieldProfile;
+import org.tdl.vireo.model.Note;
+
+public interface SimpleWorkflowStepView extends SimpleNamedModelView {
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = TreeOrganizationView.class, resolver = BaseEntityIdResolver.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public TreeOrganizationView getOriginatingOrganization();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = SimpleWorkflowStepView.class, resolver = BaseEntityIdResolver.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public SimpleWorkflowStepView getOriginatingWorkflowStep();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = FieldProfile.class, resolver = BaseEntityIdResolver.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public List<FieldProfile> getOriginalFieldProfiles();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = Note.class, resolver = BaseEntityIdResolver.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public List<Note> getOriginalNotes();
+
+    public Boolean getOverrideable();
+
+    public List<FieldProfile> getAggregateFieldProfiles();
+
+    public List<Note> getAggregateNotes();
+
+    public String getInstructions();
+}

--- a/src/main/java/org/tdl/vireo/view/TreeOrganizationView.java
+++ b/src/main/java/org/tdl/vireo/view/TreeOrganizationView.java
@@ -1,0 +1,23 @@
+package org.tdl.vireo.view;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import java.util.Set;
+import org.tdl.vireo.model.OrganizationCategory;
+
+public interface TreeOrganizationView extends SimpleNamedModelView {
+
+    public OrganizationCategory getCategory();
+
+    public Boolean getAcceptsSubmissions();
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = TreeOrganizationView.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    public TreeOrganizationView getParentOrganization();
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public Set<TreeOrganizationView> getChildrenOrganizations();
+
+}

--- a/src/main/webapp/app/config/apiMapping.js
+++ b/src/main/webapp/app/config/apiMapping.js
@@ -382,6 +382,7 @@ var apiMapping = {
         }
     },
     FieldProfile: {
+        lazy: true,
         validations: true,
         all: {
             'endpoint': '/private/queue',
@@ -488,6 +489,7 @@ var apiMapping = {
         }
     },
     Organization: {
+        lazy: true,
         validations: true,
         channel: "/channel/organization",
         all: {

--- a/src/main/webapp/app/controllers/organizationSettingsController.js
+++ b/src/main/webapp/app/controllers/organizationSettingsController.js
@@ -81,15 +81,16 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
             return;
         }
 
+        $scope.loadingOrganization = true;
+
         var existingSelected = $scope.selectedOrganization;
 
         if (!!organization && !!organization.id) {
-            $scope.loadingOrganization = true;
-
             if (!organization.complete && !organization.shallow || organization.$dirty) {
-                OrganizationRepo.getById(organization.id, 'shallow').then(function (org) {
-                    if (!!org && !!org.id) {
-                        org = new Organization(org);
+                OrganizationRepo.getById(organization.id, 'shallow').then(function (response) {
+                    if (!!response && !!response.id) {
+                        var org = response;
+                        var i;
                         org.complete = false;
                         org.shallow = true;
                         org.tree = false;
@@ -97,16 +98,20 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
                         $scope.newOrganization.parent = org;
                         $scope.selectedOrganization = org;
 
-                        for (var i = 0; i < $scope.organizations.length; i++) {
+                        for (i = 0; i < $scope.organizations.length; i++) {
                             if ($scope.organizations[i].id === org.id) {
-                                angular.extend($scope.organizations[i], org);
+                                $scope.organizations[i] = org;
 
                                 break;
                             }
                         }
 
+                        if (i == $scope.organizations.length) {
+                            $scope.organizations.push(org);
+                        }
+
                         if (!!org.parentOrganization) {
-                            for (var i = 0; i < $scope.organizations.length; i++) {
+                            for (i = 0; i < $scope.organizations.length; i++) {
                                 if ($scope.organizations[i].id === org.parentOrganization) {
                                     if (!!$scope.organizations[i].childrenOrganizations) {
                                         for (var j = 0; j < $scope.organizations[i].childrenOrganizations.length; j++) {
@@ -153,6 +158,7 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
             $scope.deleteDisabled = true;
 
             AccordionService.closeAll();
+            $scope.loadingOrganization = false;
         }
     };
 

--- a/src/main/webapp/app/controllers/organizationSettingsController.js
+++ b/src/main/webapp/app/controllers/organizationSettingsController.js
@@ -124,6 +124,10 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
                         }
 
                         OrganizationRepo.setSelectedOrganization(org);
+
+                        if (!existingSelected || existingSelected.id !== organization.id) {
+                            AccordionService.closeAll();
+                        }
                     }
 
                     $scope.setDeleteDisabled();
@@ -138,10 +142,10 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
                 $scope.selectedOrganization = organization;
                 $scope.setDeleteDisabled();
                 $scope.loadingOrganization = false;
-            }
 
-            if (!!$scope.existingSelected && existingSelected.id !== organization.id) {
-                AccordionService.closeAll();
+                if (!existingSelected || existingSelected.id !== organization.id) {
+                    AccordionService.closeAll();
+                }
             }
         } else {
             $scope.selectedOrganization = undefined;

--- a/src/main/webapp/app/controllers/organizationSettingsController.js
+++ b/src/main/webapp/app/controllers/organizationSettingsController.js
@@ -52,7 +52,7 @@ vireo.controller('OrganizationSettingsController', function ($controller, $scope
 
     $scope.getSelectedOrganizationValidationResults = function () {
         if ($scope.getSelectedOrganizationId()) {
-            return $scope.selectedOrganization.getValidationResuls;
+            return $scope.selectedOrganization.getValidationResults;
         }
     };
 

--- a/src/main/webapp/app/controllers/settings/fieldProfileManagementController.js
+++ b/src/main/webapp/app/controllers/settings/fieldProfileManagementController.js
@@ -127,11 +127,11 @@ vireo.controller("FieldProfileManagementController", function ($q, $controller, 
                 delete $scope.modalData.fieldPredicate;
             }
         };
-        
+
         $scope.mustCreateFieldPredicate = function () {
             return typeof $scope.modalData.fieldPredicate === 'string';
         };
-        
+
         $scope.canCreateFieldPredicate = function () {
             return $scope.mustCreateFieldPredicate() && $scope.modalData.fieldPredicate.length > 0;
         };
@@ -156,6 +156,10 @@ vireo.controller("FieldProfileManagementController", function ($q, $controller, 
         };
 
         $scope.createFieldProfile = function () {
+            if (!!$scope.getSelectedOrganizationId()) {
+                $scope.getSelectedOrganization().$dirty = true;
+            }
+
             $scope.createFieldPredicate().then(function() {
                 WorkflowStepRepo.addFieldProfile($scope.step, $scope.modalData).then(function() {
                     resetModalData();
@@ -182,6 +186,10 @@ vireo.controller("FieldProfileManagementController", function ($q, $controller, 
         };
 
         $scope.updateFieldProfile = function () {
+            if (!!$scope.getSelectedOrganizationId()) {
+                $scope.getSelectedOrganization().$dirty = true;
+            }
+
             $scope.createFieldPredicate().then(function() {
                 WorkflowStepRepo.updateFieldProfile($scope.step, $scope.modalData).then(function() {
                     resetModalData();
@@ -190,17 +198,25 @@ vireo.controller("FieldProfileManagementController", function ($q, $controller, 
         };
 
         $scope.removeFieldProfile = function () {
+            if (!!$scope.getSelectedOrganizationId()) {
+                $scope.getSelectedOrganization().$dirty = true;
+            }
+
             WorkflowStepRepo.removeFieldProfile($scope.step, $scope.modalData);
         };
 
         $scope.reorderFieldProfiles = function (src, dest) {
+            if (!!$scope.getSelectedOrganizationId()) {
+                $scope.getSelectedOrganization().$dirty = true;
+            }
+
             return WorkflowStepRepo.reorderFieldProfiles($scope.step, src, dest);
         };
 
         $scope.isEditable = function (fieldProfile) {
             var editable = fieldProfile.overrideable;
             if (!editable) {
-                editable = fieldProfile.originatingWorkflowStep == $scope.step.id && $scope.organizationRepo.getSelectedOrganization().originalWorkflowSteps.indexOf(fieldProfile.originatingWorkflowStep) > -1;
+                editable = fieldProfile.originatingWorkflowStep == $scope.step.id && !!$scope.getSelectedOrganizationOriginalWorkflowSteps() && $scope.getSelectedOrganizationOriginalWorkflowSteps().indexOf(fieldProfile.originatingWorkflowStep) > -1;
             }
             return editable;
         };

--- a/src/main/webapp/app/controllers/settings/noteManagementController.js
+++ b/src/main/webapp/app/controllers/settings/noteManagementController.js
@@ -30,8 +30,8 @@ vireo.controller("NoteManagementController", function ($controller, $scope, Drag
     $scope.resetNotes = function() {
         $scope.workflowStepRepo.clearValidationResults();
         $scope.noteRepo.clearValidationResults();
-        for(var key in $scope.forms) {
-            if($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
+        for (var key in $scope.forms) {
+            if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
                 $scope.forms[key].$setPristine();
                 $scope.forms[key].$setUntouched();
             }
@@ -46,9 +46,9 @@ vireo.controller("NoteManagementController", function ($controller, $scope, Drag
             });
         }
 
-        if($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
-			$scope.modalData.refresh();
-		}
+        if ($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
+            $scope.modalData.refresh();
+        }
         $scope.modalData = new Note({
             overrideable: true,
             name: '',
@@ -61,6 +61,10 @@ vireo.controller("NoteManagementController", function ($controller, $scope, Drag
     $scope.resetNotes();
 
     $scope.createNote = function() {
+        if (!!$scope.getSelectedOrganizationId()) {
+            $scope.getSelectedOrganization().$dirty = true;
+        }
+
         WorkflowStepRepo.addNote($scope.step, $scope.modalData);
     };
 
@@ -74,22 +78,34 @@ vireo.controller("NoteManagementController", function ($controller, $scope, Drag
     };
 
     $scope.updateNote = function() {
+        if (!!$scope.getSelectedOrganizationId()) {
+            $scope.getSelectedOrganization().$dirty = true;
+        }
+
         WorkflowStepRepo.updateNote($scope.step, $scope.modalData);
     };
 
     $scope.removeNote = function() {
+        if (!!$scope.getSelectedOrganizationId()) {
+            $scope.getSelectedOrganization().$dirty = true;
+        }
+
         WorkflowStepRepo.removeNote($scope.step, $scope.modalData);
     };
 
     $scope.reorderNotes = function(src, dest) {
+        if (!!$scope.getSelectedOrganizationId()) {
+            $scope.getSelectedOrganization().$dirty = true;
+        }
+
         return WorkflowStepRepo.reorderNotes($scope.step, src, dest);
     };
 
     $scope.isEditable = function(note) {
         var editable = note.overrideable;
-        if(!editable) {
+        if (!editable) {
             editable = note.originatingWorkflowStep == $scope.step.id &&
-                       $scope.selectedOrganization.originalWorkflowSteps.indexOf(note.originatingWorkflowStep) > -1;
+                       !!$scope.selectedOrganization && $scope.selectedOrganization.originalWorkflowSteps.indexOf(note.originatingWorkflowStep) > -1;
         }
         return editable;
     };

--- a/src/main/webapp/app/controllers/settings/organizationCategoriesController.js
+++ b/src/main/webapp/app/controllers/settings/organizationCategoriesController.js
@@ -24,9 +24,9 @@ vireo.controller("OrganizationCategoriesController", function ($controller, $sco
                     $scope.forms[key].$setUntouched();
                 }
             }
-        	if($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
-    			$scope.modalData.refresh();
-    		}
+            if($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
+                $scope.modalData.refresh();
+            }
             $scope.modalData = {};
             $scope.closeModal();
         };

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -114,8 +114,6 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
     $scope.resetManageOrganization = function (organization) {
         if (!!organization && !!organization.id) {
             organization.complete = false;
-            organization.shallow = false;
-            organization.tree = false;
 
             organization.clearValidationResults();
             organization.refresh();

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -10,7 +10,7 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
 
     $scope.organizationCategories = OrganizationCategoryRepo.getAll();
 
-    $scope.ready = $q.all([OrganizationRepo.ready(), OrganizationCategoryRepo.ready()]);
+    $scope.ready = $q.all([OrganizationCategoryRepo.ready()]);
 
     $scope.forms = {};
 
@@ -35,8 +35,8 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
         $scope.resetWorkflowSteps();
 
         $scope.showOrganizationManagement = function () {
-            var selectedOrg = $scope.getSelectedOrganization();
-            return selectedOrg !== undefined && selectedOrg.id !== undefined && (selectedOrg.id !== 1 || (selectedOrg.id == 1 && $scope.isAdmin()));
+            var selectedId = $scope.getSelectedOrganizationId();
+            return !!selectedId && (selectedId !== 1 || (selectedId == 1 && $scope.isAdmin()));
         };
 
         $scope.updateOrganization = function (organization) {
@@ -64,7 +64,7 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
 
         $scope.cancelDeleteOrganization = function () {
             $scope.closeModal();
-            $scope.getSelectedOrganization().clearValidationResults();
+            OrganizationRepo.clearValidationResults();
         };
 
         $scope.restoreOrganizationDefaults = function (organization) {
@@ -80,7 +80,7 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
 
         $scope.cancelRestoreOrganizationDefaults = function () {
             $scope.closeModal();
-            $scope.getSelectedOrganization().clearValidationResults();
+            OrganizationRepo.clearValidationResults();
         };
 
         $scope.addWorkflowStep = function () {
@@ -115,12 +115,14 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
             $scope.openModal('#workflow-step-delete-confirm-' + step.id);
         };
 
-        $scope.resetManageOrganization = function () {
-            if ($scope.getSelectedOrganization() !== undefined && $scope.getSelectedOrganization().id !== undefined) {
-                $scope.getSelectedOrganization().complete = false;
-                $scope.setSelectedOrganization($scope.getSelectedOrganization());
-                $scope.getSelectedOrganization().clearValidationResults();
-                $scope.getSelectedOrganization().refresh();
+        $scope.resetManageOrganization = function (organization) {
+            if (!!organization && !!organization.id) {
+                organization.complete = false;
+                organization.shallow = false;
+                organization.tree = false;
+
+                organization.clearValidationResults();
+                organization.refresh();
             }
         };
 

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -14,117 +14,116 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
 
     $scope.forms = {};
 
+    $scope.resetWorkflowSteps = function () {
+        $scope.organizationRepo.clearValidationResults();
+        for (var key in $scope.forms) {
+            if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
+                $scope.forms[key].$setPristine();
+                $scope.forms[key].$setUntouched();
+            }
+        }
+        if ($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
+            $scope.modalData.refresh();
+        }
+        $scope.modalData = {
+            overrideable: true
+        };
+        $scope.closeModal();
+    };
+
+    $scope.showOrganizationManagement = function () {
+        var selectedId = $scope.getSelectedOrganizationId();
+        return !!selectedId && (selectedId !== 1 || (selectedId == 1 && $scope.isAdmin()));
+    };
+
+    $scope.updateOrganization = function (organization) {
+        $scope.updatingOrganization = true;
+        organization.save().then(function () {
+            // update the parent scoped selected organization
+            $scope.setSelectedOrganization(organization);
+            $scope.updatingOrganization = false;
+        });
+    };
+
+    $scope.deleteOrganization = function (organization) {
+        $scope.organizationRepo.deleteById(organization.id).then(function (res) {
+            var apiRes = angular.fromJson(res.body);
+            if (apiRes.meta.status !== 'INVALID') {
+                $scope.closeModal();
+                $timeout(function () {
+                    AlertService.add(apiRes.meta, 'organization/delete');
+                }, 300);
+            } else {
+                $scope.closeModal();
+            }
+        });
+    };
+
+    $scope.cancelDeleteOrganization = function () {
+        $scope.closeModal();
+        OrganizationRepo.clearValidationResults();
+    };
+
+    $scope.restoreOrganizationDefaults = function (organization) {
+        OrganizationRepo.restoreDefaults(organization).then(function (data) {
+            if (data.meta.status !== 'INVALID') {
+                $scope.closeModal();
+                $timeout(function () {
+                    AlertService.add(data.meta, 'organization/restore-defaults');
+                }, 300);
+            }
+        });
+    };
+
+    $scope.cancelRestoreOrganizationDefaults = function () {
+        $scope.closeModal();
+        OrganizationRepo.clearValidationResults();
+    };
+
+    $scope.addWorkflowStep = function () {
+        var name = $scope.modalData.name;
+        OrganizationRepo.addWorkflowStep($scope.modalData);
+    };
+
+    $scope.deleteWorkflowStep = function (workflowStep) {
+        OrganizationRepo.deleteWorkflowStep(workflowStep).then(function (resObj) {
+            if (resObj.meta.status === 'SUCCESS') {
+                AccordionService.close(workflowStep.name);
+            }
+        });
+    };
+
+    $scope.updateWorkflowStep = function (workflowStep) {
+        return OrganizationRepo.updateWorkflowStep(workflowStep);
+    };
+
+    $scope.reorderWorkflowStepUp = function (workflowStepID) {
+        AccordionService.closeAll();
+        return OrganizationRepo.reorderWorkflowSteps("up", workflowStepID);
+    };
+
+    $scope.reorderWorkflowStepDown = function (workflowStepID) {
+        AccordionService.closeAll();
+        return OrganizationRepo.reorderWorkflowSteps("down", workflowStepID);
+    };
+
+    $scope.openConfirmDeleteModal = function (step) {
+        $scope.openModal('#workflow-step-delete-confirm-' + step.id);
+    };
+
+    $scope.resetManageOrganization = function (organization) {
+        if (!!organization && !!organization.id) {
+            organization.complete = false;
+            organization.shallow = false;
+            organization.tree = false;
+
+            organization.clearValidationResults();
+            organization.refresh();
+        }
+    };
+
     $scope.ready.then(function () {
-        $scope.resetWorkflowSteps = function () {
-            $scope.organizationRepo.clearValidationResults();
-            for (var key in $scope.forms) {
-                if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
-                    $scope.forms[key].$setPristine();
-                    $scope.forms[key].$setUntouched();
-                }
-            }
-            if ($scope.modalData !== undefined && $scope.modalData.refresh !== undefined) {
-                $scope.modalData.refresh();
-            }
-            $scope.modalData = {
-                overrideable: true
-            };
-            $scope.closeModal();
-        };
-
         $scope.resetWorkflowSteps();
-
-        $scope.showOrganizationManagement = function () {
-            var selectedId = $scope.getSelectedOrganizationId();
-            return !!selectedId && (selectedId !== 1 || (selectedId == 1 && $scope.isAdmin()));
-        };
-
-        $scope.updateOrganization = function (organization) {
-            $scope.updatingOrganization = true;
-            organization.save().then(function () {
-                // update the parent scoped selected organization
-                $scope.setSelectedOrganization(organization);
-                $scope.updatingOrganization = false;
-            });
-        };
-
-        $scope.deleteOrganization = function (organization) {
-            $scope.organizationRepo.deleteById(organization.id).then(function (res) {
-                var apiRes = angular.fromJson(res.body);
-                if (apiRes.meta.status !== 'INVALID') {
-                    $scope.closeModal();
-                    $timeout(function () {
-                        AlertService.add(apiRes.meta, 'organization/delete');
-                    }, 300);
-                } else {
-                    $scope.closeModal();
-                }
-            });
-        };
-
-        $scope.cancelDeleteOrganization = function () {
-            $scope.closeModal();
-            OrganizationRepo.clearValidationResults();
-        };
-
-        $scope.restoreOrganizationDefaults = function (organization) {
-            OrganizationRepo.restoreDefaults(organization).then(function (data) {
-                if (data.meta.status !== 'INVALID') {
-                    $scope.closeModal();
-                    $timeout(function () {
-                        AlertService.add(data.meta, 'organization/restore-defaults');
-                    }, 300);
-                }
-            });
-        };
-
-        $scope.cancelRestoreOrganizationDefaults = function () {
-            $scope.closeModal();
-            OrganizationRepo.clearValidationResults();
-        };
-
-        $scope.addWorkflowStep = function () {
-            var name = $scope.modalData.name;
-            OrganizationRepo.addWorkflowStep($scope.modalData);
-        };
-
-        $scope.deleteWorkflowStep = function (workflowStep) {
-            OrganizationRepo.deleteWorkflowStep(workflowStep).then(function (resObj) {
-                if (resObj.meta.status === 'SUCCESS') {
-                    AccordionService.close(workflowStep.name);
-                }
-            });
-        };
-
-        $scope.updateWorkflowStep = function (workflowStep) {
-            OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
-            return OrganizationRepo.updateWorkflowStep(workflowStep);
-        };
-
-        $scope.reorderWorkflowStepUp = function (workflowStepID) {
-            AccordionService.closeAll();
-            return OrganizationRepo.reorderWorkflowSteps("up", workflowStepID);
-        };
-
-        $scope.reorderWorkflowStepDown = function (workflowStepID) {
-            AccordionService.closeAll();
-            return OrganizationRepo.reorderWorkflowSteps("down", workflowStepID);
-        };
-
-        $scope.openConfirmDeleteModal = function (step) {
-            $scope.openModal('#workflow-step-delete-confirm-' + step.id);
-        };
-
-        $scope.resetManageOrganization = function (organization) {
-            if (!!organization && !!organization.id) {
-                organization.complete = false;
-                organization.shallow = false;
-                organization.tree = false;
-
-                organization.clearValidationResults();
-                organization.refresh();
-            }
-        };
 
         $scope.testBoolean = true;
 

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -125,8 +125,6 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
     $scope.ready.then(function () {
         $scope.resetWorkflowSteps();
 
-        $scope.testBoolean = true;
-
         OrganizationRepo.listen(function () {
             $scope.resetWorkflowSteps();
         });

--- a/src/main/webapp/app/controllers/sidebar/organizationSideBarController.js
+++ b/src/main/webapp/app/controllers/sidebar/organizationSideBarController.js
@@ -4,14 +4,13 @@ vireo.controller("OrganizationSideBarController", function ($controller, $scope,
         $scope: $scope
     }));
 
-    $scope.organizations = OrganizationRepo.getAll();
+    $scope.organizations = [];
 
     $scope.organizationRepo = OrganizationRepo;
 
     var organizationCategories = OrganizationCategoryRepo.getAll();
 
     $scope.ready = $q.all([
-        OrganizationRepo.ready(),
         OrganizationCategoryRepo.ready()
     ]);
 
@@ -44,8 +43,6 @@ vireo.controller("OrganizationSideBarController", function ($controller, $scope,
             }
         };
 
-        $scope.reset();
-
         $scope.createNewOrganization = function (hierarchical) {
             $scope.creatingNewOrganization = true;
             var parentOrganization = hierarchical === 'true' ? OrganizationRepo.newOrganization.parent : $scope.organizations[0];
@@ -63,6 +60,15 @@ vireo.controller("OrganizationSideBarController", function ($controller, $scope,
             });
         };
 
+        OrganizationRepo.getAllSpecific('tree').then(function (orgs) {
+            $scope.organizations.length = 0;
+
+            if (!!orgs && orgs.length > 0) {
+                angular.extend($scope.organizations, orgs);
+            }
+
+            $scope.reset();
+        });
     });
 
 });

--- a/src/main/webapp/app/controllers/sidebar/organizationSideBarController.js
+++ b/src/main/webapp/app/controllers/sidebar/organizationSideBarController.js
@@ -16,59 +16,56 @@ vireo.controller("OrganizationSideBarController", function ($controller, $scope,
 
     $scope.forms = {};
 
-    $scope.ready.then(function () {
+    $scope.organizationCategories = organizationCategories.filter(function (category) {
+        return !!category && category.name !== 'System';
+    });
 
-        $scope.organizationCategories = organizationCategories.filter(function (category) {
-            return category.name !== 'System';
-        });
+    $scope.reset = function () {
+        $scope.organizationRepo.clearValidationResults();
 
-        $scope.reset = function () {
-            $scope.organizationRepo.clearValidationResults();
-
-            for (var key in $scope.forms) {
-                if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
-                    $scope.forms[key].$setPristine();
-                    $scope.forms[key].$setUntouched();
-                }
+        for (var key in $scope.forms) {
+            if ($scope.forms[key] !== undefined && !$scope.forms[key].$pristine) {
+                $scope.forms[key].$setPristine();
+                $scope.forms[key].$setUntouched();
             }
+        }
 
-            $scope.newOrganization = OrganizationRepo.resetNewOrganization();
+        $scope.newOrganization = OrganizationRepo.resetNewOrganization();
 
-            if ($scope.newOrganization.category === undefined) {
-                $scope.newOrganization.category = $scope.organizationCategories[0];
+        if ($scope.newOrganization.category === undefined) {
+            $scope.newOrganization.category = $scope.organizationCategories[0];
+        }
+
+        if ($scope.newOrganization.parent === undefined) {
+            $scope.newOrganization.parent = $scope.organizations[0];
+        }
+    };
+
+    $scope.createNewOrganization = function (hierarchical) {
+        $scope.creatingNewOrganization = true;
+        var parentOrganization = hierarchical === 'true' ? OrganizationRepo.newOrganization.parent : $scope.organizations[0];
+        OrganizationRepo.create({
+            "name": OrganizationRepo.newOrganization.name,
+            "category": OrganizationRepo.newOrganization.category,
+            "parentOrganization": {
+                "id": parentOrganization.id,
+                "name": parentOrganization.name,
+                "category": parentOrganization.category
             }
-
-            if ($scope.newOrganization.parent === undefined) {
-                $scope.newOrganization.parent = $scope.organizations[0];
-            }
-        };
-
-        $scope.createNewOrganization = function (hierarchical) {
-            $scope.creatingNewOrganization = true;
-            var parentOrganization = hierarchical === 'true' ? OrganizationRepo.newOrganization.parent : $scope.organizations[0];
-            OrganizationRepo.create({
-                "name": OrganizationRepo.newOrganization.name,
-                "category": OrganizationRepo.newOrganization.category,
-                "parentOrganization": {
-                    "id": parentOrganization.id,
-                    "name": parentOrganization.name,
-                    "category": parentOrganization.category
-                }
-            }, parentOrganization).then(function () {
-                $scope.creatingNewOrganization = false;
-                $scope.reset();
-            });
-        };
-
-        OrganizationRepo.getAllSpecific('tree').then(function (orgs) {
-            $scope.organizations.length = 0;
-
-            if (!!orgs && orgs.length > 0) {
-                angular.extend($scope.organizations, orgs);
-            }
-
+        }, parentOrganization).then(function () {
+            $scope.creatingNewOrganization = false;
             $scope.reset();
         });
+    };
+
+    OrganizationRepo.getAllSpecific('tree').then(function (orgs) {
+        $scope.organizations.length = 0;
+
+        if (!!orgs && orgs.length > 0) {
+            angular.extend($scope.organizations, orgs);
+        }
+
+        $scope.reset();
     });
 
 });

--- a/src/main/webapp/app/controllers/submission/newSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/newSubmissionController.js
@@ -81,10 +81,8 @@ vireo.controller('NewSubmissionController', function ($controller, $location, $q
             $scope.creatingSubmission = false;
 
             var apiRes = angular.fromJson(response.body);
-            if (apiRes.meta.status === 'SUCCESS') {
-                var submission = new Submission(apiRes.payload.Submission);
-                StudentSubmissionRepo.add(submission);
-                $location.path("/submission/" + submission.id);
+            if (apiRes.meta.status === 'SUCCESS' && !!apiRes.payload.Long) {
+                $location.path("/submission/" + apiRes.payload.Long);
             }
         });
     };

--- a/src/main/webapp/app/controllers/submission/newSubmissionController.js
+++ b/src/main/webapp/app/controllers/submission/newSubmissionController.js
@@ -1,69 +1,117 @@
-vireo.controller('NewSubmissionController', function ($controller, $location, $q, $scope, OrganizationRepo, StudentSubmissionRepo, ManagedConfigurationRepo, SubmissionStates) {
+vireo.controller('NewSubmissionController', function ($controller, $location, $q, $scope, Organization, OrganizationRepo, StudentSubmissionRepo, ManagedConfigurationRepo, Submission, SubmissionStates) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
     }));
 
-    $scope.organizations = OrganizationRepo.getAll();
+    $scope.organizations = [];
 
     $scope.configuration = ManagedConfigurationRepo.getAll();
 
     $scope.studentSubmissions = StudentSubmissionRepo.getAll();
 
-    $scope.ready = false;
+    $scope.selectedOrganization = new Organization({});
 
-    $q.all([OrganizationRepo.ready(), ManagedConfigurationRepo.ready(), StudentSubmissionRepo.ready()]).then(function () {
+    $scope.ready = false;
+    $scope.loadingOrganization = false;
+
+    $scope.getSelectedOrganizationId = function () {
+        if (!!$scope.selectedOrganization && !!$scope.selectedOrganization.id) {
+            return $scope.selectedOrganization.id;
+        }
+    };
+
+    $scope.getSelectedOrganizationName = function () {
+        if ($scope.getSelectedOrganizationId()) {
+            return $scope.selectedOrganization.name;
+        }
+    };
+
+    $scope.getSelectedOrganizationAcceptsSubmissions = function () {
+        if (!!$scope.getSelectedOrganizationId()) {
+            return $scope.selectedOrganization.acceptsSubmissions;
+        }
+    };
+
+    $scope.getSelectedOrganization = function () {
+        return $scope.selectedOrganization;
+    };
+
+    $scope.setSelectedOrganization = function (organization) {
+        $scope.selectedOrganization = new Organization(organization);
+
+        if (!!organization && !!organization.id) {
+            OrganizationRepo.setSelectedOrganization(organization);
+        }
+    };
+
+    $scope.hasSubmission = function (organization) {
+        var hasSubmission = false;
+        for (var i in $scope.studentSubmissions) {
+            var submission = $scope.studentSubmissions[i];
+            if (!!organization && submission.organization.id === organization.id) {
+                hasSubmission = true;
+                break;
+            }
+        }
+        return hasSubmission;
+    };
+
+    $scope.gotoSubmission = function (organization) {
+        for (var i in $scope.studentSubmissions) {
+            var submission = $scope.studentSubmissions[i];
+            if (!!organization && submission.organization.id === organization.id) {
+                if (submission.submissionStatus.submissionState === SubmissionStates.IN_PROGRESS) {
+                    $location.path("/submission/" + submission.id);
+                } else {
+                    $location.path("/submission/" + submission.id + "/view");
+                }
+            }
+        }
+    };
+
+    $scope.createSubmission = function () {
+        $scope.creatingSubmission = true;
+
+        var sub = {
+            'organizationId': $scope.getSelectedOrganizationId()
+        };
+
+        StudentSubmissionRepo.create(sub).then(function (response) {
+            $scope.creatingSubmission = false;
+
+            var apiRes = angular.fromJson(response.body);
+            if (apiRes.meta.status === 'SUCCESS') {
+                var submission = new Submission(apiRes.payload.Submission);
+                StudentSubmissionRepo.add(submission);
+                $location.path("/submission/" + submission.id);
+            }
+        });
+    };
+
+    $scope.rebuildOrganizationTree = function () {
+        return $q(function (resolve, reject) {
+            OrganizationRepo.getAllSpecific('tree').then(function (orgs) {
+                $scope.organizations.length = 0;
+                angular.extend($scope.organizations, orgs);
+
+                resolve();
+            }).catch(function(reason) {
+                reject(reason);
+            });
+        });
+    };
+
+    OrganizationRepo.getAllSpecific('tree').then(function (orgs) {
+        $scope.organizations.length = 0;
+
+        if (!!orgs && orgs.length > 0) {
+            $scope.setSelectedOrganization(new Organization(orgs[0]));
+
+            angular.extend($scope.organizations, orgs);
+        }
 
         $scope.ready = true;
-
-        $scope.getSelectedOrganization = function () {
-            return OrganizationRepo.getSelectedOrganization();
-        };
-
-        $scope.setSelectedOrganization = function (organization) {
-            OrganizationRepo.setSelectedOrganization(organization);
-        };
-
-        $scope.hasSubmission = function (organization) {
-            var hasSubmission = false;
-            for (var i in $scope.studentSubmissions) {
-                var submission = $scope.studentSubmissions[i];
-                if (submission.organization.id === organization.id) {
-                    hasSubmission = true;
-                    break;
-                }
-            }
-            return hasSubmission;
-        };
-
-        $scope.gotoSubmission = function (organization) {
-            for (var i in $scope.studentSubmissions) {
-                var submission = $scope.studentSubmissions[i];
-                if (submission.organization.id === organization.id) {
-                    if (submission.submissionStatus.submissionState === SubmissionStates.IN_PROGRESS) {
-                        $location.path("/submission/" + submission.id);
-                    } else {
-                        $location.path("/submission/" + submission.id + "/view");
-                    }
-                }
-            }
-        };
-
-        $scope.createSubmission = function () {
-            $scope.creatingSubmission = true;
-            StudentSubmissionRepo.create({
-                'organizationId': $scope.getSelectedOrganization().id
-            }).then(function (response) {
-                $scope.creatingSubmission = false;
-                var apiRes = angular.fromJson(response.body);
-                if (apiRes.meta.status === 'SUCCESS') {
-                    var submission = apiRes.payload.Submission;
-                    StudentSubmissionRepo.add(submission);
-                    $location.path("/submission/" + submission.id);
-                }
-            });
-        };
-
     });
 
 });

--- a/src/main/webapp/app/model/organization.js
+++ b/src/main/webapp/app/model/organization.js
@@ -26,45 +26,6 @@ vireo.model("Organization", function Organization($q, WsApi, InputTypes, EmailRe
         }
       ];
 
-      organization.addEmailWorkflowRule = function (templateId, recipient, submissionStatusId) {
-            angular.extend(apiMapping.Organization.addEmailWorkflowRule, {
-                'method': organization.id + "/add-email-workflow-rule",
-                'data': {
-                    templateId: templateId,
-                    recipient: recipient,
-                    submissionStatusId: submissionStatusId
-                }
-            });
-
-            var promise = WsApi.fetch(apiMapping.Organization.addEmailWorkflowRule);
-
-            return promise;
-        };
-
-        organization.removeEmailWorkflowRule = function (rule) {
-            angular.extend(apiMapping.Organization.removeEmailWorkflowRule, {
-                'method': organization.id + "/remove-email-workflow-rule/" + rule.id,
-            });
-
-            var promise = WsApi.fetch(apiMapping.Organization.removeEmailWorkflowRule);
-
-            return promise;
-        };
-
-        organization.editEmailWorkflowRule = function (rule) {
-            angular.extend(apiMapping.Organization.editEmailWorkflowRule, {
-                'method': organization.id + "/edit-email-workflow-rule/" + rule.id,
-                'data': {
-                    templateId: rule.emailTemplate.id,
-                    recipient: rule.emailRecipient
-                }
-            });
-
-            var promise = WsApi.fetch(apiMapping.Organization.editEmailWorkflowRule);
-
-            return promise;
-        };
-
         organization.getWorkflowEmailContacts = function() {
           var recipientInputTypes = [
             InputTypes.INPUT_CONTACT,
@@ -86,15 +47,6 @@ vireo.model("Organization", function Organization($q, WsApi, InputTypes, EmailRe
           });
 
           return angular.copy(organization.defaultRecipients).concat(dynamicRecipients);
-        };
-
-        organization.changeEmailWorkflowRuleActivation = function (rule) {
-            angular.extend(apiMapping.Organization.changeEmailWorkflowRuleActivation, {
-                'method': organization.id + "/change-email-workflow-rule-activation/" + rule.id,
-            });
-            var promise = WsApi.fetch(apiMapping.Organization.changeEmailWorkflowRuleActivation);
-
-            return promise;
         };
 
         return organization;

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -674,7 +674,9 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
                         // Some browsers, like Firefox, do not support 'MMMM yyyy' formats for Date.parse().
                         if (isNaN(stamp) && predicate.format == 'MMMM yyyy') {
                             var split = fieldValue.value.match(/^(\S+) (\d+)$/);
-                            stamp = Date.parse(split[1] + ' 01, ' + split[2]);
+                            if (!!split && split.length > 1) {
+                                stamp = Date.parse(split[1] + ' 01, ' + split[2]);
+                            }
                         }
 
                         if (isNaN(stamp)) {

--- a/src/main/webapp/app/repo/organizationRepo.js
+++ b/src/main/webapp/app/repo/organizationRepo.js
@@ -5,17 +5,54 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
     var selectiveListenCallbacks = [];
 
     var selectedId;
+    var selectedOrganization;
 
     // additional repo methods and variables
 
     this.newOrganization = {};
 
-    this.ready().then(function () {
-        var organizations = organizationRepo.getAll();
-        if (selectedId === undefined && organizations.length > 0) {
-            organizationRepo.setSelectedOrganization(organizations[0]);
+    /**
+     * Get the organization using a specific method, such as "tree" or "shallow".
+     *
+     * This does not create a new Organization() model for each organization.
+     *
+     * This returns a promise.
+     */
+    this.getAllSpecific = function (specific) {
+        var endpoint = angular.copy(this.mapping.all);
+
+        if (specific == 'tree') {
+            endpoint.method = 'all/tree';
+        } else if (specific == 'shallow') {
+            endpoint.method = 'all/shallow';
         }
-    });
+
+        return $q(function (resolve, reject) {
+            WsApi.fetch(endpoint).then(function (res) {
+                var apiRes = angular.fromJson(res.body);
+
+                if (apiRes.meta.status === 'SUCCESS') {
+                    var keys = Object.keys(apiRes.payload);
+
+                    if (specific == 'tree') {
+                        apiRes.payload[keys[0]].shallow = false;
+                        apiRes.payload[keys[0]].tree = true;
+                    } else if (specific == 'shallow') {
+                        apiRes.payload[keys[0]].shallow = true;
+                        apiRes.payload[keys[0]].tree = false;
+                    }
+
+                    if (keys.length) {
+                        resolve(apiRes.payload[keys[0]]);
+                    } else {
+                        reject(apiRes.meta);
+                    }
+                } else {
+                    reject(apiRes.meta);
+                }
+            });
+        }.bind(this));
+    };
 
     this.create = function (organization, parentOrganization) {
         organizationRepo.clearValidationResults();
@@ -47,31 +84,81 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
     };
 
     this.getSelectedOrganization = function () {
-        return organizationRepo.findById(selectedId);
+        var organization = organizationRepo.findById(selectedId);
+
+        if (!!organization) {
+            selectedOrganization = selectedOrganization;
+        }
+
+        return organization;
+    };
+
+    this.getSelectedOrganizationId = function () {
+        return selectedId;
+    };
+
+    /**
+     * Perform the actual request to the back-end to get the organization by the given ID.
+     *
+     * If specific is passed, then use the given specific variation when querying the back-end.
+     *
+     * This returns a promise.
+     */
+    this.getById = function (id, specific) {
+        var extra = '';
+        var endpoint = angular.copy(this.mapping.get);
+
+        if (specific === 'shallow') {
+            extra = '/shallow';
+        } else if (specific === 'tree') {
+            extra = '/tree';
+        }
+
+        endpoint.method = 'get/' + id + extra;
+
+        return $q(function (resolve, reject) {
+            WsApi.fetch(endpoint).then(function (res) {
+                var apiRes = angular.fromJson(res.body);
+
+                if (apiRes.meta.status === 'SUCCESS') {
+                    var keys = Object.keys(apiRes.payload);
+
+                    if (keys.length) {
+                        var organization = new Organization(apiRes.payload[keys[0]]);
+                        organization.shallow = false;
+                        organization.tree = false;
+
+                        if (specific === 'shallow') {
+                            organization.shallow = true;
+                        } else if (specific === 'tree') {
+                            organization.tree = true;
+                        }
+
+                        resolve(organization, specific);
+                    } else {
+                        reject(apiRes.meta);
+                    }
+                } else {
+                    reject(apiRes.meta);
+                }
+            });
+        }.bind(this));
     };
 
     this.setSelectedOrganization = function (organization) {
-        selectedId = organization.id;
-        organization = organizationRepo.getSelectedOrganization();
-        if(!organization.complete) {
-            organization.updateRequested = true;
-            angular.extend(this.mapping.get, {
-                'method': 'get/' + organization.id
-            });
-            WsApi.fetch(this.mapping.get).then(function (res) {
-                var apiRes = angular.fromJson(res.body);
-                if (apiRes.meta.status === "SUCCESS") {
-                    angular.extend(organization, apiRes.payload.Organization);
-                }
-            });
+        if (!!organization && !!organization.id) {
+            selectedOrganization = organization;
+            selectedId = organization.id;
+        } else {
+            selectedOrganization = undefined;
+            selectedId = undefined;
         }
-        return organization;
     };
 
     this.addWorkflowStep = function (workflowStep) {
         organizationRepo.clearValidationResults();
         angular.extend(this.mapping.addWorkflowStep, {
-            'method': this.getSelectedOrganization().id + '/create-workflow-step',
+            'method': selectedId + '/create-workflow-step',
             'data': workflowStep
         });
         var promise = WsApi.fetch(this.mapping.addWorkflowStep);
@@ -100,7 +187,7 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
     this.updateWorkflowStep = function (workflowStep) {
         organizationRepo.clearValidationResults();
         angular.extend(this.mapping.updateWorkflowStep, {
-            'method': this.getSelectedOrganization().id + '/update-workflow-step',
+            'method': selectedId + '/update-workflow-step',
             'data': workflowStep
         });
         var promise = RestApi.post(this.mapping.updateWorkflowStep);
@@ -115,7 +202,7 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
     this.deleteWorkflowStep = function (workflowStep) {
         organizationRepo.clearValidationResults();
         angular.extend(this.mapping.deleteWorkflowStep, {
-            'method': this.getSelectedOrganization().id + '/delete-workflow-step',
+            'method': selectedId + '/delete-workflow-step',
             'data': workflowStep
         });
         var promise = RestApi.post(this.mapping.deleteWorkflowStep);
@@ -140,7 +227,7 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
     this.reorderWorkflowSteps = function (upOrDown, workflowStepID) {
         organizationRepo.clearValidationResults();
         angular.extend(this.mapping.reorderWorkflowStep, {
-            'method': this.getSelectedOrganization().id + '/shift-workflow-step-' + upOrDown + '/' + workflowStepID
+            'method': selectedId + '/shift-workflow-step-' + upOrDown + '/' + workflowStepID
         });
         var promise = WsApi.fetch(this.mapping.reorderWorkflowStep);
         promise.then(function (res) {
@@ -167,6 +254,47 @@ vireo.repo("OrganizationRepo", function OrganizationRepo($q, Organization, RestA
             });
         }.bind(this));
         return defer;
+    };
+
+    this.addEmailWorkflowRule = function (organization, templateId, recipient, submissionStatusId) {
+        angular.extend(apiMapping.Organization.addEmailWorkflowRule, {
+            'method': organization.id + "/add-email-workflow-rule",
+            'data': {
+                templateId: templateId,
+                recipient: recipient,
+                submissionStatusId: submissionStatusId
+            }
+        });
+
+        return WsApi.fetch(apiMapping.Organization.addEmailWorkflowRule);
+    };
+
+    this.removeEmailWorkflowRule = function (organization, rule) {
+        angular.extend(apiMapping.Organization.removeEmailWorkflowRule, {
+            'method': organization.id + "/remove-email-workflow-rule/" + rule.id,
+        });
+
+        return WsApi.fetch(apiMapping.Organization.removeEmailWorkflowRule);
+    };
+
+    this.editEmailWorkflowRule = function (organization, rule) {
+        angular.extend(apiMapping.Organization.editEmailWorkflowRule, {
+            'method': organization.id + "/edit-email-workflow-rule/" + rule.id,
+            'data': {
+                templateId: rule.emailTemplate.id,
+                recipient: rule.emailRecipient
+            }
+        });
+
+        return WsApi.fetch(apiMapping.Organization.editEmailWorkflowRule);
+    };
+
+    this.changeEmailWorkflowRuleActivation = function (organization, rule) {
+        angular.extend(apiMapping.Organization.changeEmailWorkflowRuleActivation, {
+            'method': organization.id + "/change-email-workflow-rule-activation/" + rule.id,
+        });
+
+        return WsApi.fetch(apiMapping.Organization.changeEmailWorkflowRuleActivation);
     };
 
     return this;

--- a/src/main/webapp/app/repo/workflowStepRepo.js
+++ b/src/main/webapp/app/repo/workflowStepRepo.js
@@ -1,4 +1,4 @@
-vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestApi, WsApi) {
+vireo.repo("WorkflowStepRepo", function WorkflowStepRepo(OrganizationRepo, RestApi, WsApi) {
 
     var workflowStepRepo = this;
 
@@ -6,10 +6,10 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.addFieldProfile = function (workflowStep, fieldProfile) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         fieldProfile.originatingWorkflowStep = workflowStep.id;
         angular.extend(this.mapping.addFieldProfile, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/add-field-profile',
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/add-field-profile',
             'data': fieldProfile
         });
         var promise = RestApi.post(this.mapping.addFieldProfile);
@@ -23,10 +23,10 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.updateFieldProfile = function (workflowStep, fieldProfile) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         fieldProfile.originatingWorkflowStep = workflowStep.id;
         angular.extend(this.mapping.updateFieldProfile, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/update-field-profile',
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/update-field-profile',
             'data': fieldProfile
         });
         var promise = RestApi.post(this.mapping.updateFieldProfile);
@@ -40,10 +40,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.removeFieldProfile = function (workflowStep, fieldProfile) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
 
         var endpoint = angular.copy(this.mapping.removeFieldProfile);
-        endpoint.method = OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-field-profile/' + fieldProfile.id;
+        endpoint.method = OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/remove-field-profile/' + fieldProfile.id;
         endpoint.data = ''; // Provide empty data to force this to be a POST
 
         return WsApi.fetch(endpoint);
@@ -51,9 +50,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.reorderFieldProfiles = function (workflowStep, src, dest) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         angular.extend(this.mapping.reorderFieldProfile, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/reorder-field-profiles/' + src + '/' + dest
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/reorder-field-profiles/' + src + '/' + dest
         });
         var promise = WsApi.fetch(this.mapping.reorderFieldProfile);
         promise.then(function (res) {
@@ -67,9 +66,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.addNote = function (workflowStep, note) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         angular.extend(this.mapping.addNote, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/add-note',
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/add-note',
             'data': note
         });
         var promise = WsApi.fetch(this.mapping.addNote);
@@ -83,9 +82,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.updateNote = function (workflowStep, note) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         angular.extend(this.mapping.updateNote, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/update-note',
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/update-note',
             'data': note
         });
         var promise = WsApi.fetch(this.mapping.updateNote);
@@ -99,8 +98,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.removeNote = function (workflowStep, note) {
         workflowStepRepo.clearValidationResults();
+
         angular.extend(this.mapping.removeNote, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/remove-note',
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/remove-note',
             'data': note
         });
         var promise = WsApi.fetch(this.mapping.removeNote);
@@ -114,9 +114,9 @@ vireo.repo("WorkflowStepRepo", function WorkfloStepRepo(OrganizationRepo, RestAp
 
     this.reorderNotes = function (workflowStep, src, dest) {
         workflowStepRepo.clearValidationResults();
-        OrganizationRepo.setToUpdate(workflowStep.originatingOrganization);
+
         angular.extend(this.mapping.reorderNote, {
-            'method': OrganizationRepo.getSelectedOrganization().id + '/' + workflowStep.id + '/reorder-notes/' + src + '/' + dest
+            'method': OrganizationRepo.getSelectedOrganizationId() + '/' + workflowStep.id + '/reorder-notes/' + src + '/' + dest
         });
         var promise = WsApi.fetch(this.mapping.reorderNote);
         promise.then(function (res) {

--- a/src/main/webapp/app/views/admin/settings/organization.html
+++ b/src/main/webapp/app/views/admin/settings/organization.html
@@ -1,52 +1,52 @@
 <div class="admin-settings" ng-controller="OrganizationSettingsController">
 
-	<validationmessage results="organizationRepo.ValidationResults"></validationmessage>
-	
-	<div class="row">
-		<triptych header="ORGANIZATIONS AND WORKFLOWS" managed="true" expcol="false"></triptych>
-	</div>
+    <validationmessage results="organizationRepo.ValidationResults"></validationmessage>
 
-	<div class="row">
-		<div id="organizationManagement" class="col-xs-12" ng-controller="OrganizationManagementController">
-			<div class="row" ng-show="showOrganizationManagement()">
-				<div class="panel-heading">
-					<h3 class="panel-title">
-						<ul class="inline-list">
-							<li ng-click="activateManagementPane('edit')">
-								<span	class="management-pane-selector"
-										ng-class="{active: managementPaneIsActive('edit')}"
-										ng-click="activateManagementPane('edit')" >
-										<span class="context-icons glyphicon glyphicon-cog" ng-class="{'active': managementPaneIsActive('edit')}"></span> Manage Organization
-								</span>
-							</li>
-							<li ng-click="activateManagementPane('workflow')">
-								<span	class="management-pane-selector"
-										ng-click="activateManagementPane('workflow')"
-										ng-class="{active: managementPaneIsActive('workflow')}">
-										<span class="context-icons glyphicon glyphicon-list-alt" ng-class="{'active': managementPaneIsActive('workflow')}"></span> Manage Workflow
-								</span>
-							</li>
-							<li ng-click="activateManagementPane('email')">
-								<span	class="management-pane-selector"
-										ng-click="activateManagementPane('email')"
-										ng-class="{active: managementPaneIsActive('email')}">
-										<span class="context-icons glyphicon glyphicon-envelope" ng-class="{'active': managementPaneIsActive('email')}"></span> Email Workflow Rules
-								</span>
-							</li>
-						</ul>
-					</h3>
-				</div>
-				<div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('edit')}">
-					<span ng-include="'views/admin/settings/organization/manageOrganization.html'">
-				</div>
-				<div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('workflow')}">
-					<span ng-include="'views/admin/settings/organization/manageWorkflow.html'">
-				</div>
-				<div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('email')}">
-					<span ng-include="'views/admin/settings/organization/emailWorkflowRules.html'">
-				</div>
-			</div>
-		</div>
-	</div>
+    <div class="row">
+        <triptych header="ORGANIZATIONS AND WORKFLOWS" managed="true" expcol="false"></triptych>
+    </div>
+
+    <div class="row">
+        <div id="organizationManagement" class="col-xs-12" ng-controller="OrganizationManagementController">
+            <div class="row" ng-show="showOrganizationManagement()">
+                <div class="panel-heading">
+                    <h3 class="panel-title">
+                        <ul class="inline-list">
+                            <li ng-click="activateManagementPane('edit')">
+                                <span   class="management-pane-selector"
+                                        ng-class="{active: managementPaneIsActive('edit')}"
+                                        ng-click="activateManagementPane('edit')" >
+                                        <span class="context-icons glyphicon glyphicon-cog" ng-class="{'active': managementPaneIsActive('edit')}"></span> Manage Organization
+                                </span>
+                            </li>
+                            <li ng-click="activateManagementPane('workflow')">
+                                <span   class="management-pane-selector"
+                                        ng-click="activateManagementPane('workflow')"
+                                        ng-class="{active: managementPaneIsActive('workflow')}">
+                                        <span class="context-icons glyphicon glyphicon-list-alt" ng-class="{'active': managementPaneIsActive('workflow')}"></span> Manage Workflow
+                                </span>
+                            </li>
+                            <li ng-click="activateManagementPane('email')">
+                                <span   class="management-pane-selector"
+                                        ng-click="activateManagementPane('email')"
+                                        ng-class="{active: managementPaneIsActive('email')}">
+                                        <span class="context-icons glyphicon glyphicon-envelope" ng-class="{'active': managementPaneIsActive('email')}"></span> Email Workflow Rules
+                                </span>
+                            </li>
+                        </ul>
+                    </h3>
+                </div>
+                <div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('edit')}">
+                    <span ng-include="'views/admin/settings/organization/manageOrganization.html'">
+                </div>
+                <div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('workflow')}">
+                    <span ng-include="'views/admin/settings/organization/manageWorkflow.html'">
+                </div>
+                <div class="col-xs-12 panel-wrap" ng-class="{active: managementPaneIsActive('email')}">
+                    <span ng-include="'views/admin/settings/organization/emailWorkflowRules.html'">
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 

--- a/src/main/webapp/app/views/admin/settings/organization/emailWorkflowRule.html
+++ b/src/main/webapp/app/views/admin/settings/organization/emailWorkflowRule.html
@@ -1,53 +1,53 @@
 <button class="btn btn-default" ng-click="openAddEmailWorkflowRuleModal('#createEmailWorkflowRule'+status.name.split(' ').join(''))">Add Rule</button>
 
 <div class="table-responsive">
-  	<table class="table table-hover table-striped">
-		<thead>
-			<tr>
-				<th></th>
-				<th>Email template</th>
-				<th>Recipient</th>
-				<th>Is System Required?</th>
-				<th></th>
-				<th>
-					<span class="glyphicon glyphicon-play"></span>/
-					<span class="glyphicon glyphicon-pause"></span>
-				</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr ng-if="rule.submissionStatus === status.id" ng-repeat="rule in getSelectedOrganization().emailWorkflowRules" class="email-workflow-rule-row">
-				<td ng-click="openEditEmailWorkflowRule(rule)">
-					<span class="glyphicon glyphicon-pencil"></span>
-				</td>
-				<td ng-click="openEditEmailWorkflowRule(rule)">
-					{{rule.emailTemplate.name}}
-				</td>
-				<td ng-click="openEditEmailWorkflowRule(rule)">
-					{{rule.emailRecipient.name}}
-				</td>
-				<td ng-click="openEditEmailWorkflowRule(rule)">
-					{{rule.isSystem}}
-				</td>
-				<span>
-					<td ng-click="confirmEmailWorkflowRuleDelete(rule);">
-						<span ng-if="rule.emailWorkflowRuleDeleteWorking && !(rule.isSystem) " class="glyphicon glyphicon-refresh spinning"></span>
-						<span ng-if="!rule.emailWorkflowRuleDeleteWorking && !(rule.isSystem)" class="glyphicon glyphicon-trash"></span>
-					</td>
-				</span>
-				<td ng-click="changeEmailWorkflowRuleActivationWorking=true;changeEmailWorkflowRuleActivation(rule, changeEmailWorkflowRuleActivationWorking);">
-					<span ng-if="changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-refresh spinning"></span>
-					<span ng-if="!rule.isDisabled && !changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-pause"></span>
-					<span ng-if="rule.isDisabled && !changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-play"></span>
-				</td>
-			</tr>
-		</tbody>
-  	</table>
+    <table class="table table-hover table-striped">
+        <thead>
+            <tr>
+                <th></th>
+                <th>Email template</th>
+                <th>Recipient</th>
+                <th>Is System Required?</th>
+                <th></th>
+                <th>
+                    <span class="glyphicon glyphicon-play"></span>/
+                    <span class="glyphicon glyphicon-pause"></span>
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr ng-if="rule.submissionStatus === status.id" ng-repeat="rule in getSelectedOrganizationEmailWorkflowRules()" class="email-workflow-rule-row">
+                <td ng-click="openEditEmailWorkflowRule(rule)">
+                    <span class="glyphicon glyphicon-pencil"></span>
+                </td>
+                <td ng-click="openEditEmailWorkflowRule(rule)">
+                    {{rule.emailTemplate.name}}
+                </td>
+                <td ng-click="openEditEmailWorkflowRule(rule)">
+                    {{rule.emailRecipient.name}}
+                </td>
+                <td ng-click="openEditEmailWorkflowRule(rule)">
+                    {{rule.isSystem}}
+                </td>
+                <span>
+                    <td ng-click="confirmEmailWorkflowRuleDelete(rule);">
+                        <span ng-if="rule.emailWorkflowRuleDeleteWorking && !(rule.isSystem) " class="glyphicon glyphicon-refresh spinning"></span>
+                        <span ng-if="!rule.emailWorkflowRuleDeleteWorking && !(rule.isSystem)" class="glyphicon glyphicon-trash"></span>
+                    </td>
+                </span>
+                <td ng-click="changeEmailWorkflowRuleActivationWorking=true; changeEmailWorkflowRuleActivation(rule, changeEmailWorkflowRuleActivationWorking);">
+                    <span ng-if="changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-refresh spinning"></span>
+                    <span ng-if="!rule.isDisabled && !changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-pause"></span>
+                    <span ng-if="rule.isDisabled && !changeEmailWorkflowRuleActivationWorking" class="glyphicon glyphicon-play"></span>
+                </td>
+            </tr>
+        </tbody>
+    </table>
 </div>
 
 <modal
-	modal-id="createEmailWorkflowRule{{status.name.split(' ').join('')}}"
-	modal-view="views/modals/organization/emailWorkflowRuleCreate.html"
-	modal-header-class="modal-header-primary"
-	wvr-modal-backdrop="static">
+    modal-id="createEmailWorkflowRule{{status.name.split(' ').join('')}}"
+    modal-view="views/modals/organization/emailWorkflowRuleCreate.html"
+    modal-header-class="modal-header-primary"
+    wvr-modal-backdrop="static">
 </modal>

--- a/src/main/webapp/app/views/admin/settings/organization/emailWorkflowRules.html
+++ b/src/main/webapp/app/views/admin/settings/organization/emailWorkflowRules.html
@@ -1,27 +1,25 @@
 <div class="panel panel-default" ng-controller="EmailWorkflowRulesController">
-	<div class="panel-heading">
-		<h3 class="panel-title">
-		Manage {{getSelectedOrganization().name}} Email Workflow Rules</h3>
-	</div>
-	<div class="panel-body">
+    <div class="panel-heading">
+        <h3 class="panel-title">
+        Manage {{getSelectedOrganizationName()}} Email Workflow Rules</h3>
+    </div>
+    <div class="panel-body">
+        <vireo-accordion single-expand="false">
+            <vireo-pane ng-repeat="status in submissionStatuses" query="email-workflowstep-rules-{{status.name}}" html="views/admin/settings/organization/emailWorkflowRule.html">{{status.name}}</vireo-pane>
+        </vireo-accordion>
 
-		<vireo-accordion single-expand="false">
-			<vireo-pane ng-repeat="status in submissionStatuses" query="email-workflowstep-rules-{{status.name}}" html="views/admin/settings/organization/emailWorkflowRule.html">{{status.name}}</vireo-pane>
-		</vireo-accordion>
+        <modal
+            modal-id="editEmailWorkflowRule"
+            modal-view="views/modals/organization/emailWorkflowRuleEdit.html"
+            modal-header-class="modal-header-primary"
+            wvr-modal-backdrop="static">
+        </modal>
 
-		<modal
-			modal-id="editEmailWorkflowRule"
-			modal-view="views/modals/organization/emailWorkflowRuleEdit.html"
-			modal-header-class="modal-header-primary"
-			wvr-modal-backdrop="static">
-		</modal>
-
-		<modal
-			modal-id="confirmEmailWorkflowRuleDelete"
-			modal-view="views/modals/organization/emailWorkflowRuleDelete.html"
-			modal-header-class="modal-header-danger"
-			wvr-modal-backdrop="static">
-		</modal>
-
-	</div>
+        <modal
+            modal-id="confirmEmailWorkflowRuleDelete"
+            modal-view="views/modals/organization/emailWorkflowRuleDelete.html"
+            modal-header-class="modal-header-danger"
+            wvr-modal-backdrop="static">
+        </modal>
+    </div>
 </div>

--- a/src/main/webapp/app/views/admin/settings/organization/manageOrganization.html
+++ b/src/main/webapp/app/views/admin/settings/organization/manageOrganization.html
@@ -1,95 +1,87 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">Manage {{getSelectedOrganization().name}}</h3>
+    <h3 class="panel-title">Manage {{getSelectedOrganizationName()}}</h3>
   </div>
 
   <div class="panel-body">
-
     <alerts seconds="45" channels="organization/update, organization/delete" types="SUCCESS, INVALID"></alerts>
 
     <form ng-submit="updateOrganization(getSelectedOrganization())" name="forms.update" novalidate>
+        <validationmessage results="getSelectedOrganizationValidationResults()"></validationmessage>
 
-      <validationmessage results="getSelectedOrganization().getValidationResults()"></validationmessage>
+        <div class="col-md-12">
+            <div class="row">
+                <div class="col-xs-6">
+                    <validatedinput
+                      no-id="true"
+                      label="Organization Name"
+                      model="getSelectedOrganization()"
+                      property="name"
+                      form="forms.update"
+                      validations="getSelectedOrganizationValidations()"
+                      results="getSelectedOrganizationValidationResults()">
+                    </validatedinput>
 
-      <div class="col-md-12">
-        <div class="row">
-          <div class="col-xs-6">
+                    <validatedselect
+                      no-id="true"
+                      label="Category"
+                      options="organizationCategories"
+                      optionproperty="name"
+                      model="getSelectedOrganization()"
+                      property="category"
+                      form="forms.update"
+                      validations="getSelectedOrganizationValidations()"
+                      results="getSelectedOrganizationValidationResults()">
+                    </validatedselect>
 
-            <validatedinput
-              no-id="true"
-              label="Organization Name"
-              model="getSelectedOrganization()"
-              property="name"
-              form="forms.update"
-              validations="getSelectedOrganization().getValidations()"
-              results="getSelectedOrganization().getValidationResults()">
-            </validatedinput>
+                    <toggleButton
+                      label="Organization accepts Submissions?"
+                      scope-value="getSelectedOrganization().acceptsSubmissions"
+                      toggle-options="{{acceptsSubmissions}}">
+                    </toggleButton>
+                </div>
 
-            <validatedselect
-              no-id="true"
-              label="Category"
-              options="organizationCategories"
-              optionproperty="name"
-              model="getSelectedOrganization()"
-              property="category"
-              form="forms.update"
-              validations="getSelectedOrganization().getValidations()"
-              results="getSelectedOrganization().getValidationResults()">
-            </validatedselect>
+                <div class="col-xs-6">
+                    <validatedinput
+                      no-id="true"
+                      label="Email Contact"
+                      model="getSelectedOrganization()"
+                      property="emails"
+                      form="forms.update"
+                      validations="getSelectedOrganizationValidations()"
+                      results="getSelectedOrganizationValidationResults()"
+                      repeatable="true">
+                    </validatedinput>
+                </div>
+            </div>
 
-            <toggleButton
-              label="Organization accepts Submissions?"
-              scope-value="organizationRepo.getSelectedOrganization().acceptsSubmissions"
-              toggle-options="{{acceptsSubmissions}}">
-            </toggleButton>
+            <hr />
 
-          </div>
-
-          <div class="col-xs-6">
-
-            <validatedinput
-              no-id="true"
-              label="Email Contact"
-              model="getSelectedOrganization()"
-              property="emails"
-              form="forms.update"
-              validations="getSelectedOrganization().getValidations()"
-              results="getSelectedOrganization().getValidationResults()"
-              repeatable="true">
-            </validatedinput>
-
-          </div>
+            <div class="row">
+                <div class="pull-right">
+                  <span uib-popover="This organization contains submissions and cannot be deleted." popover-trigger="'mouseenter'" popover-enable="deleteDisabled">
+                    <button
+                      ng-if="getSelectedOrganizationId() !== 1"
+                      type="button"
+                      class="btn btn-danger"
+                      ng-style="{'pointer-events':deleteDisabled ? 'none' : ''}"
+                      ng-disabled="deleteDisabled || loadingOrganization"
+                      ng-click="openModal('#organizationConfirmDeleteModal')">Delete Organization</button>
+                  </span>
+                  <button
+                    type="button"
+                    class="btn btn-default"
+                    ng-click="resetManageOrganization(getSelectedOrganization())"
+                    ng-disabled="updatingOrganization || loadingOrganization">Cancel</button>
+                  <button
+                    type="submit"
+                    class="btn btn-primary"
+                    ng-disabled="forms.update.$invalid || updatingOrganization">Save
+                    <span ng-if="updatingOrganization" class="glyphicon glyphicon-refresh spinning"></span>
+                  </button>
+                </div>
+            </div>
         </div>
-
-        <hr />
-
-        <div class="row">
-          <div class="pull-right">
-            <span uib-popover="This organization contains submissions and cannot be deleted." popover-trigger="'mouseenter'" popover-enable="deleteDisabled">
-              <button
-                ng-if="getSelectedOrganization().id !== 1"
-                type="button"
-                class="btn btn-danger"
-                ng-style="{'pointer-events':deleteDisabled ? 'none' : ''}"
-                ng-disabled="deleteDisabled"
-                ng-click="openModal('#organizationConfirmDeleteModal')">Delete Organization</button>
-            </span>
-            <button
-              type="button"
-              class="btn btn-default"
-              ng-click="resetManageOrganization()"
-              ng-disabled="updatingOrganization">Cancel</button>
-            <button
-              type="submit"
-              class="btn btn-primary"
-              ng-disabled="forms.update.$invalid || updatingOrganization">Save
-              <span ng-if="updatingOrganization" class="glyphicon glyphicon-refresh spinning"></span>
-            </button>
-          </div>
-        </div>
-
-      </div>
-
     </form>
 
     <modal modal-id="organizationConfirmDeleteModal"

--- a/src/main/webapp/app/views/admin/settings/organization/manageWorkflow.html
+++ b/src/main/webapp/app/views/admin/settings/organization/manageWorkflow.html
@@ -1,44 +1,41 @@
 <div class="panel panel-default">
-	<div class="panel-heading">
-    <h3 class="panel-title">Manage {{getSelectedOrganization().name}} Workflow</h3>
-	</div>
-	<div class="panel-body">
-
-    <div class="col-md-12">
-
-      <button class="btn btn-default modal-add-btn" ng-click="openModal('#addWorkflowStepModal')">
-        Add Workflow Step
-      </button>
-      <div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new workflow step."></div>
-      <modal
-        modal-id="addWorkflowStepModal"
-        modal-view="views/modals/organization/workflowStepCreateModal.html"
-        modal-header-class="modal-header-primary"
-        wvr-modal-backdrop="static">
-      </modal>
-      <vireo-accordion single-expand="false">
-        <vireo-pane ng-repeat="step in getSelectedOrganization().aggregateWorkflowSteps track by $index" bar-view="views/admin/settings/organization/workflowsteps/workflowStep.html" query="{{step.name}}" html="views/admin/settings/organization/workflowsteps/workflowStepContent.html">{{$index+1}}. {{step.name}}</vireo-pane>
-      </vireo-accordion>
-
-      <hr />
-
-      <div class="row">
-        <div class="pull-right">
-          <button
-            ng-if="getSelectedOrganization().id !== 1"
-            type="button"
-            class="btn btn-warning"
-            ng-click="openModal('#organizationConfirmRestoreDefaultsModal')">Sync with Parent</button>
-        </div>
-      </div>
-
-      <modal
-        modal-id="organizationConfirmRestoreDefaultsModal"
-        modal-view="views/modals/organization/organizationConfirmRestoreDefaultsModal.html"
-        modal-header-class="modal-header-warning"
-        wvr-modal-backdrop="static">
-      </modal>
-
+    <div class="panel-heading">
+        <h3 class="panel-title">Manage {{getSelectedOrganizationName()}} Workflow</h3>
     </div>
-  </div>
+    <div class="panel-body">
+        <div class="col-md-12">
+            <button class="btn btn-default modal-add-btn" ng-click="openModal('#addWorkflowStepModal')">
+              Add Workflow Step
+            </button>
+            <div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new workflow step."></div>
+            <modal
+              modal-id="addWorkflowStepModal"
+              modal-view="views/modals/organization/workflowStepCreateModal.html"
+              modal-header-class="modal-header-primary"
+              wvr-modal-backdrop="static">
+            </modal>
+            <vireo-accordion single-expand="false">
+              <vireo-pane ng-repeat="step in getSelectedOrganizationAggregateWorkflowSteps() track by $index" bar-view="views/admin/settings/organization/workflowsteps/workflowStep.html" query="{{step.name}}" html="views/admin/settings/organization/workflowsteps/workflowStepContent.html">{{$index+1}}. {{step.name}}</vireo-pane>
+            </vireo-accordion>
+
+            <hr />
+
+            <div class="row">
+              <div class="pull-right">
+                <button
+                  ng-if="getSelectedOrganizationId() !== 1"
+                  type="button"
+                  class="btn btn-warning"
+                  ng-click="openModal('#organizationConfirmRestoreDefaultsModal')">Sync with Parent</button>
+              </div>
+            </div>
+
+            <modal
+              modal-id="organizationConfirmRestoreDefaultsModal"
+              modal-view="views/modals/organization/organizationConfirmRestoreDefaultsModal.html"
+              modal-header-class="modal-header-warning"
+              wvr-modal-backdrop="static">
+            </modal>
+        </div>
+    </div>
 </div>

--- a/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
+++ b/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
@@ -39,8 +39,7 @@
     hint="These instructions are shown at the begining of this workflow step during the student submission process."
     scope-value="step.instructions"
     on-blur="updateWorkflowStep(step)"
-        key-down="confirmEdit(event, prop)"
-        wysiwyg="false">
+    key-down="confirmEdit(event, prop)">
 </lockingtextarea>
 
 <hr>

--- a/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
+++ b/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
@@ -1,7 +1,7 @@
-<div class="row clearfix" ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganization().id">
+<div class="row clearfix" ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganizationId()">
 
-	<div class="col-md-4">
-		<validatedinput
+    <div class="col-md-4">
+        <validatedinput
             no-id="true"
             type="text"
             label="Workflow Step Name"
@@ -12,191 +12,185 @@
             form-view="true"
             tool-tip="Enter the workflow step name.">
         </validatedinput>
-  	</div>
+    </div>
 
-  	<div class="col-md-5">
-  		<toggleButton
-			label="Workflow Step is Overrideable:"
-			scope-value="step.overrideable"
-			toggle-options='[{"true": "Yes"},{"false": "No"}]'
-			ng-click="updateWorkflowStep(step)">
-		</toggleButton>
-  	</div>
+    <div class="col-md-5">
+        <toggleButton
+            label="Workflow Step is Overrideable:"
+            scope-value="step.overrideable"
+            toggle-options='[{"true": "Yes"},{"false": "No"}]'
+            ng-click="updateWorkflowStep(step)">
+        </toggleButton>
+    </div>
 
-  	<div class="col-md-2">
-		<div class="form-group">
-			<button class="btn btn-danger" ng-click="openConfirmDeleteModal(step)">Delete Workflow Step</button>
-			<modal modal-id="workflow-step-delete-confirm-{{step.id}}" modal-view="views/modals/organization/workflowStepDeleteModal.html" modal-header-class="modal-header-danger"></modal>
-		</div>
-	</div>
+    <div class="col-md-2">
+        <div class="form-group">
+            <button class="btn btn-danger" ng-click="openConfirmDeleteModal(step)" ng-disabled="loadingOrganization">Delete Workflow Step</button>
+            <modal modal-id="workflow-step-delete-confirm-{{step.id}}" modal-view="views/modals/organization/workflowStepDeleteModal.html" modal-header-class="modal-header-danger"></modal>
+        </div>
+    </div>
 
 </div>
 
 <hr>
 
-	<lockingtextarea
-		label="Workflow Step Instructions"
-		hint="These instructions are shown at the begining of this workflow step during the student submission process."
-		scope-value="step.instructions"
-		on-blur="updateWorkflowStep(step)"
-		key-down="confirmEdit(event, prop)">
-	</lockingtextarea>
+<lockingtextarea
+    label="Workflow Step Instructions"
+    hint="These instructions are shown at the begining of this workflow step during the student submission process."
+    scope-value="step.instructions"
+    on-blur="updateWorkflowStep(step)"
+    key-down="confirmEdit(event, prop)">
+</lockingtextarea>
 
 <hr>
 
 <div ng-controller="FieldProfileManagementController">
 
-  <div ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganization().id">
+  <div ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganizationId()">
 
-		<div id="field-profiles" class="row">
+        <div id="field-profiles" class="row">
 
-			<div class="col-md-12">
+            <div class="col-md-12">
 
-				<alerts channels="/organization/workflowStep/fieldProfiles" types="ERROR, WARNING" exclusive></alerts>
+                <alerts channels="/organization/workflowStep/fieldProfiles" types="ERROR, WARNING" exclusive></alerts>
 
-				<div class="col-md-6">
+                <div class="col-md-6">
 
-					<button class="btn btn-default modal-add-btn" ng-click="openNewModal(step.id)">
-						Add Field
-					</button>
+                    <button class="btn btn-default modal-add-btn" ng-click="openNewModal(step.id)">
+                        Add Field
+                    </button>
 
-					<div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new field."></div>
+                    <div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new field."></div>
 
-					<p ng-if="step.aggregateFieldProfiles.length == 0">Add New Field</p>
+                    <p ng-if="step.aggregateFieldProfiles.length == 0">Add New Field</p>
 
-					<draganddroplist dragging="dragging"
-									 scope-value="step.aggregateFieldProfiles"
-									 properties='["gloss"]'
-									 item-view='views/directives/dragAndDropFieldProfile.html'
-									 listeners='dragControlListeners'
-									 edit='editFieldProfile(index)'
-									 is-editable='isEditable(fieldProfile)'>
-					</draganddroplist>
+                    <draganddroplist dragging="dragging"
+                                     scope-value="step.aggregateFieldProfiles"
+                                     properties='["gloss"]'
+                                     item-view='views/directives/dragAndDropFieldProfile.html'
+                                     listeners='dragControlListeners'
+                                     edit='editFieldProfile(index)'
+                                     is-editable='isEditable(fieldProfile)'>
+                    </draganddroplist>
 
-				</div>
+                </div>
 
-				<div class="col-md-6">
-					<trashcan id="field-profile-trash-{{step.id}}"
-							  dragging="dragging"
-							  listeners='dragControlListeners'>
-					</trashcan>
-				</div>
+                <div class="col-md-6">
+                    <trashcan id="field-profile-trash-{{step.id}}"
+                              dragging="dragging"
+                              listeners='dragControlListeners'>
+                    </trashcan>
+                </div>
 
-				<modal modal-id="fieldProfilesNewModal-{{step.id}}"
-					   modal-view="views/modals/organization/fieldprofiles/fieldProfilesNewModal.html"
-					   modal-header-class="modal-header-primary"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static"
+                <modal modal-id="fieldProfilesNewModal-{{step.id}}"
+                       modal-view="views/modals/organization/fieldprofiles/fieldProfilesNewModal.html"
+                       modal-header-class="modal-header-primary"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static"
              modal-fullscreen="true">
-				</modal>
+                </modal>
 
-				<modal modal-id="fieldProfilesEditModal-{{step.id}}"
-					   modal-view="views/modals/organization/fieldprofiles/fieldProfilesEditModal.html"
-					   modal-header-class="modal-header-primary"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static"
+                <modal modal-id="fieldProfilesEditModal-{{step.id}}"
+                       modal-view="views/modals/organization/fieldprofiles/fieldProfilesEditModal.html"
+                       modal-header-class="modal-header-primary"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static"
              modal-fullscreen="true">
-				</modal>
+                </modal>
 
-				<modal modal-id="fieldProfilesConfirmRemoveModal-{{step.id}}"
-					   modal-view="views/modals/organization/fieldprofiles/fieldProfilesConfirmRemoveModal.html"
-					   modal-header-class="modal-header-danger"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static"
+                <modal modal-id="fieldProfilesConfirmRemoveModal-{{step.id}}"
+                       modal-view="views/modals/organization/fieldprofiles/fieldProfilesConfirmRemoveModal.html"
+                       modal-header-class="modal-header-danger"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static"
              modal-fullscreen="true">
-				</modal>
+                </modal>
 
-			</div>
+            </div>
 
-		</div>
-	</div>
+        </div>
+    </div>
 
-	<div ng-if="!step.overrideable && step.originatingOrganization !== getSelectedOrganization().id">
-		<h3>Read only. Workflow step is non overrideable.</h3>
-		<ul class="list-unstyled">
-		   <li ng-repeat="fieldProfile in step.aggregateFieldProfiles">
-		      	{{fieldProfile.position}}. <span ng-if="!fieldProfile.optional">*</span>{{fieldProfile.gloss}}
-		   </li>
-		</ul>
-	</div>
+    <div ng-if="!step.overrideable && step.originatingOrganization !== getSelectedOrganizationId()">
+        <h3>Read only. Workflow step is non overrideable.</h3>
+        <ul class="list-unstyled">
+           <li ng-repeat="fieldProfile in step.aggregateFieldProfiles">
+                {{fieldProfile.position}}. <span ng-if="!fieldProfile.optional">*</span>{{fieldProfile.gloss}}
+           </li>
+        </ul>
+    </div>
 
 </div>
 
 <hr>
 
 <div ng-controller="NoteManagementController">
+    <div ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganizationId()">
+        <div id="notes" class="row">
+            <div class="col-md-12">
+                <alerts channels="/organization/workflowStep/notes" types="ERROR, WARNING" exclusive></alerts>
 
-	<div ng-if="step.overrideable || step.originatingOrganization === getSelectedOrganization().id">
+                <div class="col-md-6">
 
-		<div id="notes" class="row">
+                    <button class="btn btn-default modal-add-btn" ng-click="openNewModal(step.id)">
+                        Add Note
+                    </button>
 
-			<div class="col-md-12">
+                    <div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new note."></div>
 
-				<alerts channels="/organization/workflowStep/notes" types="ERROR, WARNING" exclusive></alerts>
+                    <p ng-if="step.aggregateNotes.length == 0">Add New Note</p>
 
-				<div class="col-md-6">
-
-					<button class="btn btn-default modal-add-btn" ng-click="openNewModal(step.id)">
-						Add Note
-					</button>
-
-					<div class="glyphicon glyphicon-info-sign glyiphicon-span-adjust" tooltip="Select to add a new note."></div>
-
-					<p ng-if="step.aggregateNotes.length == 0">Add New Note</p>
-
-					<draganddroplist dragging="dragging"
-									 scope-value="step.aggregateNotes"
-									 properties='["name"]'
-									 item-view='views/directives/dragAndDropNote.html'
-									 listeners='dragControlListeners'
-									 edit='editNote(index)'
-									 is-editable='isEditable(note)'>
-					</draganddroplist>
-
-				</div>
+                    <draganddroplist dragging="dragging"
+                                     scope-value="step.aggregateNotes"
+                                     properties='["name"]'
+                                     item-view='views/directives/dragAndDropNote.html'
+                                     listeners='dragControlListeners'
+                                     edit='editNote(index)'
+                                     is-editable='isEditable(note)'>
+                    </draganddroplist>
+                </div>
 
 
+                <div class="col-md-6">
+                    <trashcan id="note-trash-{{step.id}}"
+                              dragging="dragging"
+                              listeners='dragControlListeners'>
+                    </trashcan>
+                </div>
 
-				<div class="col-md-6">
-					<trashcan id="note-trash-{{step.id}}"
-							  dragging="dragging"
-							  listeners='dragControlListeners'>
-					</trashcan>
-				</div>
+                <modal modal-id="notesNewModal-{{step.id}}"
+                       modal-view="views/modals/organization/notesNewModal.html"
+                       modal-header-class="modal-header-primary"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static">
+                </modal>
 
-				<modal modal-id="notesNewModal-{{step.id}}"
-					   modal-view="views/modals/organization/notesNewModal.html"
-					   modal-header-class="modal-header-primary"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static">
-				</modal>
+                <modal modal-id="notesEditModal-{{step.id}}"
+                       modal-view="views/modals/organization/notesEditModal.html"
+                       modal-header-class="modal-header-primary"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static">
+                </modal>
 
-				<modal modal-id="notesEditModal-{{step.id}}"
-					   modal-view="views/modals/organization/notesEditModal.html"
-					   modal-header-class="modal-header-primary"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static">
-				</modal>
+                <modal modal-id="notesConfirmRemoveModal-{{step.id}}"
+                       modal-view="views/modals/organization/notesConfirmRemoveModal.html"
+                       modal-header-class="modal-header-danger"
+                       modal-keyboard="false"
+                       wvr-modal-backdrop="static">
+                </modal>
 
-				<modal modal-id="notesConfirmRemoveModal-{{step.id}}"
-					   modal-view="views/modals/organization/notesConfirmRemoveModal.html"
-					   modal-header-class="modal-header-danger"
-					   modal-keyboard="false"
-					   wvr-modal-backdrop="static">
-				</modal>
+            </div>
 
-			</div>
+        </div>
+    </div>
 
-		</div>
-	</div>
-
-	<div ng-if="!step.overrideable && step.originatingOrganization !== getSelectedOrganization().id">
-		<h3>Read only. Workflow step is non overrideable.</h3>
-		<ul class="list-unstyled">
-			<li ng-repeat="note in step.aggregateNotes">
-					 {{note.position}}. {{note.name}}
-			</li>
-		</ul>
-	</div>
+    <div ng-if="!step.overrideable && step.originatingOrganization !== getSelectedOrganizationId()">
+        <h3>Read only. Workflow step is non overrideable.</h3>
+        <ul class="list-unstyled">
+            <li ng-repeat="note in step.aggregateNotes">
+                {{note.position}}. {{note.name}}
+            </li>
+        </ul>
+    </div>
 
 </div>

--- a/src/main/webapp/app/views/directives/dragAndDropNote.html
+++ b/src/main/webapp/app/views/directives/dragAndDropNote.html
@@ -1,7 +1,6 @@
 <div class="notes" ng-mouseenter="isMouseHover=true" ng-mouseleave="isMouseHover=false">
-	<span>{{ item.position }}. </span>
-	<!-- <span ng-repeat="property in properties" class="repeated-span" ng-class="{'text-warning': !isEditable({note: item})}">{{ item[property] }} - id: {{item.id}} - originating workflowstep id: {{item.originatingWorkflowStep}} <span ng-if="item.originating"> - originating id: {{item.originating}}</span></span> -->
-  <span ng-repeat="property in properties" class="repeated-span" ng-class="{'text-warning': !isEditable({note: item})}">{{ item[property] }}</span>
-	<span ng-if="isEditable({note: item})" ng-show="isMouseHover" class="glyphicon glyphicon-pencil edit-setting-icon" ng-click="edit({index:item.position})"></span>
-	<span ng-if="!isEditable({note: item})" class="glyphicon glyphicon-info-sign text-warning" tooltip="This note is not overrideable."></span>
+    <span>{{ item.position }}. </span>
+    <span ng-repeat="property in properties" class="repeated-span" ng-class="{'text-warning': !isEditable({note: item})}">{{ item[property] }}</span>
+    <span ng-if="isEditable({note: item})" ng-show="isMouseHover" class="glyphicon glyphicon-pencil edit-setting-icon" ng-click="edit({index:item.position})"></span>
+    <span ng-if="!isEditable({note: item})" class="glyphicon glyphicon-info-sign text-warning" tooltip="This note is not overrideable."></span>
 </div>

--- a/src/main/webapp/app/views/directives/triptych.html
+++ b/src/main/webapp/app/views/directives/triptych.html
@@ -1,79 +1,79 @@
 <div class="col-xs-12 triptych">
-	<h1 ng-if="attr.header">{{attr.header}}</h1>
-	<div class="triptych-wrapper" ng-class="{'collapse': !navigation.expanded}">
-		<div class="row triptych-navigation">
-			<div class="row">
-				<div class="col-xs-12">
-					<ul class="breadcrumb">
-						<li ng-click="selectOrganization(organizations[0])">
-							<a href="#">{{organizations[0].name}}</a>
-							<span ng-if="getBreadcrumbs().length == 0" class="glyphicon glyphicon-arrow-down"></span>
-						</li>
-						<li ng-repeat="panel in getBreadcrumbs()" ng-click="selectOrganization(panel.selected.organization)">
-							<a href="#">{{panel.selected.organization.name}} ({{panel.selected.organization.category.name}})</a>
-							<span ng-if="$last" class="glyphicon glyphicon-arrow-down"></span>
-						</li>
-					</ul>
-				</div>
-			</div>
-		</div>
-		<div class="row" ng-if="organizations.length === 1">
-			<div class="col-xs-12">
-				<p>Your Institution has no child organizations. Use the 'Create Organization' side module to create your first organization.</p>
-			</div>
-		</div>
-		<div class="row triptych-panels">
-			<div class="col-xs-12 col-sm-6 col-md-4 panel-wrapper" ng-repeat="panel in navigation.panels | filter:{visible:true}" ng-class="{'opening': panel.opening, 'closing': panel.closing, 'showing': panel.visible, 'back': navigation.backward}">
-				<div class="panel panel-default triptych-panel" ng-class="{'active': panel.active, 'previously-active': panel.previouslyActive}" ng-if="organizations.length > 1">
-					<div class="panel-heading" ng-click="navigation.expanded = true">
-						<span ng-repeat="category in panel.categories" ng-click="panel.filter = category">
-							<span class="multiple category-heading">{{category}}</span>
-							<span ng-if="!$last"> / </span>
-						</span>
-						<span ng-if="panel.filter"> / <span class="category-heading" ng-click="panel.filter = ''" ng-class="{'active': category == panel.filter, 'multiple': panel.categories.length}">All</span></span>
-						<span class="glyphicon glyphicon-arrow-right pull-right" ng-if="selectedOrganization.childrenOrganizations.length > 0 || panel.previouslyActive"></span>
-					</div>
-					<div class="panel-body">
-						<ul class="list-group">
-							<li class="list-group-item triptych-panel-entry"
-								ng-repeat="organization in panel.organization.childrenOrganizations | filter:{category: {name: panel.filter}} | orderBy:['category.name','name']"
-								ng-click="selectOrganization(organization)" 
-								ng-class="{'selected': panel.selected.organization.id == organization.id}">
-								<ul class="inline-list pull-right" ng-if="attr.managed">
-									<li ng-click="activateManagementPane('edit')">
-										<span class="context-icons glyphicon glyphicon-cog pull-right" ng-class="{'active': managementPaneIsActive('edit')}" tooltip="Manage organization"></span>
-									</li>
-									<li ng-click="activateManagementPane('workflow')">
-										<span class="context-icons glyphicon glyphicon-list-alt pull-right" ng-class="{'active': managementPaneIsActive('workflow')}" tooltip="Manage workflow"></span>
-									</li>
-									<li ng-click="activateManagementPane('email')">
-										<span class="context-icons glyphicon glyphicon-envelope pull-right" ng-class="{'active': managementPaneIsActive('email')}" tooltip="Manage email workflow rules"></span>
-									</li>
-								</ul>
-								<ul class="inline-list pull-right" ng-if="!attr.managed">
-									<li ng-if="hasSubmission(organization)" ng-click="gotoSubmission(organization)">
-										<span class="context-icons glyphicon glyphicon-list-alt pull-right" tooltip="Continue submission"></span>
-									</li>
-								</ul>
-								<span>
-									<span>{{organization.name}}</span>
-									<span class="badge" ng-if="organization.childrenOrganizations.length">{{organization.childrenOrganizations.length}}</span>
-									<span class="category-label" ng-if="panel.categories.length > 1">{{organization.category.name}}</span>
-								</span>
-							</li>
-						</ul>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row" ng-if="attr.expcol">
-		<div class="divider-wrapper col-xs-12" ng-click="navigation.expanded = !navigation.expanded">
-			<span class="collapse-btn glyphicon glyphicon-chevron-up" ng-if="navigation.expanded"></span>
-			<span ng-if="!navigation.expanded">EXPAND NAVIGATION</span>
-			<hr class="divider">
-			<span class="collapse-btn glyphicon glyphicon-chevron-down" ng-if="!navigation.expanded"></span>
-		</div>
-	</div>
-	<ng-transclude></ng-transclude>
+    <h1 ng-if="attr.header">{{attr.header}}</h1>
+    <div class="triptych-wrapper" ng-class="{'collapse': !navigation.expanded}">
+        <div class="row triptych-navigation">
+            <div class="row">
+                <div class="col-xs-12">
+                    <ul class="breadcrumb">
+                        <li ng-click="selectOrganization(organizations[0])">
+                            <a href="#">{{organizations[0].name}}</a>
+                            <span ng-if="getBreadcrumbs().length == 0" class="glyphicon glyphicon-arrow-down"></span>
+                        </li>
+                        <li ng-repeat="panel in getBreadcrumbs()" ng-click="selectOrganization(panel.selected.organization)">
+                            <a href="#">{{panel.selected.organization.name}} ({{panel.selected.organization.category.name}})</a>
+                            <span ng-if="$last" class="glyphicon glyphicon-arrow-down"></span>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="row" ng-if="organizations.length === 1">
+            <div class="col-xs-12">
+                <p>Your Institution has no child organizations. Use the 'Create Organization' side module to create your first organization.</p>
+            </div>
+        </div>
+        <div class="row triptych-panels">
+            <div class="col-xs-12 col-sm-6 col-md-4 panel-wrapper" ng-repeat="panel in navigation.panels | filter:{visible:true}" ng-class="{'opening': panel.opening, 'closing': panel.closing, 'showing': panel.visible, 'back': navigation.backward}">
+                <div class="panel panel-default triptych-panel" ng-class="{'active': panel.active, 'previously-active': panel.previouslyActive}" ng-if="organizations.length > 1">
+                    <div class="panel-heading" ng-click="navigation.expanded = true">
+                        <span ng-repeat="category in panel.categories" ng-click="panel.filter = category">
+                            <span class="multiple category-heading">{{category}}</span>
+                            <span ng-if="!$last"> / </span>
+                        </span>
+                        <span ng-if="panel.filter"> / <span class="category-heading" ng-click="panel.filter = ''" ng-class="{'active': category == panel.filter, 'multiple': panel.categories.length}">All</span></span>
+                        <span class="glyphicon glyphicon-arrow-right pull-right" ng-if="selectedOrganization.childrenOrganizations.length > 0 || panel.previouslyActive"></span>
+                    </div>
+                    <div class="panel-body">
+                        <ul class="list-group">
+                            <li class="list-group-item triptych-panel-entry"
+                                ng-repeat="organization in panel.organization.childrenOrganizations | filter:{category: {name: panel.filter}} | orderBy:['category.name','name']"
+                                ng-click="selectOrganization(organization)"
+                                ng-class="{'selected': panel.selected.organization.id == organization.id}">
+                                <ul class="inline-list pull-right" ng-if="attr.managed">
+                                    <li ng-click="activateManagementPane('edit')">
+                                        <span class="context-icons glyphicon glyphicon-cog pull-right" ng-class="{'active': managementPaneIsActive('edit')}" tooltip="Manage organization"></span>
+                                    </li>
+                                    <li ng-click="activateManagementPane('workflow')">
+                                        <span class="context-icons glyphicon glyphicon-list-alt pull-right" ng-class="{'active': managementPaneIsActive('workflow')}" tooltip="Manage workflow"></span>
+                                    </li>
+                                    <li ng-click="activateManagementPane('email')">
+                                        <span class="context-icons glyphicon glyphicon-envelope pull-right" ng-class="{'active': managementPaneIsActive('email')}" tooltip="Manage email workflow rules"></span>
+                                    </li>
+                                </ul>
+                                <ul class="inline-list pull-right" ng-if="!attr.managed">
+                                    <li ng-if="hasSubmission(organization)" ng-click="gotoSubmission(organization)">
+                                        <span class="context-icons glyphicon glyphicon-list-alt pull-right" tooltip="Continue submission"></span>
+                                    </li>
+                                </ul>
+                                <span>
+                                    <span>{{organization.name}}</span>
+                                    <span class="badge" ng-if="organization.childrenOrganizations.length">{{organization.childrenOrganizations.length}}</span>
+                                    <span class="category-label" ng-if="panel.categories.length > 1">{{organization.category.name}}</span>
+                                </span>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row" ng-if="attr.expcol">
+        <div class="divider-wrapper col-xs-12" ng-click="navigation.expanded = !navigation.expanded">
+            <span class="collapse-btn glyphicon glyphicon-chevron-up" ng-if="navigation.expanded"></span>
+            <span ng-if="!navigation.expanded">EXPAND NAVIGATION</span>
+            <hr class="divider">
+            <span class="collapse-btn glyphicon glyphicon-chevron-down" ng-if="!navigation.expanded"></span>
+        </div>
+    </div>
+    <ng-transclude></ng-transclude>
 </div>

--- a/src/main/webapp/app/views/modals/organization/emailWorkflowRuleCreate.html
+++ b/src/main/webapp/app/views/modals/organization/emailWorkflowRuleCreate.html
@@ -5,7 +5,7 @@
     <h3 class="modal-title">Add Email Workflow Rule to {{status.name}}</h3>
 </div>
 
-<form ng-submit="addEmailWorkflowRule(newTemplate,newRecipient,status)" name="forms.add" novalidate>
+<form ng-submit="addEmailWorkflowRule(newTemplate, newRecipient, status)" name="forms.add" novalidate>
 
     <div class="addRecipientModal modal-body">
         <div class="row">

--- a/src/main/webapp/app/views/modals/organization/emailWorkflowRuleDelete.html
+++ b/src/main/webapp/app/views/modals/organization/emailWorkflowRuleDelete.html
@@ -1,5 +1,5 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-    <button type="button" class="close" ng-click="cancelDeleteEmailWorkflowRule(getEmailWorkflowRuleToDelete())" aria-label="Close">
+    <button type="button" class="close" ng-click="cancelDeleteEmailWorkflowRule()" aria-label="Close">
         <span class="modal-close" aria-hidden="true">&times;</span>
     </button>
     <h3 class="modal-title">Delete Email Workflow Rule</h3>
@@ -7,12 +7,12 @@
 
 <form ng-submit="deleteEmailWorkflowRule()" novalidate>
 
-	<div class="modal-body">
-		<h4>Really delete email workflow rule?</h4>
-	</div>
+    <div class="modal-body">
+        <h4>Really delete email workflow rule?</h4>
+    </div>
 
-	<div class="modal-footer">
-		<button type="button" class="btn btn-default" ng-click="cancelDeleteEmailWorkflowRule()">Cancel</button>
-		<button type="submit" class="btn btn-danger">Confirm</button>
-	</div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default" ng-click="cancelDeleteEmailWorkflowRule()">Cancel</button>
+        <button type="submit" class="btn btn-danger">Confirm</button>
+    </div>
 </form>

--- a/src/main/webapp/app/views/modals/organization/fieldprofiles/fieldProfilesConfirmRemoveModal.html
+++ b/src/main/webapp/app/views/modals/organization/fieldprofiles/fieldProfilesConfirmRemoveModal.html
@@ -11,7 +11,7 @@
 
   <div class="modal-body">
     <h4><b>Click confirm to remove the Field Profile: {{modalData.gloss}}</b></h4>
-    <h4>Organization: {{organizationRepo.getSelectedOrganization().name}}</h4>
+    <h4>Organization: {{getSelectedOrganizationName()}}</h4>
     <h4>Workflow Step: {{step.name}}</h4>
     <h4>Predicate: {{modalData.fieldPredicate.value}}</h4>
   </div>

--- a/src/main/webapp/app/views/modals/organization/organizationConfirmDeleteModal.html
+++ b/src/main/webapp/app/views/modals/organization/organizationConfirmDeleteModal.html
@@ -6,9 +6,9 @@
 </div>
 
 <form novalidate>
-  <validationmessage results="getSelectedOrganization().getValidationResults()"></validationmessage>
+  <validationmessage results="getSelectedOrganizationValidationResults()"></validationmessage>
   <div class="modal-body">
-    <h4>Really delete organization "{{ getSelectedOrganization().name }}"?</h4>
+    <h4>Really delete organization "{{ getSelectedOrganizationName() }}"?</h4>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelDeleteOrganization()">Cancel</button>

--- a/src/main/webapp/app/views/modals/organization/organizationConfirmRestoreDefaultsModal.html
+++ b/src/main/webapp/app/views/modals/organization/organizationConfirmRestoreDefaultsModal.html
@@ -7,8 +7,8 @@
 
 <form novalidate>
   <div class="modal-body">
-    <h4>Really sync the workflow for "{{ getSelectedOrganization().name }}" with parent?</h4>
-    <p>This will result in the loss of all organizational customizations for this organization and all of its decendent organizations.</p> 
+    <h4>Really sync the workflow for "{{ getSelectedOrganizationName() }}" with parent?</h4>
+    <p>This will result in the loss of all organizational customizations for this organization and all of its decendent organizations.</p>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default" ng-click="cancelRestoreOrganizationDefaults()">Cancel</button>

--- a/src/main/webapp/app/views/submission/submissionNew.html
+++ b/src/main/webapp/app/views/submission/submissionNew.html
@@ -3,13 +3,13 @@
     <div class="row">
       <div class="col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-4">
         <form name="newSubmission" ng-if="ready">
-          <button ng-if="getSelectedOrganization().acceptsSubmissions" class="btn btn-primary triptych-start-submission form-control" ng-click="createSubmission(getSelectedOrganization())" ng-disabled="creatingSubmission">
-            <span>Start {{getSelectedOrganization().name}} Submission <span ng-if="creatingSubmission" class="glyphicon glyphicon-refresh spinning"> </span></span>
+          <button ng-if="getSelectedOrganizationAcceptsSubmissions()" class="btn btn-primary triptych-start-submission form-control" ng-click="createSubmission(getSelectedOrganization())" ng-disabled="creatingSubmission">
+            <span>Start {{getSelectedOrganizationName()}} Submission <span ng-if="creatingSubmission" class="glyphicon glyphicon-refresh spinning"> </span></span>
           </button>
-          <button ng-if="!getSelectedOrganization().acceptsSubmissions && hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission form-control" ng-click="gotoSubmission(getSelectedOrganization())">
-            <span>Continue {{getSelectedOrganization().name}} Submission</span>
+          <button ng-if="!getSelectedOrganizationAcceptsSubmissions() && hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission form-control" ng-click="gotoSubmission(getSelectedOrganization())">
+            <span>Continue {{getSelectedOrganizationName()}} Submission</span>
           </button>
-          <button ng-if="!getSelectedOrganization().acceptsSubmissions && !hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission disabled form-control">
+          <button ng-if="!getSelectedOrganizationAcceptsSubmissions() && !hasSubmission(getSelectedOrganization())" class="btn btn-primary triptych-start-submission disabled form-control">
             <span>Choose an Organization that allows Submissions</span>
           </button>
         </form>

--- a/src/main/webapp/tests/core/mocks/mockAbstractCoreModel.js
+++ b/src/main/webapp/tests/core/mocks/mockAbstractCoreModel.js
@@ -2,8 +2,8 @@ var mockModel = function (modelName, $q, mockDataObj) {
     var model = {};
     var combinationOperation = "";
 
-    model.isDirty = false;
     model.isValid = false;
+    model.$dirty = false;
 
     model.mock = function(toMock) {
         if (typeof toMock === "object") {
@@ -41,10 +41,10 @@ var mockModel = function (modelName, $q, mockDataObj) {
 
     model.dirty = function(boolean) {
         if (boolean !== undefined) {
-            model.isDirty = boolean;
+            model.$dirty = boolean;
         }
 
-        return model.isDirty;
+        return model.$dirty;
     };
 
     model.enableMergeCombinationOperation = function () {

--- a/src/main/webapp/tests/core/mocks/mockAbstractCoreRepo.js
+++ b/src/main/webapp/tests/core/mocks/mockAbstractCoreRepo.js
@@ -246,9 +246,6 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
     repo.setToDelete = function (id) {
     };
 
-    repo.setToUpdate = function (id) {
-    };
-
     repo.sort = function (guarantor, facet) {
         var payload = {};
         return payloadPromise($q.defer(), payload);

--- a/src/main/webapp/tests/mocks/repos/mockOrganizationRepo.js
+++ b/src/main/webapp/tests/mocks/repos/mockOrganizationRepo.js
@@ -23,7 +23,17 @@ angular.module("mock.organizationRepo", []).service("OrganizationRepo", function
     repo.selectedId = null;
     repo.submissionsCount = {};
 
+    repo.addEmailWorkflowRule = function (organization, template, recipient, submissionStatus) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
     repo.addWorkflowStep = function (workflowStep) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    repo.changeEmailWorkflowRuleActivation = function (organization, emailWorkflowRule) {
         var payload = {};
         return payloadPromise($q.defer(), payload);
     };
@@ -70,6 +80,21 @@ angular.module("mock.organizationRepo", []).service("OrganizationRepo", function
         return valuePromise($q.defer(), response);
     };
 
+    repo.editEmailWorkflowRule = function (organization, emailWorkflowRule) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    repo.getAllSpecific = function (specific) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
+    repo.getById = function (id, specific) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
+    };
+
     repo.getNewOrganization = function () {
         return repo.newOrganization;
     };
@@ -82,6 +107,15 @@ angular.module("mock.organizationRepo", []).service("OrganizationRepo", function
             }
         }
         return found;
+    };
+
+    repo.getSelectedOrganizationId = function () {
+        return repo.selectedId;
+    };
+
+    repo.removeEmailWorkflowRule = function (organization, emailWorkflowRule) {
+        var payload = {};
+        return payloadPromise($q.defer(), payload);
     };
 
     repo.reorderWorkflowSteps = function (upOrDown, workflowStepID) {

--- a/src/main/webapp/tests/unit/controllers/organizationSettingsControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/organizationSettingsControllerTest.js
@@ -14,7 +14,9 @@ describe("controller: OrganizationSettingsController", function () {
 
     var initializeController = function(settings) {
         inject(function ($controller, $rootScope, _ModalService_, _Organization_, _OrganizationRepo_, _RestApi_, _SidebarService_, _StorageService_) {
-            scope = $rootScope.$new();
+            if (!settings || !settings.keepScope) {
+                scope = $rootScope.$new();
+            }
 
             OrganizationRepo = _OrganizationRepo_;
 
@@ -64,12 +66,52 @@ describe("controller: OrganizationSettingsController", function () {
         it("should be defined", function () {
             expect(controller).toBeDefined();
         });
+        it("should be defined with organizations tree loaded", function () {
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([ new mockOrganization(q) ]);
+                });
+            };
+
+            initializeController({ keepScope: true });
+
+            expect(scope.organizations).toBeDefined();
+            expect(scope.organizations.length).toEqual(1);
+        });
     });
 
     describe("Are the scope methods defined", function () {
         it("activateManagementPane should be defined", function () {
             expect(scope.activateManagementPane).toBeDefined();
             expect(typeof scope.activateManagementPane).toEqual("function");
+        });
+        it("getSelectedOrganizationAcceptsSubmissions should be defined", function () {
+            expect(scope.getSelectedOrganizationAcceptsSubmissions).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationAcceptsSubmissions).toEqual("function");
+        });
+        it("getSelectedOrganizationAggregateWorkflowSteps should be defined", function () {
+            expect(scope.getSelectedOrganizationAggregateWorkflowSteps).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationAggregateWorkflowSteps).toEqual("function");
+        });
+        it("getSelectedOrganizationEmailWorkflowRules should be defined", function () {
+            expect(scope.getSelectedOrganizationEmailWorkflowRules).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationEmailWorkflowRules).toEqual("function");
+        });
+        it("getSelectedOrganizationId should be defined", function () {
+            expect(scope.getSelectedOrganizationId).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationId).toEqual("function");
+        });
+        it("getSelectedOrganizationName should be defined", function () {
+            expect(scope.getSelectedOrganizationName).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationName).toEqual("function");
+        });
+        it("getSelectedOrganizationValidations should be defined", function () {
+            expect(scope.getSelectedOrganizationValidations).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationValidations).toEqual("function");
+        });
+        it("getSelectedOrganizationValidationResults should be defined", function () {
+            expect(scope.getSelectedOrganizationValidationResults).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationValidationResults).toEqual("function");
         });
         it("getSelectedOrganization should be defined", function () {
             expect(scope.getSelectedOrganization).toBeDefined();
@@ -78,6 +120,10 @@ describe("controller: OrganizationSettingsController", function () {
         it("managementPaneIsActive should be defined", function () {
             expect(scope.managementPaneIsActive).toBeDefined();
             expect(typeof scope.managementPaneIsActive).toEqual("function");
+        });
+        it("rebuildOrganizationTree should be defined", function () {
+            expect(scope.rebuildOrganizationTree).toBeDefined();
+            expect(typeof scope.rebuildOrganizationTree).toEqual("function");
         });
         it("setDeleteDisabled should be defined", function () {
             expect(scope.setDeleteDisabled).toBeDefined();
@@ -94,12 +140,13 @@ describe("controller: OrganizationSettingsController", function () {
             scope.activeManagementPane = null;
             scope.activateManagementPane(true);
 
-            expect(scope.activeManagementPane).toBe(true);
+            expect(scope.activeManagementPane).toEqual(true);
         });
-        it("getSelectedOrganization should get the selected organization", function () {
+        it("getSelectedOrganization should return an organization", function () {
             var response;
             var organization = new mockOrganization(q);
-            organization.mock(dataOrganization2);
+
+            scope.selectedOrganization = undefined;
 
             response = scope.getSelectedOrganization();
 
@@ -112,21 +159,221 @@ describe("controller: OrganizationSettingsController", function () {
             expect(response).toBeDefined();
             expect(response.id).not.toBeDefined();
 
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
             scope.selectedOrganization = organization;
 
             response = scope.getSelectedOrganization();
 
             expect(response.id).toEqual(organization.id);
         });
+        it("getSelectedOrganizationAcceptsSubmissions should return acceptsSubmissions", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.acceptsSubmissions = true;
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).toEqual(organization.acceptsSubmissions);
+        });
+        it("getSelectedOrganizationAggregateWorkflowSteps should return aggregateWorkflowSteps", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.aggregateWorkflowSteps = { steps: [] };
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationAggregateWorkflowSteps();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationAggregateWorkflowSteps();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationAggregateWorkflowSteps();
+
+            expect(response).toEqual(organization.aggregateWorkflowSteps);
+        });
+        it("getSelectedOrganizationEmailWorkflowRules should return emailWorkflowRules", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.emailWorkflowRules = { rule: [] };
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationEmailWorkflowRules();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationEmailWorkflowRules();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationEmailWorkflowRules();
+
+            expect(response).toEqual(organization.emailWorkflowRules);
+        });
+        it("getSelectedOrganizationId should return an ID", function () {
+            var response;
+            var organization = new mockOrganization(q);
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).toEqual(organization.id);
+        });
+        it("getSelectedOrganizationName should return a name", function () {
+            var response;
+            var organization = new mockOrganization(q);
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).toEqual(organization.name);
+        });
+        it("getSelectedOrganizationOriginalWorkflowSteps should return originalWorkflowSteps", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.originalWorkflowSteps = { steps: [] };
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationOriginalWorkflowSteps();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationOriginalWorkflowSteps();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationOriginalWorkflowSteps();
+
+            expect(response).toEqual(organization.originalWorkflowSteps);
+        });
+        it("getSelectedOrganizationValidations should return validations", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.getValidations = { validations: true };
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationValidations();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationValidations();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationValidations();
+
+            expect(response).toEqual(organization.getValidations);
+        });
+        it("getSelectedOrganizationValidations should return validations", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.getValidationResults = { validations: true };
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationValidationResults();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationValidationResults();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationValidationResults();
+
+            expect(response).toEqual(organization.getValidationResults);
+        });
         it("managementPaneIsActive should return a boolean", function () {
             var response = scope.managementPaneIsActive("test");
 
-            expect(response).toBe(false);
+            expect(response).toEqual(false);
 
             scope.activateManagementPane("test");
 
             response = scope.managementPaneIsActive("test");
-            expect(response).toBe(true);
+            expect(response).toEqual(true);
         });
         it("setDeleteDisabled should assign delete disabled", function () {
             var organization = new mockOrganization(q);
@@ -134,7 +381,7 @@ describe("controller: OrganizationSettingsController", function () {
 
             scope.setDeleteDisabled();
             scope.$digest();
-            expect(scope.deleteDisabled).toBe(null);
+            expect(scope.deleteDisabled).toEqual(null);
 
             scope.deleteDisabled = null;
             scope.selectedOrganization = organization;
@@ -142,21 +389,86 @@ describe("controller: OrganizationSettingsController", function () {
 
             scope.setDeleteDisabled();
             scope.$digest();
-            expect(scope.deleteDisabled).toBe(false);
+            expect(scope.deleteDisabled).toEqual(false);
 
             scope.deleteDisabled = null;
             OrganizationRepo.submissionsCount[organization.id] = 2;
 
             scope.setDeleteDisabled(organization.id);
             scope.$digest();
-            expect(scope.deleteDisabled).toBe(true);
+            expect(scope.deleteDisabled).toEqual(true);
         });
-        it("setSelectedOrganization should assign selected organization", function () {
+        it("rebuildOrganizationTree should rebuild the tree on resolve", function () {
             var organization1 = new mockOrganization(q);
             var organization2 = new mockOrganization(q);
             organization2.mock(dataOrganization2);
 
+            scope.organizations = [ organization1 ];
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([]);
+                });
+            };
+
+            scope.rebuildOrganizationTree();
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(0);
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([organization1, organization2]);
+                });
+            };
+
+            scope.rebuildOrganizationTree();
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(2);
+            expect(scope.organizations[0].id).toEqual(organization1.id);
+            expect(scope.organizations[1].id).toEqual(organization2.id);
+        });
+        it("rebuildOrganizationTree should not rebuild the tree on reject", function () {
+            var organization1 = new mockOrganization(q);
+            var organization2 = new mockOrganization(q);
+            var reason = "Testing rejection.";
+            organization2.mock(dataOrganization2);
+
+            scope.organizations = [ organization1 ];
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    reject(reason);
+                });
+            };
+
+            scope.rebuildOrganizationTree().catch(function (error) {
+                expect(error).toEqual(reason);
+            });
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(1);
+        });
+        it("setSelectedOrganization should assign selected organization", function () {
+            var organization1 = new mockOrganization(q);
+            var organization2 = new mockOrganization(q);
+            var organization3;
+            organization2.mock(dataOrganization2);
+
+            organization3 = angular.copy(organization2)
+            organization3.isModified = "from organization3";
+
             scope.selectedOrganization = organization2;
+
+            scope.loadingOrganization = true;
+
+            scope.setSelectedOrganization(organization1);
+
+            expect(scope.loadingOrganization).toEqual(true);
+            expect(scope.selectedOrganization.id).toEqual(organization2.id);
+
+            scope.loadingOrganization = false;
 
             scope.setSelectedOrganization();
 
@@ -178,21 +490,49 @@ describe("controller: OrganizationSettingsController", function () {
             OrganizationRepo.selectedOrganization = organization2;
             OrganizationRepo.selectedId = organization2.id;
 
-            var defer = q.defer();
-
             OrganizationRepo.getById = function (id, specific) {
-                return defer.promise;
+                return q(function (resolve, reject) {
+                    resolve(organization1);
+                });
             };
 
             spyOn(AccordionService, "closeAll");
 
             scope.setSelectedOrganization(organization1);
 
-            defer.resolve(organization1);
             scope.$digest();
 
             expect(scope.selectedOrganization.id).toEqual(organization1.id);
             expect(AccordionService.closeAll).toHaveBeenCalled();
+
+            organization2.parentOrganization = organization1;
+            organization1.childrenOrganizations = [ organization2 ];
+            scope.organizations = [ organization1, organization2 ];
+            scope.selectedOrganization = organization2;
+            organization1.$dirty = true;
+
+            OrganizationRepo.getById = function (id, specific) {
+                return q(function (resolve, reject) {
+                    resolve(organization3);
+                });
+            };
+
+            scope.setSelectedOrganization(organization1);
+
+            scope.$digest();
+
+            expect(scope.selectedOrganization.id).toEqual(organization3.id);
+            expect(scope.selectedOrganization.isModified).toEqual(organization3.isModified);
+
+            organization1.complete = true;
+            organization1.shallow = false;
+            organization1.$dirty = false;
+
+            scope.selectedOrganization = organization2;
+
+            scope.setSelectedOrganization(organization1);
+
+            expect(scope.selectedOrganization.id).toEqual(organization1.id);
         });
     });
 

--- a/src/main/webapp/tests/unit/controllers/settings/emailWorkflowRulesControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/emailWorkflowRulesControllerTest.js
@@ -12,11 +12,36 @@ describe("controller: EmailWorkflowRulesController", function () {
     };
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, _EmailTemplateRepo_, _ModalService_, _RestApi_, _StorageService_, _SubmissionStatusRepo_) {
+        inject(function ($controller, $injector, $rootScope, $timeout, SubmissionStates, _AccordionService_, _EmailTemplateRepo_, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _SidebarService_, _StorageService_, _SubmissionStatusRepo_, _StudentSubmissionRepo_, _UserService_, _UserSettings_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
+
+            // The controller being tested is included inside of a OrganizationSettingsController scope.
+            // This results in having additional methods on the scope that the controller being tested requires.
+            $controller("AbstractController", {
+                $injector: $injector,
+                $scope: scope,
+                $timeout: $timeout,
+                UserService: _UserService_,
+                UserSettings: _UserSettings_,
+                ManagedConfigurationRepo: _ManagedConfigurationRepo_,
+                StudentSubmissionRepo: _StudentSubmissionRepo_,
+                SubmissionStates: SubmissionStates
+            });
+
+            $controller("OrganizationSettingsController", {
+                $scope: scope,
+                $window: mockWindow(),
+                AccordionService: _AccordionService_,
+                ModalService: _ModalService_,
+                OrganizationRepo: OrganizationRepo,
+                RestApi: _RestApi_,
+                SidebarService: _SidebarService_,
+                StorageService: _StorageService_,
+                WsApi: WsApi
+            });
 
             controller = $controller("EmailWorkflowRulesController", {
                 $q: q,
@@ -115,7 +140,9 @@ describe("controller: EmailWorkflowRulesController", function () {
             var template = {id: 1};
             var emailRecipient = mockEmailRecipient(q);
             var submissionStatus = mockSubmissionStatus(q);
-            OrganizationRepo.selectedId = dataOrganization1.id;
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
 
             spyOn(scope, "resetEmailWorkflowRule");
 
@@ -130,7 +157,10 @@ describe("controller: EmailWorkflowRulesController", function () {
             scope.$digest();
         });
         it("buildRecipients should build the recipients", function () {
-            OrganizationRepo.selectedId = dataOrganization1.id;
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
+
             scope.recipients = null;
             scope.$digest();
 
@@ -150,7 +180,9 @@ describe("controller: EmailWorkflowRulesController", function () {
         });
         it("changeEmailWorkflowRuleActivation should change the email", function () {
             var working = null;
-            OrganizationRepo.selectedId = dataOrganization1.id;
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
 
             scope.changeEmailWorkflowRuleActivation("rule", working);
             scope.$digest();
@@ -169,8 +201,11 @@ describe("controller: EmailWorkflowRulesController", function () {
             expect(scope.openModal).toHaveBeenCalled();
         });
         it("deleteEmailWorkflowRule should delete the rule", function () {
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
+
             scope.emailWorkflowRuleDeleteWorking = null;
-            OrganizationRepo.selectedId = dataOrganization1.id;
 
             scope.deleteEmailWorkflowRule("rule");
             scope.$digest();
@@ -179,11 +214,13 @@ describe("controller: EmailWorkflowRulesController", function () {
         });
         it("editEmailWorkflowRule should reset the rule", function () {
             var emailRecipient = new mockEmailRecipient(q);
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
 
             emailRecipient.mock(dataEmailRecipient3);
             emailRecipient.data.id = 7;
 
-            OrganizationRepo.selectedId = dataOrganization1.id;
             scope.emailWorkflowRuleToEdit = {
                 emailRecipient: emailRecipient
             };
@@ -202,6 +239,9 @@ describe("controller: EmailWorkflowRulesController", function () {
         });
         it("openAddEmailWorkflowRuleModal should open a modal", function () {
             var emailRecipient = mockEmailRecipient(q);
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
 
             emailRecipient.mock(dataEmailRecipient3);
 
@@ -224,6 +264,9 @@ describe("controller: EmailWorkflowRulesController", function () {
             var emailRecipient2 = new mockEmailRecipient(q);
             var emailTemplate = new mockEmailTemplate(q);
             var emailTemplate2 = new mockEmailTemplate(q);
+            var organization = mockOrganization(q);
+
+            scope.selectedOrganization = organization;
 
             emailRecipient.mock(dataEmailRecipient3);
             emailRecipient2.mock(dataEmailRecipient2);

--- a/src/main/webapp/tests/unit/controllers/settings/organizationManagementControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/settings/organizationManagementControllerTest.js
@@ -359,12 +359,10 @@ describe("controller: OrganizationManagementController", function () {
         it("updateWorkflowStep should update a workflow step", function () {
             var workflowStep = new mockWorkflowStep(q);
 
-            spyOn(OrganizationRepo, "setToUpdate");
             spyOn(OrganizationRepo, "updateWorkflowStep");
 
             scope.updateWorkflowStep(workflowStep);
 
-            expect(OrganizationRepo.setToUpdate).toHaveBeenCalled();
             expect(OrganizationRepo.updateWorkflowStep).toHaveBeenCalled();
         });
     });

--- a/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
@@ -1,6 +1,6 @@
 describe("controller: NewSubmissionController", function () {
 
-    var controller, location, q, scope, OrganizationRepo, WsApi;
+    var controller, location, q, scope, Organization, OrganizationRepo, Submission, WsApi;
 
     var initializeVariables = function(settings) {
         inject(function ($location, $q, _OrganizationRepo_, _WsApi_) {
@@ -13,7 +13,7 @@ describe("controller: NewSubmissionController", function () {
     };
 
     var initializeController = function(settings) {
-        inject(function ($controller, $rootScope, SubmissionStates, _ManagedConfigurationRepo_, _ModalService_, _RestApi_, _StorageService_, _StudentSubmissionRepo_) {
+        inject(function ($controller, $rootScope, SubmissionStates, _ManagedConfigurationRepo_, _ModalService_, _Organization_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _Submission_) {
             scope = $rootScope.$new();
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
@@ -27,9 +27,11 @@ describe("controller: NewSubmissionController", function () {
                 SubmissionStates: SubmissionStates,
                 ManagedConfigurationRepo: _ManagedConfigurationRepo_,
                 ModalService: _ModalService_,
+                Organization: _Organization_,
                 OrganizationRepo: OrganizationRepo,
                 StorageService: _StorageService_,
                 StudentSubmissionRepo: _StudentSubmissionRepo_,
+                Submission: _Submission_,
                 RestApi: _RestApi_,
                 WsApi: WsApi
             });
@@ -47,10 +49,15 @@ describe("controller: NewSubmissionController", function () {
         module("mock.managedConfiguration");
         module("mock.managedConfigurationRepo");
         module("mock.modalService");
-        module("mock.organization");
+        module("mock.organization", function($provide) {
+            $provide.value("Organization", mockParameterModel(q, mockOrganization));
+        });
         module("mock.organizationRepo");
         module("mock.restApi");
         module("mock.storageService");
+        module("mock.submission", function($provide) {
+            $provide.value("Submission", mockParameterModel(q, mockSubmission));
+        });
         module("mock.studentSubmission");
         module("mock.studentSubmissionRepo");
         module("mock.wsApi");
@@ -101,11 +108,16 @@ describe("controller: NewSubmissionController", function () {
         });
         it("getSelectedOrganization should return an organization", function () {
             var response;
-            OrganizationRepo.selectedId = 1;
+            var organization = new mockOrganization(q);
+            organization.mock(dataOrganization1);
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
 
             response = scope.getSelectedOrganization();
 
-            expect(response.id).toBe(OrganizationRepo.selectedId);
+            expect(response.id).toBe(organization.id);
         });
         it("gotoSubmission should change the URL path", function () {
             var organization = new mockOrganization(q);

--- a/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/newSubmissionControllerTest.js
@@ -14,7 +14,9 @@ describe("controller: NewSubmissionController", function () {
 
     var initializeController = function(settings) {
         inject(function ($controller, $rootScope, SubmissionStates, _ManagedConfigurationRepo_, _ModalService_, _Organization_, _RestApi_, _StorageService_, _StudentSubmissionRepo_, _Submission_) {
-            scope = $rootScope.$new();
+            if (!settings || !settings.keepScope) {
+                scope = $rootScope.$new();
+            }
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
@@ -71,6 +73,18 @@ describe("controller: NewSubmissionController", function () {
         it("should be defined", function () {
             expect(controller).toBeDefined();
         });
+        it("should be defined with organizations tree loaded", function () {
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([ new mockOrganization(q) ]);
+                });
+            };
+
+            initializeController({ keepScope: true });
+
+            expect(scope.organizations).toBeDefined();
+            expect(scope.organizations.length).toEqual(1);
+        });
     });
 
     describe("Are the scope methods defined", function () {
@@ -81,6 +95,18 @@ describe("controller: NewSubmissionController", function () {
         it("getSelectedOrganization should be defined", function () {
             expect(scope.getSelectedOrganization).toBeDefined();
             expect(typeof scope.getSelectedOrganization).toEqual("function");
+        });
+        it("getSelectedOrganizationAcceptsSubmissions should be defined", function () {
+            expect(scope.getSelectedOrganizationAcceptsSubmissions).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationAcceptsSubmissions).toEqual("function");
+        });
+        it("getSelectedOrganizationId should be defined", function () {
+            expect(scope.getSelectedOrganizationId).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationId).toEqual("function");
+        });
+        it("getSelectedOrganizationName should be defined", function () {
+            expect(scope.getSelectedOrganizationName).toBeDefined();
+            expect(typeof scope.getSelectedOrganizationName).toEqual("function");
         });
         it("gotoSubmission should be defined", function () {
             expect(scope.gotoSubmission).toBeDefined();
@@ -94,6 +120,10 @@ describe("controller: NewSubmissionController", function () {
             expect(scope.setSelectedOrganization).toBeDefined();
             expect(typeof scope.setSelectedOrganization).toEqual("function");
         });
+        it("rebuildOrganizationTree should be defined", function () {
+            expect(scope.rebuildOrganizationTree).toBeDefined();
+            expect(typeof scope.rebuildOrganizationTree).toEqual("function");
+        });
     });
 
     describe("Do the scope methods work as expected", function () {
@@ -104,12 +134,24 @@ describe("controller: NewSubmissionController", function () {
             scope.createSubmission();
             scope.$digest();
 
-            expect(scope.creatingSubmission).toBe(false);
+            expect(scope.creatingSubmission).toEqual(false);
         });
         it("getSelectedOrganization should return an organization", function () {
             var response;
             var organization = new mockOrganization(q);
-            organization.mock(dataOrganization1);
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganization();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganization();
+
+            expect(response).toBeDefined();
+            expect(response.id).not.toBeDefined();
 
             OrganizationRepo.selectedId = organization.id;
             OrganizationRepo.selectedOrganization = organization;
@@ -117,7 +159,80 @@ describe("controller: NewSubmissionController", function () {
 
             response = scope.getSelectedOrganization();
 
-            expect(response.id).toBe(organization.id);
+            expect(response.id).toEqual(organization.id);
+        });
+        it("getSelectedOrganizationAcceptsSubmissions should return acceptsSubmissions", function () {
+            var response;
+            var organization = new mockOrganization(q);
+            organization.acceptsSubmissions = true;
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationAcceptsSubmissions();
+
+            expect(response).toEqual(organization.acceptsSubmissions);
+        });
+        it("getSelectedOrganizationId should return an ID", function () {
+            var response;
+            var organization = new mockOrganization(q);
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationId();
+
+            expect(response).toEqual(organization.id);
+        });
+        it("getSelectedOrganizationName should return a name", function () {
+            var response;
+            var organization = new mockOrganization(q);
+
+            scope.selectedOrganization = undefined;
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).not.toBeDefined();
+
+            scope.selectedOrganization = {};
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).not.toBeDefined();
+
+            OrganizationRepo.selectedId = organization.id;
+            OrganizationRepo.selectedOrganization = organization;
+            scope.selectedOrganization = organization;
+
+            response = scope.getSelectedOrganizationName();
+
+            expect(response).toEqual(organization.name);
         });
         it("gotoSubmission should change the URL path", function () {
             var organization = new mockOrganization(q);
@@ -126,6 +241,15 @@ describe("controller: NewSubmissionController", function () {
             scope.studentSubmissions[0].submissionStatus = { submissionState: "IN_PROGRESS" };
 
             spyOn(location, "path");
+
+            scope.gotoSubmission();
+            expect(location.path).not.toHaveBeenCalled();
+
+            scope.gotoSubmission({});
+            expect(location.path).not.toHaveBeenCalled();
+
+            scope.gotoSubmission({ id: "should not match" });
+            expect(location.path).not.toHaveBeenCalled();
 
             scope.gotoSubmission(organization);
             expect(location.path).toHaveBeenCalled();
@@ -139,14 +263,74 @@ describe("controller: NewSubmissionController", function () {
             var organization = new mockOrganization(q);
             scope.studentSubmissions = [];
 
+            response = scope.hasSubmission();
+
+            expect(response).toEqual(false);
+
+            response = scope.hasSubmission({});
+
+            expect(response).toEqual(false);
+
             response = scope.hasSubmission(organization);
-            expect(response).toBe(false);
+            expect(response).toEqual(false);
 
             scope.studentSubmissions = [ new mockStudentSubmission(q) ];
             scope.studentSubmissions[0].organization = organization;
 
             response = scope.hasSubmission(organization);
-            expect(response).toBe(true);
+            expect(response).toEqual(true);
+        });
+        it("rebuildOrganizationTree should rebuild the tree on resolve", function () {
+            var organization1 = new mockOrganization(q);
+            var organization2 = new mockOrganization(q);
+            organization2.mock(dataOrganization2);
+
+            scope.organizations = [ organization1 ];
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([]);
+                });
+            };
+
+            scope.rebuildOrganizationTree();
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(0);
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    resolve([organization1, organization2]);
+                });
+            };
+
+            scope.rebuildOrganizationTree();
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(2);
+            expect(scope.organizations[0].id).toEqual(organization1.id);
+            expect(scope.organizations[1].id).toEqual(organization2.id);
+        });
+        it("rebuildOrganizationTree should not rebuild the tree on reject", function () {
+            var organization1 = new mockOrganization(q);
+            var organization2 = new mockOrganization(q);
+            var reason = "Testing rejection.";
+            organization2.mock(dataOrganization2);
+
+            scope.organizations = [ organization1 ];
+
+            OrganizationRepo.getAllSpecific = function () {
+                return q(function (resolve, reject) {
+                    reject(reason);
+                });
+            };
+
+            scope.rebuildOrganizationTree().catch(function (error) {
+                expect(error).toEqual(reason);
+            });
+            scope.$digest();
+
+            expect(scope.organizations.length).toEqual(1);
         });
         it("setSelectedOrganization should select the organization", function () {
             var organization = new mockOrganization(q);
@@ -154,7 +338,7 @@ describe("controller: NewSubmissionController", function () {
 
             scope.setSelectedOrganization(organization);
 
-            expect(OrganizationRepo.selectedId).toBe(organization.id);
+            expect(OrganizationRepo.selectedId).toEqual(organization.id);
         });
     });
 });

--- a/src/main/webapp/tests/unit/models/organizationTest.js
+++ b/src/main/webapp/tests/unit/models/organizationTest.js
@@ -37,59 +37,13 @@ describe('model: Organization', function () {
     });
 
     describe('Are the model methods defined', function () {
-        it('addEmailWorkflowRule should be defined', function () {
-            expect(model.addEmailWorkflowRule).toBeDefined();
-            expect(typeof model.addEmailWorkflowRule).toEqual("function");
-        });
-        it('changeEmailWorkflowRuleActivation should be defined', function () {
-            expect(model.changeEmailWorkflowRuleActivation).toBeDefined();
-            expect(typeof model.changeEmailWorkflowRuleActivation).toEqual("function");
-        });
-        it('editEmailWorkflowRule should be defined', function () {
-            expect(model.editEmailWorkflowRule).toBeDefined();
-            expect(typeof model.editEmailWorkflowRule).toEqual("function");
-        });
         it('getWorkflowEmailContacts should be defined', function () {
             expect(model.getWorkflowEmailContacts).toBeDefined();
             expect(typeof model.getWorkflowEmailContacts).toEqual("function");
         });
-        it('removeEmailWorkflowRule should be defined', function () {
-            expect(model.removeEmailWorkflowRule).toBeDefined();
-            expect(typeof model.removeEmailWorkflowRule).toEqual("function");
-        });
     });
 
     describe('Are the model methods working as expected', function () {
-        it('addEmailWorkflowRule should call WsApi', function () {
-            spyOn(WsApi, 'fetch');
-
-            model.addEmailWorkflowRule(1, "test", 1);
-            scope.$digest();
-
-            expect(WsApi.fetch).toHaveBeenCalled();
-        });
-        it('changeEmailWorkflowRuleActivation should call WsApi', function () {
-            spyOn(WsApi, 'fetch');
-
-            model.changeEmailWorkflowRuleActivation({id: 1});
-            scope.$digest();
-
-            expect(WsApi.fetch).toHaveBeenCalled();
-        });
-        it('editEmailWorkflowRule should call WsApi', function () {
-            var rule = {
-                id: 1,
-                emailTemplate: new mockEmailTemplate(q),
-                recipient: "test"
-            };
-
-            spyOn(WsApi, 'fetch');
-
-            model.editEmailWorkflowRule(rule);
-            scope.$digest();
-
-            expect(WsApi.fetch).toHaveBeenCalled();
-        });
         it('getWorkflowEmailContacts should return an array', function () {
             var response;
             var fieldProfile = new mockFieldProfile(q);
@@ -111,14 +65,6 @@ describe('model: Organization', function () {
 
             expect(typeof response).toBe("object");
             expect(typeof response.length).toBe("number");
-        });
-        it('removeEmailWorkflowRule should call WsApi', function () {
-            spyOn(WsApi, 'fetch');
-
-            model.removeEmailWorkflowRule({id: 1});
-            scope.$digest();
-
-            expect(WsApi.fetch).toHaveBeenCalled();
         });
     });
 });

--- a/src/main/webapp/tests/unit/repos/organizationRepoTest.js
+++ b/src/main/webapp/tests/unit/repos/organizationRepoTest.js
@@ -47,9 +47,17 @@ describe("service: organizationRepo", function () {
     });
 
     describe("Are the repo methods defined", function () {
+        it('addEmailWorkflowRule should be defined', function () {
+            expect(repo.addEmailWorkflowRule).toBeDefined();
+            expect(typeof repo.addEmailWorkflowRule).toEqual("function");
+        });
         it("addWorkflowStep should be defined", function () {
             expect(repo.addWorkflowStep).toBeDefined();
             expect(typeof repo.addWorkflowStep).toEqual("function");
+        });
+        it('changeEmailWorkflowRuleActivation should be defined', function () {
+            expect(repo.changeEmailWorkflowRuleActivation).toBeDefined();
+            expect(typeof repo.changeEmailWorkflowRuleActivation).toEqual("function");
         });
         it("create should be defined", function () {
             expect(repo.create).toBeDefined();
@@ -67,6 +75,10 @@ describe("service: organizationRepo", function () {
             expect(repo.deleteWorkflowStep).toBeDefined();
             expect(typeof repo.deleteWorkflowStep).toEqual("function");
         });
+        it('editEmailWorkflowRule should be defined', function () {
+            expect(repo.editEmailWorkflowRule).toBeDefined();
+            expect(typeof repo.editEmailWorkflowRule).toEqual("function");
+        });
         it("getNewOrganization should be defined", function () {
             expect(repo.getNewOrganization).toBeDefined();
             expect(typeof repo.getNewOrganization).toEqual("function");
@@ -78,6 +90,10 @@ describe("service: organizationRepo", function () {
         it("ready should be defined", function () {
             expect(repo.ready).toBeDefined();
             expect(typeof repo.ready).toEqual("function");
+        });
+        it('removeEmailWorkflowRule should be defined', function () {
+            expect(repo.removeEmailWorkflowRule).toBeDefined();
+            expect(typeof repo.removeEmailWorkflowRule).toEqual("function");
         });
         it("reorderWorkflowSteps should be defined", function () {
             expect(repo.reorderWorkflowSteps).toBeDefined();
@@ -102,6 +118,14 @@ describe("service: organizationRepo", function () {
     });
 
     describe("Do the repo methods work as expected", function () {
+        it('addEmailWorkflowRule should call WsApi', function () {
+            spyOn(WsApi, 'fetch');
+
+            repo.addEmailWorkflowRule({id: 1}, 1, "test", 1);
+            scope.$digest();
+
+            expect(WsApi.fetch).toHaveBeenCalled();
+        });
         it("addWorkflowStep should add a step", function () {
             var workflowStep = new mockWorkflowStep(q);
 
@@ -117,6 +141,14 @@ describe("service: organizationRepo", function () {
             scope.$digest();
 
             // TODO
+        });
+        it('changeEmailWorkflowRuleActivation should call WsApi', function () {
+            spyOn(WsApi, 'fetch');
+
+            repo.changeEmailWorkflowRuleActivation({id: 1}, {id: 1});
+            scope.$digest();
+
+            expect(WsApi.fetch).toHaveBeenCalled();
         });
         it("create should create an organization", function () {
             var organization1 = new mockOrganization(q);
@@ -190,6 +222,20 @@ describe("service: organizationRepo", function () {
 
             // TODO
         });
+        it('editEmailWorkflowRule should call WsApi', function () {
+            var rule = {
+                id: 1,
+                emailTemplate: new mockEmailTemplate(q),
+                recipient: "test"
+            };
+
+            spyOn(WsApi, 'fetch');
+
+            repo.editEmailWorkflowRule({id: 1}, rule);
+            scope.$digest();
+
+            expect(WsApi.fetch).toHaveBeenCalled();
+        });
         it("getNewOrganization should return an organization", function () {
             WsApi.fetch = function() {
                 return payloadPromise(q.defer());
@@ -220,6 +266,14 @@ describe("service: organizationRepo", function () {
             scope.$digest();
 
             // TODO
+        });
+        it('removeEmailWorkflowRule should call WsApi', function () {
+            spyOn(WsApi, 'fetch');
+
+            repo.removeEmailWorkflowRule({id: 1}, {id: 1});
+            scope.$digest();
+
+            expect(WsApi.fetch).toHaveBeenCalled();
         });
         it("reorderWorkflowSteps should reorder the steps", function () {
             WsApi.fetch = function() {

--- a/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
+++ b/src/test/java/org/tdl/vireo/controller/OrganizationControllerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.test.context.ActiveProfiles;
 import org.tdl.vireo.exception.ComponentNotPresentOnOrgException;
 import org.tdl.vireo.exception.SystemEmailRuleNotDeleteableException;
@@ -142,6 +143,34 @@ public class OrganizationControllerTest extends AbstractControllerTest {
 
         List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
         assertEquals(organizations.size(), got.size());
+    }
+
+    @Test
+    public void testAllSpecificOrganizationsSpecificTree() {
+        when(organizationRepo.findViewAllByOrderByIdAsc(Mockito.<Class<Organization>>any())).thenReturn(organizations);
+
+        ApiResponse response = organizationController.getSpecificAllOrganizations("tree");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
+        assertEquals(organizations.size(), got.size());
+    }
+
+    @Test
+    public void testAllSpecificOrganizationsSpecificShallow() {
+        when(organizationRepo.findViewAllByOrderByIdAsc(Mockito.<Class<Organization>>any())).thenReturn(organizations);
+
+        ApiResponse response = organizationController.getSpecificAllOrganizations("shallow");
+        assertEquals(ApiStatus.SUCCESS, response.getMeta().getStatus());
+
+        List<?> got = (ArrayList<?>) response.getPayload().get("ArrayList<Organization>");
+        assertEquals(organizations.size(), got.size());
+    }
+
+    @Test
+    public void testAllSpecificOrganizationsInvalidSpecific() {
+        ApiResponse response = organizationController.getSpecificAllOrganizations("unknown and not valid");
+        assertEquals(ApiStatus.INVALID, response.getMeta().getStatus());
     }
 
     @Test


### PR DESCRIPTION
resolves #1842

Do not send the full Organization structure to the front-end for the triptych and related functionality to process.
Change the behavior to send a `tree view that has a minimal amount of data, essentially removing the recursive nature of the Organization and Workflow Step structure.
This allows for incredibly fast responses.

This works great for the New Submission view.
The Organization Settings Admin view, however, is another matter.

The Triptych stores the organization structure and selects the Organizations for editing via the Triptych's Organization tree structure (the parent-child properties).
These are loaded via the `tree` view and do not have the required data.
A new view, called `shallow` is created in order to load the necessary information while not loading the entire Organization.
The `shallow` load of an Organization is not as performant as I would like it to be.
Therefore, only load the `shallow` when necessary (which happens to be whenever the Organization is selected).

Once an Organization is selected and the `shallow` is loaded, subsequent selects end up causing a new load.
To prevent this, caching of the just loaded `shallow` Organization is performed.

Now the Organization needs to be designated as `dirty` so that any updates will trigger an appropriate reload.


### Java Side / Back End Changes

Add New end points:
1. `/all/{specific}`, where `specific` is any supported string (currently only `tree` and `shallow`).
   This loads all organizations for the given specific view.
2. `/get/{id}/{specific}`, where `specific` is any supported string (currently only `tree` and `shallow`).
   This loads a single organization for the given specific view.

Add a comment to `isComplete()` method as this is now more relevant than before.

The appropriate end points are added in the repo to facilitate the described behavior.

The model views are broken down further into two new types:
1. `SimpleModelView`: Only has one property, the `id`.
2. `SimpleNameModelView`: Only has two properties, the `id` and 'name'.

The model views are then updated to utilize these views as appropriate.

The following model views are then added:
1. `TreeOrganizationView`: A minimal Organization structure designed to provide the entire Organization tree.
2. `ShallowOrganizationView`: An expanded version of `TreeOrganizationView` designed to be editable via the Organization Settings Admin view.
3. `SimpleWorkflowStepView`: A minimal Workflow Step view designed to reduce the performance cost by only loading the required properties and is designed to be editable via the Organization Settings Admin view..

The `SimpleVocabularyWordView` is not used any more and so it is removed.


### UI: API Mapping Changes

The Field Profile and the Organization must now be lazy loaded.
They are causing a performance problem and are often loaded when the loaded data is not even being used.


### UI: `OrganizationRepo.getAll()`

The `OrganizationRepo.getAll()` is being called in numerous controllers when that data is not going to be used any more.
The `getAll()` is built into weaver-ui-core and must not be used when the goal here is to load a `tree` view or a `shallow` view.
This is also a major performance bottleneck.
The data loaded by this is also unavailable for direct manipulation and therefore cannot be used.

Get rid of all of these calls and implement the required behavior to perform the `tree` and `shallow` loads using the newly added end point.


### UI: Numerous views call things like `getSelectedOrganization().acceptsSubmissions` or `getSelectedOrganization().name`

This is not save in that if nothing is selected then there is an attempt to act on a property of `NULL`.
This is an error that becomes more fully exposed now that the data is being more dynamically loaded than before.
Add several functions that check the existence of the object in place of these (returning `NULL` otherwise).

The new functions are named using obvious names, such as changing `getSelectedOrganization().name` into `getSelectedOrganizationName()`.


### UI: Setting the Selected Organization

The mouse can be clicked while selecting, so add a `loadingOrganization` to prevent bad behavior that corrupt the local data.

When selecting the Organization, check to see if the Organization is already cached locally, is only loaded as `tree` in the cache, or the cached version is`dirty` and needs to be updated.
In these cases, perform the `shallow` load.

Of particular note is that the loaded Organizations must all reference the new `shallow` Organization where applicable.
Walk through the entire tree structure and update the existing Organization with the now downloaded `shallow` version.


### UI: Setting the Selected Organization, when Dirty

This has a notable performance hit and could use further optimization by breaking down the logic in cases when this is `dirty`.
This change set is big enough and so more granular improvements are skipped at this time.

A quick solution might be to walk through the local cache and perform the appropriate updates (if possible) on the local cached data.
Otherwise, do a `shallow` load, which is expensive (but still cheaper than loading the full Organization model).


### UI: Ready or Not

The `OrganizationRepo.ready(0` calls are not needed anymore as the full Organization list is not being loaded.
Instead, set `ready` when the Organization tree array is loaded.

When the Organization tree array is fully loaded, then select the first Organization as the selected Organization by default.

Each Organization in the tree array must be a proper Organization model object.
Walk through the entire tree array, including parents and children, instantiating each Organization as a proper Organization object.
Take care of designating that this is a `tree` view loaded Organization and is neither a `shallow` nor a `complete` Organization.

The rebuilding of the Organization to instantiate each Organization in the tree array must be made available so that the Triptych can trigger the rebuild when needed.
This includes when the Organization gets a `BROADCAST`, such as when an Organization is added or deleted.


### UI: A Lot is Tied to the Triptych

The Triptych is loaded by two Controllers:
1. `NewSubmissionController`
2. `OrganizationSettingsController`

The Triptych requires functions and properties to be defined in each of these.
Then the Triptych will include other Controllers that then make similar assumptions.

The Triptych child Controllers:
1. `emailWorkflowRulesController`
2. `fieldProfileManagementController`
3. `noteManagementController`
4. `organizationManagementController`
5. `organizationSideBarController`

Each of these has its own nuance and special behavior that needs to be appropriately updated and handled.
Each of these has its own view that must be updated as appropriate.

Changing any part of the Triptych affects all of these.

The Triptych is tied to those two Controllers above as well as the `OrganizationRepo`.
Any changes on these can force changes on all of the child Controllers.

Using reduced data, such as the `tree` view in an Organization therefore affects all of these Controllers and their (numerous) related views.

Each of the child view needs to take special care to set the selected Organization to be `dirty` on any change they perform.
Each of the child view should no longer load the full Organization repository.

The `organizationSideBarController` in particular keeps its own copy of the Organization data and needs to perform its own load of the Organization `tree` view.
Fortunately, this is an inexpensive operation.


### UI: The Triptych

Add a `repoListenLock` to prevent running the rebuild process too much (and therefore breaking things).
The timeout already exists, so just add a lock that unlocks once the timeout resolves and the task is resolved.
The timeout is greatly reduce to improve the re-load response time.
The lock will prevent most of the problems and should be better than the timeout.

The Triptych must recursively walk through the Organization tree until it finds the desired Organization.
A more centralized Organization design could allow for a cache where each Organization has a key mapped by the id at the top level to avoid the need for such complex searches.
This could then be further optimized to select from this cache rather than from the tree so that the tree need not be recursively updated (except on tree structural changes like adding and removing an Organization).
This is omitted due to additional complexity of such a change.


### UI: The Organization

The Organization has a several repository-type methods on the model.
This is inefficient as these methods are copied for every Organization, which has a processing cost (which is now shown to be a major performance bottleneck in general).
Re-locate these into the `OrganizationRepo`, accepting the appropriate Organization as a parameter.

This further fixes problems where the children Contollers may need information from the parent Controllers that is not necessarily available.



### UI: The Organization Repository

Expose the selected Organization so that one Controller in particular that requires this data but does not have it on its scope can access.

Add the `getAllSpecific()` method to handle fetching the appropriate Organization tree from the back end with the appropriate specific view mode.

For compatibility with other existing behavior, the `getSelectedOrganization()` method will call `findById()` as it did before.
This data is neither used or loaded and should return nothing in the Triptych use cases.
When the `findById()` returns nothing, then attempt to get using the explicitly saved selected Organization (`selectedOrganization`).

Update several end points to use the selectedId and not risk access on a `NULL` property.

As mentioned above in the "The Organization" section, add the repository specific methods pulled off of the Organization model.


### UI: Omitted Designs - Centralized Organization

There are additional changes that I experimented with.
One of which is using the `OrganizationRepo` as the one source of the loaded Organization array.
This worked well but involved a lot more changes.
To avoid adding even more code changes, I omitted this change.

Using a centralized Organization would be a design improvement in that all of the Organization repository loading data is in one place.
This would further reduce duplicate calls, such as how the `organizationSideBarController` currently works.


### UI: More Optimization is Still Needed

The performance problems are greatly reduced but the Organization Settings Admin View still loads slower than desirable for the individual (`shallow`) Organization data.

As suggested above, a more granular solution should be considered.

Editing the properties on an Organization is now slower due to the need to refresh the data due to a lack of more granular local cache management.


### UI: Unresolved Problem, Console Errors in Organization Settings Admin View

There are some errors that appear in the console log but do not have any functional impact.
Investigating these will take some time that I did not want to delay this change set further by.

I believe these are caused by data being accessed and the data is not fully loaded.
The problem is that the errors do not provide sufficient details on exactly where the problem happens.

The errors are like this:
```
Failed to set an indexed property on 'Window': Indexed property setter is not supported.
```

The error comes from weaver-ui-core not safely handling bad data.
The solution should be to just fix the bad data from happening.


### UI: Existing Problems - Locked Text Fields Show Nothing

This is a notable existing problem and is not caused by these changes.

I have observed this on several sprints after testing for them.
I thought this was fixed so maybe there was a merge error that caused the fix to get lost or otherwise not committed.


### Unit Tests for both Back End and Front End (UI)

~This commit does not include the appropriate unit tests given the size of the change set.~

~I will follow up this commit with some unit tests at some point.~

Unit tests are now added, including coverage on much of the newly added code.