### PR TITLE
Fix timezone issue for submission status sidebox display

### DIFF
--- a/src/main/webapp/app/views/sideboxes/submissionStatus.html
+++ b/src/main/webapp/app/views/sideboxes/submissionStatus.html
@@ -20,7 +20,7 @@
 			is-open="date"
 			close-text="Close"
 			stringtodate>
-			<span ng-if="!box.savingDate" class="glyphicon glyphicon-pencil"></span> <span ng-if="box.savingDate" class="glyphicon glyphicon-refresh spinning"></span> {{box.submission.submissionDate || "not submitted" | date: 'M/d/yyyy'}}
+			<span ng-if="!box.savingDate" class="glyphicon glyphicon-pencil"></span> <span ng-if="box.savingDate" class="glyphicon glyphicon-refresh spinning"></span> {{box.submission.submissionDate || "not submitted" | date: 'M/d/yyyy' : 'UTC'}}
 		</li>
 
 		<li><button ng-click="openModal('#advisorEmail')" class="btn btn-default">Generate Advisor Email</button></li>


### PR DESCRIPTION
We were seeing the problem described [here](https://stackoverflow.com/questions/20662140/using-angularjs-date-filter-with-utc-date) in the submission status sidebox, and applying the suggested fix resolved the issue.

