### PR TITLE
real fix for pom for proquest and README regarding maven version 3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you would like to help with testing or development, GitHub issues and pull re
 
 ## Building
 
-Vireo build is done with [Maven](https://maven.apache.org/). The build is configured with [pom.xml](https://github.com/TexasDigitalLibrary/Vireo/blob/master/pom.xml) and [package.json](https://github.com/TexasDigitalLibrary/Vireo/blob/master/package.json). There are several command line arguments that can be used when packaging Vireo 4.
+Vireo build is done with [Maven](https://maven.apache.org/).  The most current maven compatible with vireo4 is 3.9.2.  Maven 3.9.3 is not compatible with the AngularJS used by vireo4. The build is configured with [pom.xml](https://github.com/TexasDigitalLibrary/Vireo/blob/master/pom.xml) and [package.json](https://github.com/TexasDigitalLibrary/Vireo/blob/master/package.json). There are several command line arguments that can be used when packaging Vireo 4.
 
 * ```-Dproduction``` will package production ready. **Required for Tomcat deployment or running as a jar**
 * ```-DskipTests``` will skip tests.

--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,6 @@
       <groupId>com.github.steveash.hnp</groupId>
       <artifactId>human-name-parser</artifactId>
       <version>0.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Somehow I failed to get these changes in main with an earlier PR.  This will remove an exclusion from pom.xml which stopped parsing for proquest (a regression) plus an update to the readme to notify people about maven compatibility versions.