### PR TITLE
Issue #2109: Fixing the "ProQuest Publication" filter throwing java.lang.ClassCastException.

### DIFF
--- a/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
+++ b/src/main/java/org/tdl/vireo/controller/SubmissionListController.java
@@ -210,7 +210,7 @@ public class SubmissionListController {
     public ApiResponse addFilterCriterion(@WeaverUser User user, @RequestBody Map<String, Object> data) {
 
         String criterionName = (String) data.get("criterionName");
-        String filterValue = (String) data.get("filterValue");
+        String filterValue = String.valueOf(data.get("filterValue"));
         Boolean exactMatch = (Boolean) data.get("exactMatch");
         String filterGloss = (String) data.get("filterGloss");
 


### PR DESCRIPTION
Resolves [Issue 2109](https://github.com/TexasDigitalLibrary/Vireo/issues/2109) .

I tested with our instances and it worked, and didn't seem to wreck other filters, but some more testing/review is always helpful.