### PR TITLE
Cli submission generate improvements.

### DIFF
--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -2,12 +2,14 @@ package org.tdl.vireo.cli;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.Scanner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.tdl.vireo.model.User;
 import org.tdl.vireo.service.CliService;
 
 /**
@@ -23,7 +25,7 @@ import org.tdl.vireo.service.CliService;
 @Order(value = Ordered.LOWEST_PRECEDENCE)
 @Component
 public class Cli implements CommandLineRunner {
-    
+
     @Autowired
     CliService cliService;
 
@@ -40,106 +42,129 @@ public class Cli implements CommandLineRunner {
         Boolean running = runConsole ? true : false;
 
         if (running) {
+            final Scanner reader = new Scanner(System.in); // Reading from System.in
             final String PROMPT = "\n" + (char) 27 + "[36mvireo>" + (char) 27 + "[37m ";
-
-            Scanner reader = new Scanner(System.in); // Reading from System.in
             boolean expansive = false;
             int itemsGenerated = 0;
 
             System.out.print(PROMPT);
 
             while (running && reader.hasNextLine()) {
+                try {
+                    String n = reader.nextLine();
 
-                String n = reader.nextLine();
+                    n = n.trim();
 
-                n = n.trim();
+                    String[] commandTokens = n.split("\\s+");
+                    List<String> commandArgs = new ArrayList<String>();
 
-                String[] commandTokens = n.split("\\s+");
-                List<String> commandArgs = new ArrayList<String>();
+                    String command = null;
+                    int num1 = 0;
+                    int num2 = 0;
 
-                String command = null;
-                int num1 = 0;
-                int num2 = 0;
-
-                if (commandTokens.length > 0)
-                    command = commandTokens[0];
-                if (commandTokens.length > 1) {
-                    for (int i = 1; i < commandTokens.length; i++) {
-                        commandArgs.add(commandTokens[i]);
-                    }
-
-                }
-
-                switch (command) {
-                case "exit":
-                    System.out.println("\nGoodbye.");
-                    running = false;
-                    break;
-
-                case "accounts":
-                    num1 = 0;
-                    if (commandArgs.size() > 0) {
-                        try {
-                            num1 = Integer.parseInt(commandArgs.get(0));
-                        } catch (Exception e) {
-                            System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
+                    if (commandTokens.length > 0)
+                        command = commandTokens[0];
+                    if (commandTokens.length > 1) {
+                        for (int i = 1; i < commandTokens.length; i++) {
+                            commandArgs.add(commandTokens[i]);
                         }
+
                     }
 
-                    cliService.operateAccounts(expansive, num1);
-                    break;
+                    switch (command) {
+                    case "exit":
+                        System.out.println("\nGoodbye.");
+                        running = false;
+                        break;
 
-                case "admin_accounts":
-                    num1 = 0;
-                    if (commandArgs.size() > 0) {
-                        try {
-                            num1 = Integer.parseInt(commandArgs.get(0));
-                        } catch (Exception e) {
-                            System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
-                        }
-                    }
-
-                    cliService.operateAdminAccounts(expansive, num1);
-                    break;
-
-                case "expansive":
-                    expansive = !expansive;
-                    System.out.println("\nSet expansive = " + (expansive ? "true" : "false") + ".");
-                    break;
-
-                case "generate":
-                    num1 = 0;
-                    num2 = 100;
-                    if (commandArgs.size() > 0) {
-                        try {
-                            // First argument is number of submissions.
-                            num1 = Integer.parseInt(commandArgs.get(0));
-
-                            // Second argument is maximum action logs.
-                            if (commandArgs.size() > 1) {
-                                num2 = Integer.parseInt(commandArgs.get(1));
+                    case "accounts":
+                        num1 = 0;
+                        if (commandArgs.size() > 0) {
+                            try {
+                                num1 = Integer.parseInt(commandArgs.get(0));
+                            } catch (Exception e) {
+                                System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
                             }
-                        } catch (Exception e) {
-                            System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
                         }
+
+                        cliService.operateAccounts(expansive, num1);
+                        break;
+
+                    case "admin_accounts":
+                        num1 = 0;
+                        if (commandArgs.size() > 0) {
+                            try {
+                                num1 = Integer.parseInt(commandArgs.get(0));
+                            } catch (Exception e) {
+                                System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
+                            }
+                        }
+
+                        cliService.operateAdminAccounts(expansive, num1);
+                        break;
+
+                    case "expansive":
+                        expansive = !expansive;
+                        System.out.println("\nSet expansive = " + (expansive ? "true" : "false") + ".");
+                        break;
+
+                    case "generate":
+                        num1 = 0;
+                        num2 = 100;
+                        if (commandArgs.size() > 0) {
+                            try {
+                                // First argument is number of submissions.
+                                num1 = Integer.parseInt(commandArgs.get(0));
+
+                                // Second argument is maximum action logs.
+                                if (commandArgs.size() > 1) {
+                                    num2 = Integer.parseInt(commandArgs.get(1));
+                                }
+                            } catch (Exception e) {
+                                System.err.println("unable to parse as a number of items: " + commandArgs.get(0));
+                            }
+                        }
+
+                        {
+                            Random random = new Random();
+                            int idOffset = cliService.countUsers();
+                            User helpfulHarry = null;
+
+                            if (expansive) {
+                                helpfulHarry = cliService.createHelpfulHarry(idOffset++, CliService.EMAIL_DATE);
+                            }
+
+                            for (int i = itemsGenerated; i < num1 + itemsGenerated; i++) {
+                                cliService.operateGenerate(expansive, num2, random, idOffset, helpfulHarry, i);
+                                System.out.print("\r" + (i - itemsGenerated) + " of " + num1 + " generated...");
+                            }
+
+                            if (expansive) {
+                                System.out.println("\rGenerated " + num1 + " submissions expansively with max action logs of " + num2 + ".");
+                            } else {
+                                System.out.println("\rGenerated " + num1 + " submissions.");
+                            }
+
+                            itemsGenerated += num1;
+                        }
+
+                        break;
+
+                    case "":
+                        break;
+
+                    default:
+                        System.out.println("Unknown command " + n);
                     }
 
-                    cliService.operateGenerate(expansive, num1, num2, itemsGenerated);
-                    break;
+                    if (running) System.out.print(PROMPT);
 
-                case "":
-                    break;
-
-                default:
-                    System.out.println("Unknown command " + n);
+                } catch (Exception e) {
+                    e.printStackTrace();
                 }
-
-                if (running)
-                    System.out.print(PROMPT);
-
             }
-            reader.close();
 
+            reader.close();
         }
     }
 

--- a/src/main/java/org/tdl/vireo/cli/Cli.java
+++ b/src/main/java/org/tdl/vireo/cli/Cli.java
@@ -127,14 +127,14 @@ public class Cli implements CommandLineRunner {
 
                         {
                             Random random = new Random();
-                            int idOffset = cliService.countUsers();
+                            long idOffset = cliService.countUsers();
                             User helpfulHarry = null;
 
                             if (expansive) {
                                 helpfulHarry = cliService.createHelpfulHarry(idOffset++, CliService.EMAIL_DATE);
                             }
 
-                            for (int i = itemsGenerated; i < num1 + itemsGenerated; i++) {
+                            for (long i = itemsGenerated; i < num1 + itemsGenerated; i++) {
                                 cliService.operateGenerate(expansive, num2, random, idOffset, helpfulHarry, i);
                                 System.out.print("\r" + (i - itemsGenerated) + " of " + num1 + " generated...");
                             }

--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -110,7 +110,7 @@ public class CliService {
         }
     }
 
-    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, int idOffset, User helpfulHarry, int i) throws OrganizationDoesNotAcceptSubmissionsException {
+    public void operateGenerate(boolean expansive, int maxActionLogs, Random random, long idOffset, User helpfulHarry, long i) throws OrganizationDoesNotAcceptSubmissionsException {
         Calendar now = Calendar.getInstance();
         User submitter = userRepo.create("bob" + EMAIL_DATE.format(now.getTime()) + (idOffset + i + 1) + "@boring.bob", "bob", "boring " + (idOffset + i + 1), Role.ROLE_STUDENT);
         Credentials credentials = new Credentials();
@@ -303,8 +303,8 @@ public class CliService {
         submissionRepo.saveAndFlush(sub);
     }
 
-    public int countUsers() {
-        return userRepo.findAll().toArray().length;
+    public long countUsers() {
+        return userRepo.count();
     }
 
     public void setAcceptSubmissions(Organization organization) {
@@ -314,7 +314,7 @@ public class CliService {
         }
     }
 
-    public User createHelpfulHarry(int offset, SimpleDateFormat formatter) {
+    public User createHelpfulHarry(long offset, SimpleDateFormat formatter) {
         String dateString = formatter.format(Calendar.getInstance().getTime());
         return userRepo.create("harry" + dateString + offset + "@help.ful", "Harry", "Helpful " + offset, Role.ROLE_REVIEWER);
     }

--- a/src/main/java/org/tdl/vireo/service/CliService.java
+++ b/src/main/java/org/tdl/vireo/service/CliService.java
@@ -144,8 +144,6 @@ public class CliService {
                 programsVW.add(vw);
             } else if (vw.getControlledVocabulary().getName().equalsIgnoreCase("schools")) {
                 schoolsVW.add(vw);
-            } else if (vw.getControlledVocabulary().getName().equalsIgnoreCase("schools")) {
-                schoolsVW.add(vw);
             }
         });
 


### PR DESCRIPTION
This is a collection of several CLI improvements, mostly focused on Submission generation.

### Relocate `generate` CLI code outside of transaction and improve error handling.
The relocation allows for faster transactional operation. With the loop outside of the transaction, then the transaction can be committed for each pass. This then allows for reduced memory requirements for large transactions (such as when generate a huge amount of submissions).

The exception handling is improved by catching the exceptions at the CLI level such that CLI related exceptions can be reported without crashing the entire server. Now, if a CLI fails due to some error, then the server does not exit.

### Improve CLI generation, fixing embargoes to be actual embargoes and several others.
The embargoes are now generated from the actual list of embargoes. If there are no embargoes then it falls back to a randomly generated string.

Handle other similar cases that are easy to resolve at the same time. This makes the generated data more accurate and easier to test. Especially when using them for filtering.

### Switch to `localhost.localdomain` for example address.
This is done to avoid any potential accidents if e-mails are sent.

### Improve performance of CLI generate.
Doing a `findAll()` and then counting the length of the array is highly inefficient.
Using `findAll()` slowing down the generation of large data sets for testing.
Change the code to an SQL count via the JPA `count()` method.