### PR TITLE
Issue #2032: Consolidate file upload get pattern and always return .pdf for `_doctype_primary`

### DIFF
--- a/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
+++ b/src/main/webapp/app/controllers/submission/adminSubmissionViewController.js
@@ -382,12 +382,10 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
         };
 
         $scope.getPattern = function (doctype) {
-            var pattern = "*";
             var fieldPredicate;
-            var i;
 
-            for(i in $scope.fieldPredicates) {
-                if($scope.fieldPredicates[i].value === doctype) {
+            for (var i in $scope.fieldPredicates) {
+                if ($scope.fieldPredicates[i].value === doctype) {
                     fieldPredicate = $scope.fieldPredicates[i];
                     break;
                 }
@@ -395,17 +393,11 @@ vireo.controller("AdminSubmissionViewController", function ($anchorScroll, $cont
 
             if (fieldPredicate !== undefined) {
                 var fieldProfile = $scope.submission.getFieldProfileByPredicate(fieldPredicate);
-                if (angular.isDefined(fieldProfile.controlledVocabulary)) {
-                    var cv = fieldProfile.controlledVocabulary;
-                    pattern = "";
-                    for (i in cv.dictionary) {
-                        var word = cv.dictionary[i];
-                        pattern += pattern.length > 0 ? (",." + word.name) : ("." + word.name);
-                    }
-                }
+
+                return FileUploadService.getPattern(fieldProfile);
             }
 
-            return pattern;
+            return '*';
         };
 
         $scope.queueUpload = function (files) {

--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -153,16 +153,7 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, Controlle
             };
 
             $scope.getPattern = function () {
-                var pattern = "*";
-                if(angular.isDefined($scope.profile.controlledVocabulary)) {
-                    var cv = $scope.profile.controlledVocabulary;
-                    pattern = "";
-                    for (var i in cv.dictionary) {
-                        var word = cv.dictionary[i];
-                        pattern += pattern.length > 0 ? (",." + word.name) : ("." + word.name);
-                    }
-                }
-                return pattern;
+                return FileUploadService.getPattern($scope.profile);
             };
 
             $scope.queueUpload = function (files) {

--- a/src/main/webapp/app/services/fileUploadService.js
+++ b/src/main/webapp/app/services/fileUploadService.js
@@ -2,6 +2,25 @@ vireo.service("FileUploadService", function ($q, FieldValue, FileService) {
 
     var FileUploadService = this;
 
+    FileUploadService.getPattern = function (fieldProfile) {
+        var pattern = '*';
+
+        if (fieldProfile?.fieldPredicate?.value === '_doctype_primary') {
+            return '.pdf'
+        }
+
+        if (angular.isDefined(fieldProfile?.controlledVocabulary)) {
+            var cv = fieldProfile?.controlledVocabulary;
+            pattern = '';
+            for (var i in cv.dictionary) {
+                var word = cv.dictionary[i];
+                pattern += pattern.length > 0 ? (",." + word.name) : ("." + word.name);
+            }
+        }
+
+        return pattern;
+    };
+
     FileUploadService.uploadFile = function (submission, fieldValue) {
         return FileService.upload({
             'endpoint': '',

--- a/src/main/webapp/tests/mocks/services/mockFileUploadService.js
+++ b/src/main/webapp/tests/mocks/services/mockFileUploadService.js
@@ -1,6 +1,10 @@
 angular.module("mock.fileUploadService", []).service("FileUploadService", function($q) {
     var service = mockService($q);
 
+    service.getPattern = function (fieldProfile) {
+        return '*';
+    }
+
     service.archiveFile = function (submission, fieldValue, removeFieldValue) {
         var payload = {};
         return payloadPromise($q.defer(), payload);

--- a/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
+++ b/src/main/webapp/tests/unit/controllers/submission/adminSubmissionViewControllerTest.js
@@ -654,10 +654,12 @@ describe("controller: AdminSubmissionViewController", function () {
             scope.submission.mockWorkflowSteps.aggregateFieldProfiles[0].mock(dataFieldProfile2);
             scope.submission.mockWorkflowSteps.aggregateFieldProfiles[0].fieldPredicate = scope.fieldPredicates[1];
 
-            response = scope.getPattern("text/plain");
+            spyOn(FileUploadService, "getPattern").and.returnValue(".pdf");
+            response = scope.getPattern("_doctype_primary");
             expect(response).toBeDefined();
             expect(response).not.toEqual("*");
 
+            FileUploadService.getPattern.and.returnValue(".pdf");
             response = scope.getPattern("does not exist");
             expect(response).toEqual("*");
         });


### PR DESCRIPTION
With this PR, the behavior of file upload will be as follows.

- if field profile predicate equals `_docype_primary` return pattern `.pdf`
- else if field profile has a controlled vocabulary, return constructed pattern from it
- else return `*`


In order to restrict file extensions for file upload of a new field profile that does not use `_docype_primary` field predicate, you can create a controlled vocabulary and assign it to the field profile for INPUT_TYPE.