### PR TITLE
Issue 1802: Manuscript File name is not being loaded.

### DIFF
--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -47,13 +47,16 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
         };
 
         var enrichDocumentTypeFieldValue = function (fieldValue) {
-            if (fieldValue.fileInfo === undefined && fieldValue.value !== undefined && fieldValue.value.length > 0) {
-                submission.fileInfo(fieldValue).then(function (response) {
-                    fieldValue.fileInfo = angular.fromJson(response.body).payload.ObjectNode;
-                });
-            }
-            if (fieldValue.value.length > 0 && submission.getFileType(fieldValue.fieldPredicate) === 'PRIMARY') {
-                submission.primaryDocumentFieldValue = fieldValue;
+            if (!!fieldValue.value) {
+                if (!fieldValue.fileInfo && fieldValue.value.length > 0) {
+                    submission.fileInfo(fieldValue).then(function (response) {
+                        fieldValue.fileInfo = angular.fromJson(response.body).payload.ObjectNode;
+                    });
+                }
+
+                if (fieldValue.value.length > 0 && submission.getFileType(fieldValue.fieldPredicate) === 'PRIMARY') {
+                    submission.primaryDocumentFieldValue = fieldValue;
+                }
             }
         };
 

--- a/src/main/webapp/app/views/submission/submissionHistory.html
+++ b/src/main/webapp/app/views/submission/submissionHistory.html
@@ -1,53 +1,50 @@
 <div class="container submission-history">
+    <ul class="breadcrumb">
+        <li><a href=".">Home</a></li>
+        <li class="active">Submissions</li>
+    </ul>
 
-	<ul class="breadcrumb">
-		<li><a href=".">Home</a></li>
-		<li class="active">Submissions</li>
-	</ul>
+    <div class="row page-head">
+        <h3 class="span11">Submission History</h3>
+    </div>
 
-	<div class="row page-head">
-		<h3 class="span11">Submission History</h3>
-	</div>
+    <div class="currently-accepting-submissions">Currently accepting submissions for the {{configuration.application.current_semester.value}} semester.</div>
 
-	<div class="currently-accepting-submissions">Currently accepting submissions for the {{configuration.application.current_semester.value}} semester.</div>
+    <div class="col-xs-12 history-table">
+        <table ng-table="tableParams" show-filter="false" class="table table-bordered table-striped etd-table">
+          <tr ng-repeat="row in $data track by row.id" ng-init="row.fetchDocumentTypeFileInfo()">
+            <td title="'Organization'">{{row.organization.name}}</td>
+            <td title="'Status'">{{row.submissionStatus.name}}</td>
+            <td title="'Document Title'">{{getDocumentTitle(row) || "No Title"}}</td>
+            <td title="'Manuscript File Name'">{{getManuscriptFileName(row, "No Primary Document")}}</td>
+            <td title="'Date Submitted'">{{row.submissionDate || "Not Submitted" | date: M/d/yyyy}}</td>
+            <td title="'Assigned To'">{{row.assignee.settings.displayName || "Not Assigned"}}</td>
+            <td title="'Actions'">
+                <button ng-if="row.submissionStatus.name === SubmissionStatuses.IN_PROGRESS" class="btn btn-danger" ng-click="confirmDelete(row)">Delete</button>
+                <a href="{{'submission/' + row.id}}" ng-if="row.submissionStatus.name === SubmissionStatuses.IN_PROGRESS" class="btn btn-primary">Continue</a>
+                <a href="{{'submission/' + row.id + '/view'}}" ng-if="row.submissionStatus.name !== SubmissionStatuses.IN_PROGRESS && row.submissionStatus.name !== SubmissionStatuses.NEEDS_CORRECTIONS" class="btn btn-primary">View</a>
+                <a href="{{'submission/' + row.id + '/view'}}" ng-if="row.submissionStatus.name === SubmissionStatuses.NEEDS_CORRECTIONS" class="btn btn-primary">Edit</a>
+            </td>
+          </tr>
+        </table>
 
-	<div class="col-xs-12 history-table">
-		<table ng-table="tableParams" show-filter="false" class="table table-bordered table-striped etd-table">
-	 	  <tr ng-repeat="row in $data track by row.id" ng-init="row.fetchDocumentTypeFileInfo()">
-			<td title="'Organization'">{{row.organization.name}}</td>
-			<td title="'Status'">{{row.submissionStatus.name}}</td>
-			<td title="'Document Title'">{{getDocumentTitle(row) || "No Title"}}</td>
-			<td title="'Manuscript File Name'">{{getManuscriptFileName(row) || "No Primary Document"}}</td>
-			<td title="'Date Submitted'">{{row.submissionDate || "Not Submitted" | date: M/d/yyyy}}</td>
-			<td title="'Assigned To'">{{row.assignee.settings.displayName || "Not Assigned"}}</td>
-			<td title="'Actions'">
-				<button ng-if="row.submissionStatus.name === SubmissionStatuses.IN_PROGRESS" class="btn btn-danger" ng-click="confirmDelete(row)">Delete</button>
-				<a href="{{'submission/' + row.id}}" ng-if="row.submissionStatus.name === SubmissionStatuses.IN_PROGRESS" class="btn btn-primary">Continue</a>
-				<a href="{{'submission/' + row.id + '/view'}}" ng-if="row.submissionStatus.name !== SubmissionStatuses.IN_PROGRESS && row.submissionStatus.name !== SubmissionStatuses.NEEDS_CORRECTIONS" class="btn btn-primary">View</a>
-				<a href="{{'submission/' + row.id + '/view'}}" ng-if="row.submissionStatus.name === SubmissionStatuses.NEEDS_CORRECTIONS" class="btn btn-primary">Edit</a>
-			</td>
-		  </tr>
-		</table>
+        <div ng-controller="SettingsController">
+            <button class="btn btn-primary" ng-if="multipleSubmissions() && studentsSubmissions.length > 0 && submissionsOpen()" ng-click="openModal('#confirmNewSubmission')">New Submission</button>
+            <button class="btn btn-primary" ng-if="multipleSubmissions() && studentsSubmissions.length === 0 && submissionsOpen()" ng-click="startNewSubmission('/submission/new')">New Submission</button>
+            <button class="btn btn-primary" ng-if="!multipleSubmissions() && studentsSubmissions.length === 0 && submissionsOpen()" ng-click="startNewSubmission('/submission/new')">New Submission</button>
+            <modal
+                modal-id="confirmNewSubmission"
+                modal-view="views/modals/submissions/confirmNewSubmission.html"
+                modal-header-class="modal-header-danger"
+                wvr-modal-backdrop="static">
+            </modal>
 
-		<div ng-controller="SettingsController">
-			<button class="btn btn-primary" ng-if="multipleSubmissions() && studentsSubmissions.length > 0 && submissionsOpen()" ng-click="openModal('#confirmNewSubmission')">New Submission</button>
-	    <button class="btn btn-primary" ng-if="multipleSubmissions() && studentsSubmissions.length === 0 && submissionsOpen()" ng-click="startNewSubmission('/submission/new')">New Submission</button>
-	    <button class="btn btn-primary" ng-if="!multipleSubmissions() && studentsSubmissions.length === 0 && submissionsOpen()" ng-click="startNewSubmission('/submission/new')">New Submission</button>
-
-			<modal
-				modal-id="confirmNewSubmission"
-				modal-view="views/modals/submissions/confirmNewSubmission.html"
-				modal-header-class="modal-header-danger"
-				wvr-modal-backdrop="static">
-			</modal>
-
-			<modal
-				modal-id="confirmDeleteSubmission"
-				modal-view="views/modals/submissions/confirmDeleteSubmission.html"
-				modal-header-class="modal-header-danger"
-				wvr-modal-backdrop="static">
-			</modal>
-
-		</div>
-	</div>
+            <modal
+                modal-id="confirmDeleteSubmission"
+                modal-view="views/modals/submissions/confirmDeleteSubmission.html"
+                modal-header-class="modal-header-danger"
+                wvr-modal-backdrop="static">
+            </modal>
+        </div>
+    </div>
 </div>

--- a/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/submissionHistoryControllerTest.js
@@ -120,17 +120,24 @@ describe("controller: SubmissionHistoryController", function () {
             expect(result).toBe(row.fieldValues[0].value);
         });
         it("getManuscriptFileName should return a manuscript file name", function () {
+            var defaultMessage = "default message";
+            var expectedMessage = "test";
             var result;
-            var row = { fieldValues: [ new mockFieldValue(q) ] };
+            var row = {
+                fieldValues: [ new mockFieldValue(q) ],
+                fileInfo: function (fieldValue) {
+                    return payloadPromise(q.defer());
+                }
+            };
 
-            result = scope.getManuscriptFileName(row);
-            expect(result).toBe(null);
+            result = scope.getManuscriptFileName(row, defaultMessage);
+            expect(result).toEqual(defaultMessage);
 
             row.fieldValues[0].fieldPredicate.value = "_doctype_primary";
-            row.fieldValues[0].fileInfo = { name: "test" };
+            row.fieldValues[0].fileInfo = { name: expectedMessage };
 
-            result = scope.getManuscriptFileName(row);
-            expect(result).toBe(row.fieldValues[0].fileInfo.name);
+            result = scope.getManuscriptFileName(row, defaultMessage);
+            expect(result).toEqual(expectedMessage);
         });
         it("startNewSubmission should close a modal", function () {
             scope.submissionToDelete = mockSubmission(q);


### PR DESCRIPTION
resolves #1802

On the Submission History view, the manuscript file name needs to be manually loaded using the submission call.
Do the fetch manually, updating the value as needed.
Change the behavior to have the default in the parameter rather than via an `||`.

A locking mechanism is in use to prevent problems with the digest cycles, ensuring only a single load.
The locking is implemented on a per field value id basis.

Simplify `enrichDocumentTypeFieldValue()` design to use a single check on `fieldValue.value`.