### PR TITLE
Issue #1974: Filter available embargoes in admin submission view

### DIFF
--- a/src/main/webapp/app/views/admin/info/edit/input-radio.html
+++ b/src/main/webapp/app/views/admin/info/edit/input-radio.html
@@ -1,4 +1,4 @@
-<div class="input-radio-container" ng-repeat="word in fieldProfile.controlledVocabulary.dictionary" ng-click="toggleFieldValue(field, word.name)">
+<div class="input-radio-container" ng-repeat="word in fieldProfile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:orderVocabularyWords" ng-click="toggleFieldValue(field, word.name)">
   <div class="col-xs-8">
     <span class="radio-label">{{word.name}}:</span>
   </div>


### PR DESCRIPTION
To test

1. Create a submission with embargo Document Only Hold
2. Goto Settings -> Workflow Management -> EMBARGO Types
3. Edite Document Only Hold embargo
4. Toggle `This embargo option will be available for new submissions.` 
5. Save
6. Create a new submission and confirm Document Only Hold is no longer an option
7. Edit initial submission as admin and change to Full Record Hold
8. Try editing Default Embargos again and Document Only Hold should not be an option