### PR TITLE
Fix Excel export with POI version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,12 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.20.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
       <version>5.4.1</version>


### PR DESCRIPTION
This PR resolves #2098 for us.

It updates the POI/Workbook dependency to the latest, which brings with it a requirement for including commons-io.