### PR TITLE
Issue #1891: New file types (document types) dedicated field predicate default true for documentTypePredicate flag

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/DocumentTypeRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/DocumentTypeRepoImpl.java
@@ -19,7 +19,7 @@ public class DocumentTypeRepoImpl extends AbstractWeaverOrderedRepoImpl<Document
 
     @Override
     public DocumentType create(String name) {
-        return create(name, fieldPredicateRepo.save(new FieldPredicate("_doctype_" + name.toLowerCase().replace(' ', '_'), Boolean.valueOf(false))));
+        return create(name, fieldPredicateRepo.save(new FieldPredicate("_doctype_" + name.toLowerCase().replace(' ', '_'), Boolean.valueOf(true))));
     }
 
     @Override

--- a/src/main/webapp/app/views/admin/settings/workflow/documentTypes.html
+++ b/src/main/webapp/app/views/admin/settings/workflow/documentTypes.html
@@ -12,7 +12,7 @@
 
       <div class="glyphicon glyphicon-info-sign opaque glyiphicon-span-adjust" tooltip="Select to add a new file type."></div>
 
-      <p ng-if="graduationMonths.length == 0">Add new File Type</p>
+      <p ng-if="documentTypes.length == 0">Add new File Type</p>
 
       <draganddroplist dragging="dragging" scope-value="documentTypes" properties='["name"]' item-view='views/directives/dragAndDropDocumentType.html' listeners='dragControlListeners' edit='launchEditModal(index)' sort-column='name' , sort-action='sortAction' sort-method='sortDocumentTypes(column)' sort-label='File Types'></draganddroplist>
     </div>


### PR DESCRIPTION
For any file types that have been created prior to this patch will require the following SQL updating field predicates with prefix `_doctype_` as convention to have its column `documentTypePredicate` to true.

```
UPDATE field_predicate
SET document_type_predicate = true
WHERE value LIKE '_doctype_%';
```

Additionally found and corrected a copy and paste mistake.