### PR TITLE
Add new environment variables to the example environment file.

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,5 +1,5 @@
 ##############################
-# Create a .env file next to 
+# Create a .env file next to
 # this one with actual values.
 ##############################
 
@@ -30,12 +30,14 @@ SPRING_DATASOURCE_DRIVERCLASSNAME=org.postgresql.Driver
 SPRING_DATASOURCE_USERNAME=vireo
 SPRING_DATASOURCE_PASSWORD=vireo
 
-
 # location to place templated appConfig.js
 APP_PATH=/var/vireo
 # must match directory of APP_PATH
 APP_CONFIG_URI=file:/var/vireo/appConfig.js
 APP_ASSETS_URI=file:/var/vireo/
+#APP_DATALOADER_INITIALIZE=false
+#APP_FILTER_EMBARGOTYPENONE=None
+#APP_FILTER_SUBMISSIONTYPENONE=Unknown
 
 AUTH_SECURITY_JWT_SECRET=verysecretsecret
 AUTH_SECURITY_JWT_ISSUER=vireo


### PR DESCRIPTION
This is a follow up to these PRs and depends on them (but does not include them):
- #1937
- #1938

These are added as commented out so that the default `application.yml` settings are used.

The `APP_DATALOADER_INITIALIZE` should only be `true` for the initial setup but after that it is recommended to set this to `false`.

The `APP_FILTER_EMBARGOTYPENONE` and `APP_FILTER_SUBMISSIONTYPENONE` should be set to `None` as the default. These can be changed as needed, such as setting `APP_FILTER_SUBMISSIONTYPENONE` to `Unknown`.