### PR TITLE
Account for ActionLog object type in ExcelPackager

### DIFF
--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -24,7 +24,7 @@ import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.SubmissionListColumn;
 import org.tdl.vireo.model.export.ExcelExportPackage;
 import org.tdl.vireo.model.formatter.AbstractFormatter;
-
+import org.tdl.vireo.model.ActionLog;
 import edu.tamu.weaver.data.utility.EntityUtility;
 
 @Entity
@@ -111,6 +111,9 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                         } else if (valueAsObject instanceof User){
                             User user = (User) valueAsObject;
                             value = user.getName().toString();
+                        } else if (valueAsObject instanceof ActionLog){
+                            ActionLog actionLog = (ActionLog) valueAsObject;
+                            value = actionLog.getEntry().toString();
                         } else {
                             value = valueAsObject.toString();
                         }


### PR DESCRIPTION
### Issue:

When exporting a list to Excel using `BATCH OPERATIONS` -> `Download Export` -> `Export Format` -> `Excel`, the `Last Event/Last Action` column in the exported Excel file would not show the actual text from the Action Log as seen in the UI, but shown as a reference to the object/instance instead, such as `org.tdl.vireo.model.ActionLog@1234ab`. The `ExcelPackager` didn't account for the `ActionLog` object type in the series of `else if` s.

### Solution:

Add a condition check for `ActionLog` type and retrieve the action log entry text.
