### PR TITLE
Issue #1978: Remove field value from submission on success response

### DIFF
--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -490,7 +490,21 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
                 method: submission.id + "/remove-field-value",
                 data: fieldValue
             });
+
             var promise = WsApi.fetch(this.getMapping().removeFieldValue);
+
+            promise.then(function (response) {
+                var apiRes = angular.fromJson(response.body);
+                if (apiRes.meta.status === 'SUCCESS') {
+                    var index = submission.fieldValues.indexOf(fieldValue);
+                    if (index !== -1) {
+                        submission.fieldValues.splice(index, 1);
+                    }
+
+                    submission.addFieldValue(fieldValue.fieldPredicate);
+                }
+            });
+
             return promise;
         };
 

--- a/src/main/webapp/app/model/submission.js
+++ b/src/main/webapp/app/model/submission.js
@@ -145,7 +145,6 @@ var submissionModel = function ($filter, $q, ActionLog, FieldValue, FileService,
             });
 
             submission.fieldValuesRemovedListenPromise.then(null, null, function (res) {
-                console.log('remove field value promise', res);
                 var removedFieldValue = angular.fromJson(res.body).payload.FieldValue;
 
                 removeFieldValue(removedFieldValue);


### PR DESCRIPTION
This resolves the discovered UI/UX issue when the successful removing of a feedback file from the admin submission view does not update the table of files in the view.