### PR TITLE
refactor: inputtype accessibility improvements

### DIFF
--- a/src/main/webapp/app/views/inputtype/input-contact.html
+++ b/src/main/webapp/app/views/inputtype/input-contact.html
@@ -11,15 +11,16 @@
     typeahead-no-results="noResults"
     typeahead-on-select="saveWithCV(fieldValue, $item)"
     typeahead-loading="(!fieldValue.fieldPredicate.id || !typeAheads[fieldValue.fieldPredicate.id]) ? angular.noop : typeAheads[fieldValue.fieldPredicate.id].loading"
+    aria-label="{{profile.gloss}} name"
   />
   <span class="input-group-btn">
-    <button class="btn btn-default opaque" ng-if="fieldValue.value">
-      <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)"></span>
+    <button class="btn btn-default opaque" ng-if="fieldValue.value" aria-label="Remove {{profile.gloss}} {{fieldValue.value}}">
+      <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)" aria-hidden="true"></span>
     </button>
   </span>
   <span class="input-group-addon">
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
-    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}" aria-hidden="true"></span>
+    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
   </span>
 </div>
 
@@ -36,9 +37,11 @@
     typeahead-no-results="noResults"
     typeahead-on-select="saveWithCV(fieldValue, $item)"
     typeahead-loading="(!fieldValue.fieldPredicate.id || !typeAheads[fieldValue.fieldPredicate.id]) ? angular.noop : typeAheads[fieldValue.fieldPredicate.id].loading"
+    aria-label="{{profile.gloss}} contact info"
   />
   <span class="input-group-addon">
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
-    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}" aria-hidden="true"></span>
+    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
   </span>
 </div>
+

--- a/src/main/webapp/app/views/inputtype/input-contact_select.html
+++ b/src/main/webapp/app/views/inputtype/input-contact_select.html
@@ -1,24 +1,25 @@
-<div class="btn-group btn-group-justified submission-input-select" uib-dropdown keyboard-nav role="group">
-  <button type="button" class="btn dropdown-toggle dropdown-toggle-button" uib-dropdown-toggle>
-    <span class="caret"></span>
+<div class="btn-group btn-group-justified submission-input-select" uib-dropdown keyboard-nav role="group" aria-label="Contact selection group">
+  <button type="button" class="btn dropdown-toggle dropdown-toggle-button" uib-dropdown-toggle aria-label="Toggle contact dropdown menu" aria-haspopup="true" aria-expanded="false">
+    <span class="caret" aria-hidden="true"></span>
   </button>
-  <button ng-class="{selected: fieldValue.value}" type="button" class="btn btn-default dropdown-text" disabled>
+  <button ng-class="{selected: fieldValue.value}" type="button" class="btn btn-default dropdown-text" disabled aria-label="{{fieldValue.value || 'No contact selected'}}">
     <span class="text-left dropdown-text-label">{{fieldValue.value}}</span>
   </button>
-  <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+  <ul class="dropdown-menu" uib-dropdown-menu role="listbox" aria-label="Available contacts">
     <li class="select-option"
-      role="menuitem"
+      role="option"
       ng-click="fieldValue.value = word.name; fieldProfileForm.$dirty = true; saveWithCV(fieldValue, word);"
-      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord">
-      <a href="#">{{word.name}}</a>
+      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord"
+      aria-selected="{{fieldValue.value === word.name}}">
+      <a href="#" ng-click="$event.preventDefault()">{{word.name}}</a>
     </li>
   </ul>
-  <button class="btn btn-default opaque" ng-if="fieldValue.value">
-    <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)"></span>
+  <button class="btn btn-default opaque" ng-if="fieldValue.value" aria-label="Remove contact {{fieldValue.value}}">
+    <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)" aria-hidden="true"></span>
   </button>
-  <button type="button" class="btn dropdown-help" disabled>
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
-    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
+  <button type="button" class="btn dropdown-help" disabled aria-label="Help information">
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}" aria-hidden="true"></span>
+    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
   </button>
 </div>
 
@@ -27,9 +28,11 @@
     class="form-control"
     ng-model="field.contacts"
     placeholder="{{fieldValue.contacts[0]}}"
+    aria-label="Contact information"
     disabled>
   <span class="input-group-addon">
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
-    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}" aria-hidden="true"></span>
+    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
   </span>
 </div>
+

