### PR TITLE
Issue #2132: Fix timeout type cast exception when creating a deposit location.

### DIFF
--- a/src/main/java/org/tdl/vireo/model/repo/impl/DepositLocationRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/repo/impl/DepositLocationRepoImpl.java
@@ -41,7 +41,7 @@ public class DepositLocationRepoImpl extends AbstractWeaverOrderedRepoImpl<Depos
             onBehalfOf = (String) depositLocationJson.get("onBehalfOf");
         }
 
-        Integer timeout = (Integer) depositLocationJson.getOrDefault("timeout", "240");
+        Integer timeout = Integer.valueOf(depositLocationJson.getOrDefault("timeout", 240).toString());
 
         return create((String) depositLocationJson.get("name"), (String) depositLocationJson.get("repository"), (String) depositLocationJson.get("collection"), (String) depositLocationJson.get("username"), (String) depositLocationJson.get("password"), onBehalfOf, packager, (String) depositLocationJson.get("depositorName"), timeout);
     }


### PR DESCRIPTION
Resolves issue: https://github.com/TexasDigitalLibrary/Vireo/issues/2132

I've tested with our instances and it worked.
- create with default timeout 240;
- create with a different timeout, e.g. 1000;
- create with default timeout 240, and then edit it to 1000.

