### PR TITLE
Issue 1858: Fix WYSIWYG in lock unlock fields, reverting previous approach.

### DIFF
--- a/.wvr/build-config.js
+++ b/.wvr/build-config.js
@@ -31,6 +31,10 @@ const config = {
       to: './node_modules/@wvr/core/app/views'
     },
     {
+      from: './node_modules/tinymce/skins',
+      to: './skins'
+    },
+    {
       from: './build/appConfig.js.template',
       to: './appConfig.js',
       transform(content) {
@@ -58,6 +62,9 @@ const config = {
       './node_modules/ng-file-upload/dist/ng-file-upload-shim.js',
       './node_modules/ng-file-upload/dist/ng-file-upload.js',
       './node_modules/tinymce/tinymce.js',
+      './node_modules/tinymce/themes/**/theme.js',
+      './node_modules/tinymce/plugins/**/plugin.js',
+      './node_modules/tinymce/icons/**/icons.js',
       './node_modules/angular-ui-tinymce/src/tinymce.js',
       './node_modules/angular-ui-bootstrap/dist/ui-bootstrap-tpls.js',
       './node_modules/file-saver/src/FileSaver.js',

--- a/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
+++ b/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
@@ -582,8 +582,7 @@
       hint="Customize any styling on the student side using CSS."
       scope-value="settings.configurable.lookAndFeel.custom_css.value"
       on-blur="updateConfiguration('lookAndFeel', 'custom_css')"
-      key-down="confirmEdit(event, prop)"
-      wysiwyg="false">
+      key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
     <!-- FRONT PAGE INSTRUCTIONS BEFORE BUTTON -->
@@ -592,8 +591,7 @@
       hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
       scope-value="settings.configurable.lookAndFeel.front_page_instructions_before.value"
       on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_before')"
-      key-down="confirmEdit(event, prop)"
-      wysiwyg="false">
+      key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
       <!-- FRONT PAGE INSTRUCTIONS AFTER BUTTON -->
@@ -602,8 +600,7 @@
       hint="These instructions are show on the front page of Vireo to all users. New lines are converted to paragraphs automatically."
       scope-value="settings.configurable.lookAndFeel.front_page_instructions_after.value"
       on-blur="updateConfiguration('lookAndFeel', 'front_page_instructions_after')"
-      key-down="confirmEdit(event, prop)"
-      wysiwyg="false">
+      key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
       <!-- POST SUBMISSION INSTRUCTIONS -->
@@ -612,8 +609,7 @@
       hint="These instructions will be shown on the confirmation page after a student has completed their submission. New lines are converted to paragraphs automatically."
       scope-value="settings.configurable.lookAndFeel.post_submission_instructions.value"
       on-blur="updateConfiguration('lookAndFeel', 'post_submission_instructions')"
-      key-down="confirmEdit(event, prop)"
-      wysiwyg="false">
+      key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
     <!-- POST CORRECTION INSTRUCTIONS-->
@@ -622,8 +618,7 @@
       hint="These instructions are shown on the confirmation page after a student has submitted corrections for their submission. New lines are converted to paragraphs automatically."
       scope-value="settings.configurable.lookAndFeel.post_correction_instructions.value"
       on-blur="updateConfiguration('lookAndFeel', 'post_correction_instructions')"
-      key-down="confirmEdit(event, prop)"
-      wysiwyg="false">
+      key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
   </form>

--- a/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
+++ b/src/main/webapp/app/views/admin/settings/application/lookAndFeel.html
@@ -582,7 +582,8 @@
       hint="Customize any styling on the student side using CSS."
       scope-value="settings.configurable.lookAndFeel.custom_css.value"
       on-blur="updateConfiguration('lookAndFeel', 'custom_css')"
-      key-down="confirmEdit(event, prop)">
+      key-down="confirmEdit(event, prop)"
+      wysiwyg="false">
     </lockingtextarea>
 
     <!-- FRONT PAGE INSTRUCTIONS BEFORE BUTTON -->

--- a/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
+++ b/src/main/webapp/app/views/admin/settings/organization/workflowsteps/workflowStepContent.html
@@ -39,8 +39,7 @@
         hint="These instructions are shown at the begining of this workflow step during the student submission process."
         scope-value="step.instructions"
         on-blur="updateWorkflowStep(step)"
-        key-down="confirmEdit(event, prop)"
-        wysiwyg="false">
+        key-down="confirmEdit(event, prop)">
     </lockingtextarea>
 
 <hr>

--- a/src/main/webapp/app/views/admin/settings/workflow/proquestUmiDegreeCodeSettings.html
+++ b/src/main/webapp/app/views/admin/settings/workflow/proquestUmiDegreeCodeSettings.html
@@ -32,8 +32,7 @@
       hint="Students may be required to accept this license as part of their submission. New lines are converted to paragraphs automatically."
       scope-value="settings.configurable.proquest_umi_degree_code.proquest_license.value"
       on-blur="updateConfiguration('proquest_umi_degree_code', 'proquest_license')"
-      timer="5"
-      wysiwyg="false">
+      timer="5">
     </lockingtextarea>
   </div>
 </div>

--- a/src/main/webapp/app/views/admin/settings/workflow/submissionLicense.html
+++ b/src/main/webapp/app/views/admin/settings/workflow/submissionLicense.html
@@ -5,8 +5,7 @@
             hint="Students may be required to accept this license as part of their submission. New lines are converted to paragraphs automatically."
             scope-value="settings.configurable.submission.submit_license.value"
             on-blur="updateConfiguration('submission', 'submit_license')"
-            timer="5"
-            wysiwyg="false">
+            timer="5">
         </lockingtextarea>
     </div>
 </div>

--- a/src/main/webapp/app/views/directives/lockingTextArea.html
+++ b/src/main/webapp/app/views/directives/lockingTextArea.html
@@ -1,31 +1,31 @@
 <div class="row">
-	<h4>{{ label }}<div tooltip="{{hint}}"><span class="glyphicon glyphicon-info-sign opaque color-reset"></span></div></h4>
-	
-	<div class="lock-control">
-    	<a ng-if="locked" ng-click="toggleLock()" class="hover-pointer">
-			<span class="glyphicon glyphicon-lock"> </span> This field is locked to prevent accidental editing, click to unlock.
-    	</a>
-    	
-		<p ng-if="!locked" ng-click="toggleLock()" class="hover-pointer">
-			<span class="glyphicon glyphicon-pencil"></span> This field is unlocked and may be edited. Leaving the editable area will save and re-lock the field. Save and re-lock will occur after 5 seconds of inactivity after editing.
-		</p>
-		
-		<div ng-show="!locked">
-			<div ng-if="wysiwyg !== 'false'">
-				<textarea 	ui-tinymce="tinymceOptions" 
-							ng-model="$parent.scopeValue">
-				</textarea>
-			</div>
-			<div ng-if="wysiwyg === 'false'">
-				<textarea 	class="form-control locking-text-area-not-wysiwyg" 
-							ng-model="$parent.scopeValue" 
-							ng-keypress="$parent.nonWysiwygTyping($event)"
-							ng-blur="$parent.nonWysiwygBlur()">
-				</textarea>
-			</div>
-		</div>
-		<div ng-show="locked" class="locking-text-area" ng-bind-html="scopeValue|trusted" disabled></div>
+    <h4>{{ label }}<div tooltip="{{hint}}"><span class="glyphicon glyphicon-info-sign opaque color-reset"></span></div></h4>
 
-		<div class="hint">{{ hint }}</div>
-	</div>
+    <div class="lock-control">
+        <a ng-if="locked" ng-click="toggleLock()" class="hover-pointer">
+            <span class="glyphicon glyphicon-lock"> </span> This field is locked to prevent accidental editing, click to unlock.
+        </a>
+
+        <p ng-if="!locked" ng-click="toggleLock()" class="hover-pointer">
+            <span class="glyphicon glyphicon-pencil"></span> This field is unlocked and may be edited. Leaving the editable area will save and re-lock the field. Save and re-lock will occur after 5 seconds of inactivity after editing.
+        </p>
+
+        <div ng-show="!locked">
+            <div ng-if="wysiwyg !== 'false'">
+                <textarea ui-tinymce="tinymceOptions"
+                          ng-model="$parent.scopeValue">
+                </textarea>
+            </div>
+            <div ng-if="wysiwyg === 'false'">
+                <textarea class="form-control locking-text-area-not-wysiwyg"
+                          ng-model="$parent.scopeValue"
+                          ng-keypress="$parent.nonWysiwygTyping($event)"
+                          ng-blur="$parent.nonWysiwygBlur()">
+                </textarea>
+            </div>
+        </div>
+        <div ng-show="locked" class="locking-text-area" ng-bind-html="scopeValue|trusted" disabled></div>
+
+        <div class="hint">{{ hint }}</div>
+    </div>
 </div>


### PR DESCRIPTION
resolves #1858 

Originally, the Locking Text Area fields were not working at some point in time.
This got fixed by disablying the wysiwyg attribute in this PR:
- https://github.com/TexasDigitalLibrary/Vireo/pull/1792

(For this issue: https://github.com/TexasDigitalLibrary/Vireo/issues/1776)

The lack of a `wysiwyg` attribute suggested that wysiwyg is supposed to be false.

That code was approved and merged in previous sprints.

The same bug was discovered a second time in different places and recorded here:
- https://github.com/TexasDigitalLibrary/Vireo/issues/1858

The solution chosen is to do the same exact approach as the previously approved code:
- https://github.com/TexasDigitalLibrary/Vireo/pull/1859

The problem is not the "=== 'wysiwyg'" and "!== 'wysiwyg'" checks.

Instead, the WYSIWYG data is not being loaded by the webpack.
This is essentially a regression from when the project switched to use webpack.

The "custom css" text area is left to have wysiwyg set to false.