--- a/src/main/webapp/app/views/inputtype/input-date.html
+++ b/src/main/webapp/app/views/inputtype/input-date.html
@@ -5,6 +5,8 @@
     <input
       type="text"
       class="form-control"
+      id="field-{{profile.fieldPredicate.value}}"
+      name="{{profile.fieldPredicate.value}}"
       uib-datepicker-popup="{{datepickerFormat}}"
       datepicker-options="datepickerOptions"
       ng-model="fieldValue.valuePopup"
@@ -22,3 +24,4 @@
         <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
     </span>
 </div>
+

--- a/src/main/webapp/app/views/inputtype/input-degreedate.html
+++ b/src/main/webapp/app/views/inputtype/input-degreedate.html
@@ -6,6 +6,8 @@
       type="text"
       class="form-control"
       uib-datepicker-popup="MMMM yyyy"
+      id="field-{{profile.fieldPredicate.value}}"
+      name="{{profile.fieldPredicate.value}}"
       datepicker-options="datepickerOptions"
       ng-model="fieldValue.valuePopup"
       ng-click="date=true"

--- a/src/main/webapp/app/views/inputtype/input-email.html
+++ b/src/main/webapp/app/views/inputtype/input-email.html
@@ -1,7 +1,8 @@
 <div class="input-group">
   <input type="text"
     class="form-control"
-    name="profile.fieldPredicate.value"
+    id="field-{{::profile.fieldPredicate.value}}"
+    name="{{::profile.fieldPredicate.value}}"
     ng-required="!profile.optional"
     ng-model="fieldValue.value"
     ng-blur="save(fieldValue)"

--- a/src/main/webapp/app/views/inputtype/input-orcid.html
+++ b/src/main/webapp/app/views/inputtype/input-orcid.html
@@ -1,6 +1,7 @@
 <div class="input-group">
   <input type="text"
     class="form-control"
+    id="field-{{profile.fieldPredicate.value}}"
     name="{{profile.fieldPredicate.value}}"
     ng-required="!profile.optional"
     ng-model="fieldValue.value"
@@ -15,3 +16,4 @@
     <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
   </span>
 </div>
+

--- a/src/main/webapp/app/views/inputtype/input-radio.html
+++ b/src/main/webapp/app/views/inputtype/input-radio.html
@@ -1,21 +1,22 @@
 <div class="input-radio-container row" ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:orderVocabularyWords">
 	<div class="col-xs-1">
-		<label class="radio-inline">
-			<input
-	      type="radio"
-				ng-model="fieldValue.value"
-				ng-change="save(fieldValue)"
-				name="profile.fieldPredicate.value"
-				ng-disabled="fieldValue.updating"
-				ng-value="word.name"/>
-		</label>
+		<input
+      type="radio"
+			class="radio-inline"
+			ng-model="fieldValue.value"
+			ng-change="save(fieldValue)"
+			name="profile.fieldPredicate.value"
+			ng-disabled="fieldValue.updating"
+			ng-value="word.name"
+			id="field-{{profile.fieldPredicate.value}}-{{$index}}"
+			aria-labelledby="radio-label-{{profile.fieldPredicate.value}}-{{$index}}"/>
 	</div>
-  <div class="col-xs-8 well">
+  <div class="col-xs-8 well" id="radio-label-{{profile.fieldPredicate.value}}-{{$index}}">
 		<span><h5><b>{{word.name}}</b></h5>{{word.definition}}</span>
 	</div>
 	<div class="col-xs-2">
         <span ng-if="!fieldValue.updating && $index === 0" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
         <span ng-if="fieldValue.updating && $index === 0" class="glyphicon glyphicon-refresh spinning"> </span>
 	</div>
-
 </div>
+

--- a/src/main/webapp/app/views/inputtype/input-select.html
+++ b/src/main/webapp/app/views/inputtype/input-select.html
@@ -1,23 +1,26 @@
 <div class="btn-group btn-group-justified submission-input-select" uib-dropdown keyboard-nav role="group">
-  <button type="button" class="btn dropdown-toggle dropdown-toggle-button" uib-dropdown-toggle>
+  <button type="button" class="btn dropdown-toggle dropdown-toggle-button" uib-dropdown-toggle aria-label="Toggle dropdown menu">
     <span class="caret"></span>
   </button>
