### PR TITLE
include empty default value for front_page_instructions_after

### DIFF
--- a/src/main/resources/settings/SYSTEM_Defaults.json
+++ b/src/main/resources/settings/SYSTEM_Defaults.json
@@ -140,6 +140,9 @@
       "front_page_instructions_before": "<h1>Welcome to the Thesis<br/>&amp; Dissertation Submission System</h1>&#10;<p>Once you have passed the final defense and satisfied the requirements of the committee, you are ready to submit your manuscript to the Thesis Office for review. This submission process is fully electronic, and is made through an online application developed and maintained by the Texas Digital Library along with open source community partners.</p>&#10;<p>To get started with your submission, click the link below. You will be asked to authenticate using your NetID:</p>"
     },
     {
+      "front_page_instructions_after": ""
+    },
+    {
       "post_submission_instructions": "<p>The Thesis Office has received your electronic submittal. You will also receive an email confirmation. We will check your records as soon as possible to determine whether or not we have the signed Approval Form on file. Please be aware that your file is not complete and cannot be reviewed until we have both the electronic manuscript and the signed Approval Form.</p>&#10;<p>As soon as both items have been received, your manuscript will be placed in the queue and will be processed along with all other submissions for the semester in the order in which your completed file (manuscript and Approval Form) was received.</p>&#10;<p>The following are approximate turn-around times after the manuscript and the signed approval form have been submitted to the Thesis Office.&#160;Manuscripts are reviewed in the order received.</p>&#10;<p>&#160;</p>&#10;<p>Early in semester &#8211; 5 working days</p>&#10;<p>Week before Deadline Day &#8211; 10 working days</p>&#10;<p>Deadline Day &#8211; 15 working days</p>&#10;<p>&#160;</p>&#10;<p>If you have any questions about your submittal, feel free to contact our office.</p>&#10;<p>&#160;</p>&#10;<p>Thank you, Thesis Office</p>"
     },
     {

--- a/src/test/java/org/tdl/vireo/ApplicationInitializationTest.java
+++ b/src/test/java/org/tdl/vireo/ApplicationInitializationTest.java
@@ -83,7 +83,7 @@ public class ApplicationInitializationTest {
         assertSettingsType(2, "orcid", isReload);
         assertSettingsType(9, "proquest_umi_degree_code", isReload);
         assertSettingsType(1, "export", isReload);
-        assertSettingsType(21, "lookAndFeel", isReload);
+        assertSettingsType(22, "lookAndFeel", isReload);
         assertSettingsType(1, "submission", isReload);
         assertSettingsType(22, "shibboleth", isReload);
 


### PR DESCRIPTION
Adding back default value for front_page_instructions_after as empty string since removing it broke the functionality.

Resolves #2093 