### PR TITLE
Unable to re-arrange the submission workflow in Manage Workflow.

### DIFF
--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -131,6 +131,13 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
                 $scope.resetWorkflowSteps();
             }
         });
+
+        OrganizationRepo.listen(ApiResponseActions.READ, function (res) {
+            var resObj = !!res && !!res.body ? angular.fromJson(res.body) : {};
+            if (!!resObj && !!resObj.meta && !!resObj.meta.status && resObj.meta.status === 'SUCCESS') {
+              $scope.resetManageOrganization($scope.getSelectedOrganization());
+            }
+        });
     });
 
     $scope.acceptsSubmissions = [{

--- a/src/main/webapp/app/controllers/settings/organizationManagementController.js
+++ b/src/main/webapp/app/controllers/settings/organizationManagementController.js
@@ -98,11 +98,13 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
     };
 
     $scope.reorderWorkflowStepUp = function (workflowStepID) {
+        $scope.getSelectedOrganization().$dirty = true;
         AccordionService.closeAll();
         return OrganizationRepo.reorderWorkflowSteps("up", workflowStepID);
     };
 
     $scope.reorderWorkflowStepDown = function (workflowStepID) {
+        $scope.getSelectedOrganization().$dirty = true;
         AccordionService.closeAll();
         return OrganizationRepo.reorderWorkflowSteps("down", workflowStepID);
     };
@@ -123,18 +125,12 @@ vireo.controller("OrganizationManagementController", function ($controller, $loc
     $scope.ready.then(function () {
         $scope.resetWorkflowSteps();
 
-        OrganizationRepo.listen(function () {
-            $scope.resetWorkflowSteps();
+        OrganizationRepo.listen(function (res) {
+            var resObj = !!res && !!res.body ? angular.fromJson(res.body) : {};
+            if (!!resObj && !!resObj.meta && !!resObj.meta.status && resObj.meta.status === 'SUCCESS') {
+                $scope.resetWorkflowSteps();
+            }
         });
-
-        OrganizationRepo.listen(ApiResponseActions.READ, function () {
-            $scope.resetManageOrganization();
-        });
-
-        OrganizationRepo.listen(ApiResponseActions.BROADCAST, function () {
-            $scope.resetManageOrganization();
-        });
-
     });
 
     $scope.acceptsSubmissions = [{


### PR DESCRIPTION
The organization is being changed but the dirty flag is not being set. Manually set the dirty flag before sending.

The `OrganizationRepo` listeners are either not doing anything or they are not checking for when status is a failure.
The `ApiResponseActions.READ` and `ApiResponseActions.BROADCAST` never do anything because the `resetManageOrganization()` only does something when the organization is provided.
No organization is being provided.

The `OrganizationRepo.listen(ApiResponseActions.READ, function (res) {` now makes the function do something rather than being a no-op functon. The organization, if one is selected, is now reset with the selected organization.

The `BROADCAST` listener is removed.