### PR TITLE
Issue #1948: Multiple Tabs Using Crtl/Cmd - Click

### DIFF
--- a/src/main/webapp/app/controllers/submission/submissionListController.js
+++ b/src/main/webapp/app/controllers/submission/submissionListController.js
@@ -1,4 +1,4 @@
-vireo.controller("SubmissionListController", function (NgTableParams, $controller, $filter, $location, $q, $scope, ControlledVocabularyRepo, CustomActionDefinitionRepo, DepositLocationRepo, DocumentTypeRepo, EmailRecipient, EmailRecipientType, EmailTemplateRepo, EmbargoRepo, FieldPredicateRepo, FieldValueRepo, ManagerFilterColumnRepo, ManagerSubmissionListColumnRepo, NamedSearchFilterGroup, OrganizationRepo, OrganizationCategoryRepo, PackagerRepo, SavedFilter, SavedFilterRepo, SidebarService, SubmissionListColumnRepo, SubmissionRepo, SubmissionStatusRepo, UserRepo, UserSettings, WsApi) {
+vireo.controller("SubmissionListController", function (NgTableParams, $controller, $filter, $location, $q, $scope, ControlledVocabularyRepo, CustomActionDefinitionRepo, DepositLocationRepo, DocumentTypeRepo, EmailRecipient, EmailRecipientType, EmailTemplateRepo, EmbargoRepo, FieldPredicateRepo, FieldValueRepo, ManagerFilterColumnRepo, ManagerSubmissionListColumnRepo, NamedSearchFilterGroup, OrganizationRepo, OrganizationCategoryRepo, PackagerRepo, SavedFilter, SavedFilterRepo, SidebarService, SubmissionListColumnRepo, SubmissionRepo, SubmissionStatusRepo, UserRepo, UserSettings, $window, WsApi) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
@@ -1002,8 +1002,14 @@ vireo.controller("SubmissionListController", function (NgTableParams, $controlle
 
         var disabledFilterColumnOptions = createDisabledColumnOptions();
 
-        $scope.viewSubmission = function (submission) {
-            $location.path("/admin/view/" + submission.id);
+        $scope.viewSubmission = function (event, submission) {
+            const url = $location.absUrl();
+            if (event.ctrlKey || event.metaKey) {
+                $window.open(url.replace('/list', '/view/' + submission.id));
+                event.stopPropagation();
+            } else {
+              $location.path('/admin/view/' + submission.id);
+            };
         };
 
         SidebarService.addBoxes([{

--- a/src/main/webapp/app/views/admin/list.html
+++ b/src/main/webapp/app/views/admin/list.html
@@ -31,7 +31,7 @@
       </tr>
     </thead>
     <tbody>
-      <tr ng-repeat="row in $data" ng-init="$last && finished()" ng-click="viewSubmission(row)" class="select-toggle submission-list-row">
+      <tr ng-repeat="row in $data" ng-init="$last && finished()" ng-click="viewSubmission($event, row)" class="select-toggle submission-list-row">
         <td ng-repeat="col in $columns">
           <span ng-class="{'glyphicon glyphicon-remove-circle' : $first}" ng-click="addRowFilter($parent.$index, row)"></span>
           <span ng-if="col.title() !== 'Custom Actions'">{{displaySubmissionProperty(row, col)}}</span>


### PR DESCRIPTION
This PR allows for admin to open a new tab when viewing a submission by using crtl-click for Windows/Linux and cmd-click for Mac. Resolves #1948 