### PR TITLE
Issue: Search Box does not appear after selecting it in the filter of the admin list.

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -149,7 +149,9 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
             var managerFilterColumns = ManagerFilterColumnRepo.getAll().filter(function excludeSearchBox(slc) {
                 return slc.title !== 'Search Box';
             });
-            var submissionListColumns = SubmissionListColumnRepo.getAll();
+            var submissionListColumns = SubmissionListColumnRepo.getAll().filter(function excludeSearchBox(slc) {
+                return slc.title !== 'Search Box';
+            });
 
             $scope.userColumns = angular.fromJson(angular.toJson(ManagerSubmissionListColumnRepo.getAll()));
 


### PR DESCRIPTION
This is the first solution described below that fully hides the "Search Box" from the filter list to avoid this confusion. The previous solution of hiding the "Search Box" is incomplete and still displays the "Search Box" in the "Disabled Filters" column. The "Search Box" is filtered out of the "Disabled Filters" by this commit.

The following are the results of the investigation into this problem: The Search Box filter, when selected, gets saved to the database and returned to the UI on an appropriate `/submission-list/filter-columns-by-user` call.

What is happening is that the Search Box is explicitly being removed from the filter list:
- https://github.com/TexasDigitalLibrary/Vireo/blob/61fb5873989eee667951f7b80244fa4f91c084ea/src/main/webapp/app/controllers/submission/submissionListController.js#L150

And then later is handled differently as an "Excluded Column":
- https://github.com/TexasDigitalLibrary/Vireo/blob/db2b4cacea96a29912138626fe1ed5985cb5d073/src/main/webapp/app/controllers/submission/submissionListController.js#L172

It appears to be originally added here with the exluded column:
- https://github.com/TexasDigitalLibrary/Vireo/commit/c39ff04784cf02e72a89e760f2ffec0442ce85f1
- https://github.com/TexasDigitalLibrary/Vireo/pull/285

Vireo Slack messages relating to Search Box:
- https://texas-digital-library.slack.com/archives/C7R78CADB/p1550676084006100
- https://texas-digital-library.slack.com/archives/C7R78CADB/p1682428409804819?thread_ts=1682428314.318099&cid=C7R78CADB
- https://texas-digital-library.slack.com/archives/C7R78CADB/p1550696674010100

Referenced Github issues from the conversations:
- https://github.com/TexasDigitalLibrary/Vireo/issues/1146