### PR TITLE
Revert "Bump tinymce from 5.10.9 to 7.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ng-csv": "0.3.6",
     "ng-sortable": "1.3.8",
     "ng-table": "3.1.0",
-    "tinymce": "7.0.0"
+    "tinymce": "5.10.9"
   },
   "overrides": {
     "debug": "4.3.4",


### PR DESCRIPTION
Reverts TexasDigitalLibrary/Vireo#1915
When 7.0.0 is used and an admin attempts to unlock a text editor in Settings > Look And Feel the text does not display.  Reverting this PR until further investigation can be done.