### PR TITLE
Issue #2024: Add unique constraint to action log

### DIFF
--- a/src/main/java/org/tdl/vireo/model/ActionLog.java
+++ b/src/main/java/org/tdl/vireo/model/ActionLog.java
@@ -26,12 +26,12 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
 @Table(uniqueConstraints = @UniqueConstraint(
     name = "uk_action_log_unique_columns",
     columnNames = {
-    "actionDate",
-    "entry",
-    "privateFlag",
-    "submission_status_id",
-    "user_id",
-    "action_logs_id"
+        "actionDate",
+        "entry",
+        "privateFlag",
+        "submission_status_id",
+        "user_id",
+        "action_logs_id"
 }))
 public class ActionLog extends ValidatingBaseEntity {
 

--- a/src/main/java/org/tdl/vireo/model/ActionLog.java
+++ b/src/main/java/org/tdl/vireo/model/ActionLog.java
@@ -5,8 +5,10 @@ import java.util.Calendar;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import javax.persistence.UniqueConstraint;
 
 import org.tdl.vireo.model.response.Views;
 import org.tdl.vireo.model.validation.ActionLogValidator;
@@ -21,6 +23,16 @@ import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
  */
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
+@Table(uniqueConstraints = @UniqueConstraint(
+    name = "uk_action_log_unique_columns",
+    columnNames = {
+    "actionDate",
+    "entry",
+    "privateFlag",
+    "submission_status_id",
+    "user_id",
+    "action_logs_id"
+}))
 public class ActionLog extends ValidatingBaseEntity {
 
     @ManyToOne(optional = false)


### PR DESCRIPTION
This will add the unique constraint on action_log table if `spring.jpa.hibernate.ddl-auto` is set to create or update. Otherwise, please add constraints manually.

```sql
ALTER TABLE action_log
ADD CONSTRAINT uk_action_log_unique_columns
UNIQUE (action_date, entry, private_flag, submission_status_id, user_id, action_logs_id);
```

If this fails, you have actual duplicate action logs and they will need to be remediated. Here is a query to identify them.

```sql
SELECT
    action_date,
    entry,
    private_flag,
    submission_status_id,
    user_id,
    action_logs_id,
    COUNT(*) as duplicate_count
FROM
    action_log
GROUP BY
    action_date,
    entry,
    private_flag,
    submission_status_id,
    user_id,
    action_logs_id
HAVING
    COUNT(*) > 1
ORDER BY
    duplicate_count DESC;
```

This closes #2024.