### PR TITLE
Issue 1931: Pagination not working properly for combined filters list.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/SubmissionRepoImpl.java
@@ -429,16 +429,12 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
         });
 
         StringBuilder sqlSelectBuilder = new StringBuilder("SELECT DISTINCT ");
-        StringBuilder sqlCountSelectBuilder = new StringBuilder();
 
         Map<Long, ArrayList<StringBuilder>> sqlColumnsBuilders = new HashMap<>();
-        Map<String, ArrayList<StringBuilder>> sqlCountWhereFilterBuilders = new HashMap<>();
-        Map<Long, StringBuilder> sqlCountWherePredicate = new HashMap<>();
         List<String> sqlAliasBuilders = new ArrayList<>();
 
         StringBuilder sqlJoinsBuilder = new StringBuilder();
         StringBuilder sqlBuilder;
-        StringBuilder sqlCountBuilder;
         StringBuilder sqlWheresExcludeBuilder = new StringBuilder();
         StringBuilder sqlOrderBysBuilder = new StringBuilder();
 
@@ -486,13 +482,11 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = new StringBuilder();
-                        sqlCountBuilder = new StringBuilder();
 
                         switch (submissionListColumn.getInputType().getName()) {
                         case "INPUT_DEGREEDATE":
                             // Column's values are of type 'MMMM yyyy' (in SQL date format would be 'Month YYYY').
                             sqlBuilder.append("LOWER(pfv").append(n).append(".value) = LOWER('").append(filterString).append("')");
-                            sqlCountBuilder.append("LOWER(fv.value) = LOWER('").append(filterString).append("')");
                             break;
                         case "INPUT_DATE":
                             // Column's values are of type 'yyyy-mm-dd' as required by the SQL standard to represent a date without time.
@@ -504,35 +498,20 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                                     .append(".value AS DATE) BETWEEN CAST('").append(dates[0])
                                     .append("' AS DATE) AND CAST('").append(dates[1])
                                     .append("' AS DATE)");
-                                sqlCountBuilder
-                                    .append("CAST(fv.value AS DATE) BETWEEN CAST('").append(dates[0])
-                                    .append("' AS DATE) AND CAST('").append(dates[1])
-                                    .append("' AS DATE)");
                             } else {
                                 // Date Match
                                 sqlBuilder.append("pfv").append(n).append(".value = '").append(filterString).append("'");
-                                sqlCountBuilder.append("fv.value = '").append(filterString).append("'");
                             }
                             break;
                         case "INPUT_CHECKBOX":
                             sqlBuilder.append("pfv").append(n).append(".value = '").append(filterString).append("'");
-                            sqlCountBuilder.append("fv.value = '").append(filterString).append("'");
 
                             // Column's values are a boolean
                             if (!Boolean.valueOf(filterString)) {
                                 sqlWhereBuilderList.add(sqlBuilder);
 
-                                if (!sqlCountWherePredicate.containsKey(predicateId)) {
-                                    sqlCountWherePredicate.put(predicateId, new StringBuilder());
-                                }
-
-                                sqlCountWherePredicate.get(predicateId).append(" (").append(sqlCountBuilder).append(") OR");
-
                                 sqlBuilder = new StringBuilder();
                                 sqlBuilder.append(" pfv").append(n).append(".value IS NULL");
-
-                                sqlCountBuilder = new StringBuilder();
-                                sqlCountBuilder.append(" fv.value IS NULL");
                             }
 
                             break;
@@ -541,11 +520,9 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                             if (submissionListColumn.getExactMatch()) {
                                 // perform exact match
                                 sqlBuilder.append("pfv").append(n).append(".value = '").append(filterString).append("'");
-                                sqlCountBuilder.append("fv.value = '").append(filterString).append("'");
                             } else {
                                 // perform like when input from text field
                                 sqlBuilder.append("LOWER(pfv").append(n).append(".value) LIKE '%").append(escapeString(filterString)).append("%'");
-                                sqlCountBuilder.append("LOWER(fv.value) LIKE '%").append(escapeString(filterString)).append("%'");
                             }
 
                             break;
