### PR TITLE
Issue #2045: Check email workflow rules on submission status change to ensure they are respected

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -808,6 +808,7 @@ public class SubmissionController {
                             String depositURL = depositor.deposit(depositLocation, exportPackage);
                             submission.setDepositURL(depositURL);
                             submission = submissionRepo.updateStatus(submission, submissionStatus, user);
+                            submissionEmailService.sendWorkflowEmails(user, submission.getId());
                         } catch (Exception e) {
                             throw new DepositException("Failed package export on submission " + submission.getId());
                         }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -497,6 +497,7 @@ public class SubmissionController {
                         String depositURL = depositor.deposit(depositLocation, exportPackage);
                         submission.setDepositURL(depositURL);
                         submission = submissionRepo.updateStatus(submission, submissionStatus, user);
+                        submissionEmailService.sendWorkflowEmails(user, submission.getId());
                         response = new ApiResponse(SUCCESS, submission);
                     } else {
                         response = new ApiResponse(ERROR, "Could not find a depositor name " + depositLocation.getDepositorName());
@@ -507,8 +508,6 @@ public class SubmissionController {
             } else {
                 response = new ApiResponse(ERROR, "Could not find a submission status name Published");
             }
-
-            submissionEmailService.sendWorkflowEmails(user, submission.getId());
         } else {
             response = new ApiResponse(ERROR, "Could not find a submission with ID " + submissionId);
         }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -907,6 +907,7 @@ public class SubmissionController {
         String oldSubmissionStatusName = submission.getSubmissionStatus().getName();
         submission.setSubmissionStatus(needsCorrectionStatus);
         submission = submissionRepo.update(submission);
+        submissionEmailService.sendWorkflowEmails(user, submission.getId());
         actionLogRepo.createPublicLog(submission, user, "Submission status was changed from " + oldSubmissionStatusName + " to " + NEEDS_CORRECTION_SUBMISSION_STATUS_NAME);
         return new ApiResponse(SUCCESS, submission);
     }

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -246,6 +246,7 @@ public class SubmissionController {
             credentials,
             customActionDefinitionRepo.findAll()
         );
+        submissionEmailService.sendWorkflowEmails(user, submission.getId());
         actionLogRepo.createPublicLog(submission, user, "Submission created.");
 
         return new ApiResponse(SUCCESS, submission.getId());


### PR DESCRIPTION
It was found that not all persisted change of submission status was triggering email workflow rules. This is only a patch and does not guarantee all cases without a consistent and atomic approach is taken. There may be some missed by unexpected code paths and whether new code will not reintroduce this bug.