### PR TITLE
updates vireo to use embedded tomcat 9.0.108

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,24 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <version>9.0.108</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-el</artifactId>
+      <version>9.0.108</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <version>9.0.108</version>
+    </dependency>
+
+    <dependency>
       <groupId>edu.tamu.weaver</groupId>
       <artifactId>auth</artifactId>
       <version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,20 @@
       <groupId>edu.tamu.weaver</groupId>
       <artifactId>auth</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-el</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Solves #2107 and makes #2100 unnecessary for TDL hosting

There might be a better way to solve this by updating weaver to use 9.0.108 but for now this is needed for our hosting to get past some security vulnerabilities.