### PR TITLE
Issue 208: Update ProQuest file naming

### DIFF
--- a/src/main/java/org/tdl/vireo/ApplicationConstants.java
+++ b/src/main/java/org/tdl/vireo/ApplicationConstants.java
@@ -1,0 +1,11 @@
+package org.tdl.vireo;
+
+public class ApplicationConstants {
+
+    public static final String UNKNOWN = "Unknown";
+
+    private ApplicationConstants() {
+
+    }
+
+}

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -52,6 +52,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.tdl.vireo.ApplicationConstants;
 import org.tdl.vireo.exception.DepositException;
 import org.tdl.vireo.exception.OrganizationDoesNotAcceptSubmissionsException;
 import org.tdl.vireo.model.CustomActionValue;
@@ -1127,7 +1128,7 @@ public class SubmissionController {
 
         // use Unknown if no field values with predicate or value is empty
         String name = fieldValues.isEmpty() || fieldValues.get(0).getValue().trim().isEmpty()
-            ? "Unknown"
+            ? ApplicationConstants.UNKNOWN
             : fieldValues.get(0).getValue().trim();
 
         return name.substring(0, 1).toUpperCase() + name.substring(1);

--- a/src/main/java/org/tdl/vireo/controller/SubmissionController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionController.java
@@ -622,15 +622,11 @@ public class SubmissionController {
             try {
                 ZipOutputStream zos = new ZipOutputStream(sos_pq, StandardCharsets.UTF_8);
                 for (Submission submission : submissionRepo.batchDynamicSubmissionQuery(filter, columns)) {
-                    List<FieldValue> fieldValues = submission.getFieldValuesByPredicateValue("first_name");
-                    Optional<String> firstNameOpt = fieldValues.size() > 0 ? Optional.of(fieldValues.get(0).getValue()) : Optional.empty();
-                    String firstName = firstNameOpt.isPresent() ? firstNameOpt.get() : "";
-                    firstName = firstName.substring(0,1).toUpperCase()+firstName.substring(1);
-                    fieldValues = submission.getFieldValuesByPredicateValue("last_name");
-                    Optional<String> lastNameOpt = fieldValues.size() > 0 ? Optional.of(fieldValues.get(0).getValue()) : Optional.empty();
-                    String lastName = lastNameOpt.isPresent() ? lastNameOpt.get() : "";
-                    lastName = lastName.substring(0,1).toUpperCase()+lastName.substring(1);
-                    String personName = lastName+"_"+firstName;
+                    String firstName = getName(submission, "first_name");
+
+                    String lastName = getName(submission, "last_name");
+
+                    String personName = lastName + "_" + firstName;
 
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     try (ZipOutputStream b = new ZipOutputStream(baos)){
@@ -1124,6 +1120,17 @@ public class SubmissionController {
             clearAdvisorMessage += " Rejection.";
         }
         actionLogRepo.createAdvisorPublicLog(submission, clearAdvisorMessage);
+    }
+
+    private String getName(Submission submission, String predicate) {
+        List<FieldValue> fieldValues = submission.getFieldValuesByPredicateValue(predicate);
+
+        // use Unknown if no field values with predicate or value is empty
+        String name = fieldValues.isEmpty() || fieldValues.get(0).getValue().trim().isEmpty()
+            ? "Unknown"
+            : fieldValues.get(0).getValue().trim();
+
+        return name.substring(0, 1).toUpperCase() + name.substring(1);
     }
 
 }

--- a/src/main/java/org/tdl/vireo/model/formatter/ProQuestUmiFormatter.java
+++ b/src/main/java/org/tdl/vireo/model/formatter/ProQuestUmiFormatter.java
@@ -129,11 +129,13 @@ public class ProQuestUmiFormatter extends AbstractFormatter {
                 context.setVariable(key.name(), submission.getSupplementalDocumentFieldValues());
                 break;
             case PROQUEST_PERSON_FILENAME:
-                String lastName = submissionHelperUtility.getSubmitterLastName();
+                String lastName = submissionHelperUtility.getSubmitterLastName().trim().isEmpty()
+                    ? "Unkown" : submissionHelperUtility.getSubmitterLastName().trim();
                 lastName = lastName.substring(0,1).toUpperCase()+lastName.substring(1);
-                String firstName = submissionHelperUtility.getSubmitterFirstName();
+                String firstName = submissionHelperUtility.getSubmitterFirstName().trim().isEmpty()
+                    ? "Unkown" : submissionHelperUtility.getSubmitterFirstName().trim();
                 firstName = firstName.substring(0,1).toUpperCase()+firstName.substring(1);
-                String ufnSuffix = ".pdf"; //default
+                String ufnSuffix = ".pdf"; // default
                 if(submission.getPrimaryDocumentFieldValue()!=null){
                     String uploadedFileName = submission.getPrimaryDocumentFieldValue().getFileName();
                     int ufnIndx;

--- a/src/main/java/org/tdl/vireo/model/formatter/ProQuestUmiFormatter.java
+++ b/src/main/java/org/tdl/vireo/model/formatter/ProQuestUmiFormatter.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 
 import javax.persistence.Entity;
 
+import org.tdl.vireo.ApplicationConstants;
 import org.tdl.vireo.model.FieldValue;
 import org.tdl.vireo.model.Submission;
 import org.tdl.vireo.model.export.enums.ProQuestUMIKey;
@@ -130,10 +131,10 @@ public class ProQuestUmiFormatter extends AbstractFormatter {
                 break;
             case PROQUEST_PERSON_FILENAME:
                 String lastName = submissionHelperUtility.getSubmitterLastName().trim().isEmpty()
-                    ? "Unkown" : submissionHelperUtility.getSubmitterLastName().trim();
+                    ? ApplicationConstants.UNKNOWN : submissionHelperUtility.getSubmitterLastName().trim();
                 lastName = lastName.substring(0,1).toUpperCase()+lastName.substring(1);
                 String firstName = submissionHelperUtility.getSubmitterFirstName().trim().isEmpty()
-                    ? "Unkown" : submissionHelperUtility.getSubmitterFirstName().trim();
+                    ? ApplicationConstants.UNKNOWN : submissionHelperUtility.getSubmitterFirstName().trim();
                 firstName = firstName.substring(0,1).toUpperCase()+firstName.substring(1);
                 String ufnSuffix = ".pdf"; // default
                 if(submission.getPrimaryDocumentFieldValue()!=null){


### PR DESCRIPTION
- Check if submission has non-empty name field value
- Use `Unknown` otherwise

Further refactoring is required to avoid multiple logic to provide a file name for a submitter.