### PR TITLE
exclude log4j-1.2 dependency from sword-commons, and add the bridge to handle these logging calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
       <artifactId>log4j-api</artifactId>
     </dependency>
 
+    <!-- replaces log4j-1.2.15 for sword-common -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.17.1</version>
+    </dependency>
+
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
@@ -209,6 +216,10 @@
         <exclusion>
           <groupId>xom</groupId>
           <artifactId>xom</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
A routine security scan here (see below) uncovered a vulnerability in Vireo related to the sword-common log4j-1.2 dependency.   Local fix was to exclude this from sword-common in the pom, and add in the log4j-1.2-api dependency to pass the 1.2 calls to log4j2. 

Central IT has flagged old (1.x) log4j as critically vulnerable on the new DEV instance of Vireo:
CVE-2019-17571
CVE-2020-9488
CVE-2022-23302
CVE-2022-23305
CVE-2022-23307
CVE-2023-26464