@@ -553,12 +530,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
 
                         if (sqlBuilder.length() > 0) {
                             sqlWhereBuilderList.add(sqlBuilder);
-
-                            if (!sqlCountWherePredicate.containsKey(predicateId)) {
-                                sqlCountWherePredicate.put(predicateId, new StringBuilder());
-                            }
-
-                            sqlCountWherePredicate.get(predicateId).append(" (").append(sqlCountBuilder).append(") OR");
                         }
                     }
 
@@ -589,7 +560,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         sqlBuilder = new StringBuilder();
                         sqlBuilder.append("s").append(".id = ").append(filterString);
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "id").add(sqlBuilder);
                     }
 
                     break;
@@ -599,7 +569,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         .append("\nLEFT JOIN submission_status ss ON ss.id=s.submission_status_id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     if (submissionListColumn.getSortOrder() > 0) {
                         setColumnOrdering(submissionListColumn.getSort(), sqlAliasBuilders, sqlOrderBysBuilder, "ss.name");
@@ -616,7 +585,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         }
 
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "submissionStatus.name").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -635,7 +603,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                             .append("\nLEFT JOIN organization o ON o.id=s.organization_id");
 
                         sqlJoinsBuilder.append(sqlBuilder);
-                        sqlCountSelectBuilder.append(sqlBuilder);
                     }
 
                     if (submissionListColumn.getSortOrder() > 0) {
@@ -654,7 +621,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         }
 
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "organization.name").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -675,7 +641,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     sqlBuilder.append("\nLEFT JOIN organization_category oc ON oc.id=o.category_id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     if (submissionListColumn.getSortOrder() > 0) {
                         setColumnOrdering(submissionListColumn.getSort(), sqlAliasBuilders, sqlOrderBysBuilder, "oc.name");
@@ -692,7 +657,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         }
 
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "organization.category.name").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -709,7 +673,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         .append("\nLEFT JOIN weaver_users a ON a.id=s.assignee_id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     if (submissionListColumn.getSortOrder() > 0) {
                         setColumnOrdering(submissionListColumn.getSort(), sqlAliasBuilders, sqlOrderBysBuilder, "a.email");
@@ -727,7 +690,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         }
 
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "assignee.email").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -749,7 +711,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         .append("\n   ON embs.submission_id=s.id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     if (submissionListColumn.getSortOrder() > 0) {
                         setColumnOrdering(submissionListColumn.getSort(), sqlAliasBuilders, sqlOrderBysBuilder, "embs.name");
@@ -767,7 +728,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         }
 
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "embargoTypes.name").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -790,7 +750,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         .append("\n   ON action_logs_id = s.submission_status_id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     // TODO: finish sqlWheresBuilder.
 
@@ -821,7 +780,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = buildSubmissionDateFieldString("submission_date", filterString);
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "submissionDate").add(sqlBuilder);
                     }
 
                     break;
@@ -834,7 +792,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = buildSubmissionDateFieldString("approve_application_date", filterString);
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "approveApplicationDate").add(sqlBuilder);
                     }
 
                     break;
@@ -847,7 +804,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = buildSubmissionDateFieldString("approve_advisor_date", filterString);
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "approveAdvisorDate").add(sqlBuilder);
                     }
 
                     break;
@@ -860,7 +816,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = buildSubmissionDateFieldString("approve_embargo_date", filterString);
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "approveEmbargoDate").add(sqlBuilder);
                     }
 
                     break;
@@ -874,13 +829,11 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         .append("\n   ON scavcavcad.submission_id = s.id");
 
                     sqlJoinsBuilder.append(sqlBuilder);
-                    sqlCountSelectBuilder.append(sqlBuilder);
 
                     for (String filterString : submissionListColumn.getFilters()) {
                         sqlBuilder = new StringBuilder();
                         sqlBuilder.append("scavcavcad.value = true AND scavcavcad.label = '" + filterString + "'");
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "customActionValues").add(sqlBuilder);
                     }
 
                     break;
@@ -894,7 +847,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         sqlBuilder = new StringBuilder();
                         sqlBuilder.append("LOWER(s").append(".depositurl) LIKE '%").append(escapeString(filterString)).append("%'");
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "depositurl").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -915,7 +867,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
                         sqlBuilder = new StringBuilder();
                         sqlBuilder.append("LOWER(s").append(".reviewer_notes) LIKE '%").append(escapeString(filterString)).append("%'");
                         sqlWhereBuilderList.add(sqlBuilder);
