### PR TITLE
Issue #2097: Enable HTML support for email templates.

### DIFF
--- a/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
+++ b/src/main/java/org/tdl/vireo/service/VireoEmailSender.java
@@ -76,7 +76,7 @@ public class VireoEmailSender extends JavaMailSenderImpl implements EmailSender 
         loadConfiguration();
 
         MimeMessage message = createMimeMessage();
-        MimeMessageHelper mm = new MimeMessageHelper(message);
+        MimeMessageHelper mm = new MimeMessageHelper(message, true);
 
         mm.setFrom(vireoEmailConfig.getFrom());
         mm.setReplyTo(vireoEmailConfig.getReplyTo());
@@ -85,7 +85,7 @@ public class VireoEmailSender extends JavaMailSenderImpl implements EmailSender 
         mm.setCc(cc);
         mm.setBcc(bcc);
         mm.setSubject(subject);
-        mm.setText(content, false);
+        mm.setText(content, true);
 
         LOG.debug("\tSending email with subject '" + subject + "' from " + vireoEmailConfig.getFrom() + " to: [ " + String.join("; ", to) + " ], cc: [ " + String.join(";", cc) + " ], bcc: [ " + String.join(";", bcc) + " ]; ");
         send(message);


### PR DESCRIPTION
Resolves [Issue 2097](https://github.com/TexasDigitalLibrary/Vireo/issues/2097).

I'm a bit hesitant on this one though because it probably requires the admins and users to review and edit all of their existing email templates, as some formatting might not appear correctly without the HTML tags.