-  <button ng-class="{selected: fieldValue.value}" type="button" class="btn btn-default dropdown-text" disabled>
+  <button ng-class="{selected: fieldValue.value}" type="button" class="btn btn-default dropdown-text" disabled aria-label="{{fieldValue.value || 'No selection'}}">
     <span class="text-left dropdown-text-label">{{fieldValue.value}}</span>
   </button>
-  <ul class="dropdown-menu" uib-dropdown-menu role="menu">
+  <ul class="dropdown-menu" uib-dropdown-menu role="listbox" aria-labelledby="{{getSanitizedId(profile.fieldPredicate.value)}}">
     <li class="select-option"
-      role="menuitem"
+      role="option"
       ng-click="fieldValue.value = word.name; fieldProfileForm.$dirty = true; saveWithCV(fieldValue, word);"
-      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:'name'">
-      <a href="#">{{word.name}}</a>
+      ng-repeat="word in profile.controlledVocabulary.dictionary | filter:displayVocabularyWord | orderBy:'name'"
+      aria-selected="{{fieldValue.value === word.name}}">
+      <a href="#" ng-click="$event.preventDefault()">{{word.name}}</a>
     </li>
   </ul>
-  <button class="btn btn-default opaque" ng-if="fieldValue.value">
-    <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)"></span>
+  <button class="btn btn-default opaque" ng-if="fieldValue.value" aria-label="Remove {{fieldValue.value}}">
+    <span class="glyphicon glyphicon-remove clickable" ng-click="removeFieldValue(fieldValue)" aria-hidden="true"></span>
   </button>
-  <button type="button" class="btn dropdown-help" disabled>
-    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}"> </span>
-    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning"> </span>
+  <button type="button" class="btn dropdown-help" disabled aria-label="Help information">
+    <span ng-if="!fieldValue.updating" class="glyphicon glyphicon-info-sign opaque" aria-label="{{ profile.help }}" tooltip="{{ profile.help }}" aria-hidden="true"></span>
+    <span ng-if="fieldValue.updating" class="glyphicon glyphicon-refresh spinning" aria-hidden="true"></span>
   </button>
 </div>
+
+

--- a/src/main/webapp/app/views/inputtype/input-tel.html
+++ b/src/main/webapp/app/views/inputtype/input-tel.html
@@ -1,7 +1,8 @@
 <div class="input-group">
   <input type="tel"
     class="form-control"
-    name="profile.fieldPredicate.value"
+    id="field-{{profile.fieldPredicate.value}}"
+    name="{{profile.fieldPredicate.value}}"
     ng-required="!profile.optional"
     ng-blur="save(fieldValue)"
     ng-disabled="fieldValue.updating"

--- a/src/main/webapp/app/views/inputtype/input-text.html
+++ b/src/main/webapp/app/views/inputtype/input-text.html
@@ -1,6 +1,7 @@
 <div class="input-group">
   <input type="text"
     class="form-control"
+    id="field-{{profile.fieldPredicate.value}}"
     name="{{profile.fieldPredicate.value}}"
     ng-required="!profile.optional"
     ng-model="fieldValue.value"

--- a/src/main/webapp/app/views/inputtype/input-textarea.html
+++ b/src/main/webapp/app/views/inputtype/input-textarea.html
@@ -1,7 +1,8 @@
 <div class="input-group">
-  <textarea class="form-control" 
-    name="profile.fieldPredicate.value" 
-    ng-required="!profile.optional" 
+  <textarea class="form-control"
+    id="field-{{profile.fieldPredicate.value}}"
+    name="{{profile.fieldPredicate.value}}"
+    ng-required="!profile.optional"
     ng-model="fieldValue.value"
     ng-blur="save(fieldValue)"
     ng-disabled="fieldValue.updating">

--- a/src/main/webapp/app/views/inputtype/input-url.html
+++ b/src/main/webapp/app/views/inputtype/input-url.html
@@ -2,6 +2,7 @@
   <input
     type="text"
     class="form-control"
+    id="field-{{profile.fieldPredicate.value}}"
     name="{{profile.fieldPredicate.value}}"
     ng-required="!profile.optional"
     ng-model="fieldValue.value"


### PR DESCRIPTION
This brings upstream work that we have implemented in our fork at Johns Hopkins University to improve accessibility of form elements used on various pages.

In most instances the changes involve adding `id`'s to the relevant form elements to connect them with their respective labels.