### PR TITLE
Issue #2065: Event Time column not exporting correctly for Excel export.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -85,7 +85,7 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                         }
                         Object valueAsObject = EntityUtility.getValueFromPath(submission, valuePath);
 
-                        String value;
+                        String value = "";
 
                         if (valueAsObject instanceof Calendar) {
                             Calendar calendar = (Calendar) valueAsObject;
@@ -112,8 +112,18 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                             User user = (User) valueAsObject;
                             value = user.getName().toString();
                         } else if (valueAsObject instanceof ActionLog){
-                             ActionLog actionLog = (ActionLog) valueAsObject;
-                             value = actionLog.getEntry().toString();
+                            ActionLog actionLog = (ActionLog) valueAsObject;
+                            switch (column.getTitle()){
+                                case "Event Time":
+                                    Calendar actionDate = (Calendar) actionLog.getActionDate();
+                                    value = simpleDateFormat.format(actionDate.getTime());
+                                    break;
+                                case "Last Event":
+                                    value = actionLog.getEntry().toString();
+                                    break;
+                                default:
+                                    break;
+                            }
                         } else {
                             value = valueAsObject.toString();
                         }


### PR DESCRIPTION
Describe the bug:

In [Issue #1995](https://github.com/TexasDigitalLibrary/Vireo/issues/1995) I fixed the Last Event column by accounting for the `ActionLog` object type, but it turned out that more than one column references the ActionLog type and we need to differentiate what value gets returned by the column title.

Solution:
Instead of using `value = actionLog.getEntry().toString();`, add a switch statement to differentiate by column name.