-                        getFromBuildersMap(sqlCountWhereFilterBuilders, "reviewer_notes").add(sqlBuilder);
                     }
 
                     // all column search filter
@@ -942,7 +893,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
         });
         sqlSelectBuilder.setLength(sqlSelectBuilder.length() - 2);
         sqlSelectBuilder.append(" FROM submission s");
-        sqlCountSelectBuilder.insert(0, "SELECT COUNT(DISTINCT s.id) FROM submission s");
 
         // if ordering, complete order by clause and strip the tailing comma
         if (sqlOrderBysBuilder.length() > 0) {
@@ -989,54 +939,8 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
             }
         }
 
-        if (sqlCountWherePredicate.size() > 0 || sqlCountWhereFilterBuilders.size() > 0 || sqlWheresExcludeBuilder.length() > 0) {
-
-            // Conditions are AND across different predicates but are OR within the same predicate.
-            if (sqlCountWherePredicate.size() > 0) {
-                sqlCountSelectBuilder.append("\nLEFT JOIN submission_field_values sfv ON s.id = sfv.submission_id");
-                sqlCountSelectBuilder.append("\nINNER JOIN field_value fv ON sfv.field_values_id = fv.id");
-                sqlCountSelectBuilder.append("\nWHERE");
-
-                sqlCountWherePredicate.forEach((id, filter) -> {
-                    if (filter.length() > 0) {
-                        // Remove the last " OR".
-                        filter.setLength(filter.length() - 3);
-
-                        sqlCountSelectBuilder
-                            .append("\n(fv.field_predicate_id = ").append(id)
-                            .append(" AND (").append(filter).append(")) AND");
-                    }
-                });
-            } else {
-                sqlCountSelectBuilder.append("\nWHERE");
-            }
-
-            // Conditions are AND across different filters and OR within the same filter.
-            if (sqlCountWhereFilterBuilders.size() > 0) {
-                sqlCountWhereFilterBuilders.forEach((key, list) -> {
-                    sqlCountSelectBuilder.append(" (");
-
-                    list.forEach(filter -> {
-                        sqlCountSelectBuilder.append(" (").append(filter).append(") OR");
-                    });
-
-                    // Remove the last " OR".
-                    sqlCountSelectBuilder.setLength(sqlCountSelectBuilder.length() - 3);
-
-                    sqlCountSelectBuilder.append(")\n AND");
-                });
-            }
-
-            if (sqlWheresExcludeBuilder.length() > 0) {
-                sqlCountSelectBuilder.append("\n(").append(sqlWheresExcludeBuilder).append(")");
-            } else {
-                // remove last " AND"
-                sqlCountSelectBuilder.setLength(sqlCountSelectBuilder.length() - 4);
-            }
-        }
-
         String sqlQuery = sqlSelectBuilder.toString() + sqlJoinsBuilder.toString() + sqlBuilder.toString();
-        String sqlCountQuery = sqlCountSelectBuilder.toString();
+        String sqlCountQuery = "SELECT COUNT(DISTINCT s.id) FROM submission s" + sqlJoinsBuilder.toString() + sqlBuilder.toString();
 
         if (pageable != null) {
             // determine the offset and limit of the query
@@ -1128,22 +1032,6 @@ public class SubmissionRepoImpl extends AbstractWeaverRepoImpl<Submission, Submi
             .append("s.").append(column)
             .append(" = CAST('").append(filter)
             .append("' AS DATE)");
-    }
-
-    /**
-     * Get the builders list array for some key, initializing that key if not found.
-     *
-     * @param map The map of builders to select from.
-     * @param key The identifier.
-     *
-     * @return An array of the builders for the given key.
-     */
-    private ArrayList<StringBuilder> getFromBuildersMap(Map<String, ArrayList<StringBuilder>> map, String key) {
-        if (!map.containsKey(key)) {
-            map.put(key, new ArrayList<StringBuilder>());
-        }
-
-        return map.get(key);
     }
 
     /**


### PR DESCRIPTION
resolves #1931

This is a regression from the aggressive performance optimizations such as commit b2c538c5c9c7d99a18c9f8c2c47b8cc98c01a260.

The case that is not correctly handled is where there are multiple separate field values being selected and filtered upon.

Instead of fully removing the optimization, this uses the optimization when there are zero or one field_values being filtered on. Then when there are two or more field_values then omit the optimization.