### PR TITLE
Fix error handling for batch exports

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -41,6 +41,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
@@ -532,12 +533,13 @@ public class SubmissionController {
     }
 
     private void handleBatchExportError(Exception e, HttpServletResponse response) throws IOException {
-        LOG.info("Error With Export",e);
+        LOG.info("Error With Export", e);
         String responseMessage = "Something went wrong with the export!";
-        response.sendError(500, responseMessage);
-        response.setContentType("application/json");
         ApiResponse apiResponse = new ApiResponse(ERROR, responseMessage);
+        response.reset();
+        response.setContentType("application/json");
         response.getOutputStream().print(objectMapper.writeValueAsString(apiResponse));
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 
     @SuppressWarnings("unchecked")
@@ -668,9 +670,6 @@ public class SubmissionController {
                         b.putNextEntry(new ZipEntry(personName+fType));
                         b.write(fileBytes);
                         b.closeEntry();
-
-                    }catch(IOException ioe){
-                        ioe.printStackTrace();
                     }
                     zos.putNextEntry(new ZipEntry("upload_"+personName+".zip"));
                     baos.close();

--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -440,9 +440,11 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
         var batchDownloadExport = function (packager, filterId) {
             $scope.advancedfeaturesBox.exporting = true;
             SubmissionRepo.batchExport(packager, filterId).then(function (data) {
-                saveAs(new Blob([data], {
-                    type: packager.mimeType
-                }), packager.name + '.' + packager.fileExtension);
+                if (!data.meta || !data.meta.status || data.meta.status !== "ERROR") {
+                    saveAs(new Blob([data], {
+                        type: packager.mimeType
+                    }), packager.name + '.' + packager.fileExtension);
+                }
                 resetBatchProcess();
             });
         };


### PR DESCRIPTION
When an error occurrs while building the export, the error response gets written directly to the output stream, resulting in a corrupted export file and no indication from the UI that there was an error.

This PR restructures the backend export process to only write the export to the output stream when there are no errors and return an appropriate status code and apiResponse when there are error(s). 

The front end has also been updated to only deliver the response as a file download if it's error free.

With these changes, the error response is now able to be caught and displayed by the standard alert handling in the UI.