### PR TITLE
Issue #2096: License file filename errors with DSpace SWORD deposit

### DIFF
--- a/src/main/resources/formats/dspace_mets.xml
+++ b/src/main/resources/formats/dspace_mets.xml
@@ -216,7 +216,7 @@
                        SEQ=${ iter.index + 2 }">
                 <FLocat
                     LOCTYPE="URL"
-                    th:attr="'xlink:href'=${ fv.getFileName() }"/>
+                    th:attr="'xlink:href'=${ fv.getExportFileName() }"/>
             </file>
 
         </fileGrp>


### PR DESCRIPTION
[Resolves Issue 2096](https://github.com/TexasDigitalLibrary/Vireo/issues/2096)