### PR TITLE
fix 1986

### DIFF
--- a/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
+++ b/src/main/java/org/tdl/vireo/utility/SubmissionHelperUtility.java
@@ -512,13 +512,13 @@ public class SubmissionHelperUtility {
     }
 
     public String getDegreeCodeStr() {
-        Optional<String> degreeCode = getFieldValueIdentifierByPredicateValue("thesis.degree.name");
+        Optional<String> degreeCode = getFieldValueDefinitionByPredicateValue("thesis.degree.name");
         return degreeCode.isPresent() ? degreeCode.get() : "";
     }
 
     public String getDegreeCodeProc() {
-        Optional<String> degreeCode = getFieldValueDefinitionByPredicateValue("thesis.degree.name");
-        return degreeCode.isPresent() ? degreeCode.get().toUpperCase().substring(0,1) : "";
+        Optional<String> degreeCodeProc = getFieldValueIdentifierByPredicateValue("thesis.degree.name");
+        return degreeCodeProc.isPresent() ? degreeCodeProc.get().toUpperCase().substring(0,1) : "";
     }
 
     public String getDegreeCollege() {


### PR DESCRIPTION
fixes #1986 
Originally my migration code mixed up the values to be filled into Identifier and Definition for the field_values associated with the field_predicate for proquest_embargo and I introduced the error to SubmissionHelperUtility.java at some point.  Now that there are proquest exports of submissions using new non migrated data I am reverting SubmissionHelperUtility.java almost to its original state (except for lower and upper case changes which were not in original).

I also need to do data fixes for a few hosted sites to fix older migrated data but that is beyond the scope of this ticket.

I could also clean up some other redundant SubmissionHelperUtility.java methods but that will be another PR perhaps after this sprint.
