### PR TITLE
Issue #1882: Check submission id is defined in route before fetching action logs

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/submissionViewController.js
@@ -213,7 +213,9 @@ vireo.controller("SubmissionViewController", function ($controller, $q, $routePa
         });
 
         $scope.getPaginatedActionLog = function (orderBy, page, count) {
-            return StudentSubmissionRepo.findPaginatedActionLogsById($routeParams.submissionId, orderBy, page, count);
+            return angular.isDefined($routeParams.submissionId)
+                ? StudentSubmissionRepo.findPaginatedActionLogsById($routeParams.submissionId, orderBy, page, count)
+                : $q(function(resolve) { resolve([]); });
         }
 
     });


### PR DESCRIPTION
`getPaginatedActionLog` is being called by submissionView.html when viewing a submission. Upon submission corrections, the navigation changes the path and triggers a digest cycle for submissionView.html without submission id available for asynchronously fetching the action logs. This was causing the undefined in the path and the subsequent 500 error response. This solution is to return an empty set when called in an invalid context. It would be preferred for view isolation to avoid the call to fetch action logs when not intended to be rendered.