### PR TITLE
Issue 2128: Fix Committee Contact Email in Excel Export

### DIFF
--- a/src/main/java/org/tdl/vireo/model/Submission.java
+++ b/src/main/java/org/tdl/vireo/model/Submission.java
@@ -253,6 +253,9 @@ public class Submission extends ValidatingBaseEntity {
     @JsonView(Views.SubmissionList.class)
     private Map<Long, String> columnValues;
 
+    @Transient
+    private String committeeContactEmail;
+
     public Submission() {
         setModelValidator(new SubmissionValidator());
         setFieldValues(new HashSet<FieldValue>());
@@ -603,17 +606,16 @@ public class Submission extends ValidatingBaseEntity {
         Optional<FieldValue> optFv = this.getFieldValuesByPredicateValue("dc.contributor.advisor")
             .stream()
             .findFirst();
-        String email = null;
         if (optFv.isPresent()) {
             Optional<String> optEmail = optFv.get()
                 .getContacts()
                 .stream()
                 .findFirst();
             if (optEmail.isPresent()) {
-                email = optEmail.get();
+                committeeContactEmail = optEmail.get();
             }
         }
-        return email;
+        return committeeContactEmail;
     }
 
     /**

--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -83,6 +83,7 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                         if(column.getValuePath().size() > 1){
                              valuePath = new String[] {valuePath[0]};
                         }
+                        submission.getCommitteeContactEmail();
                         Object valueAsObject = EntityUtility.getValueFromPath(submission, valuePath);
 
                         String value = "";


### PR DESCRIPTION
Fix https://github.com/TexasDigitalLibrary/Vireo/issues/2128

- add a backing field in `committeeContactEmail` in `Submission.java`
- modify `getCommitteeContactEmail()` to return the value
- call `getCommitteeContactEmail()` in `ExcelPackager.java` before the value lookup so the value is getting generated
- `committeeContactEmail` should then be covered by the `else ... value = valueAsObject.toString();` clause in the export

I've tested on our instance.