### PR TITLE
Issue #2136: Use valuePath instead of column header texts for ActionLog in ExcelPackager

### DIFF
--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -114,12 +114,13 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                             value = user.getName().toString();
                         } else if (valueAsObject instanceof ActionLog){
                             ActionLog actionLog = (ActionLog) valueAsObject;
-                            switch (column.getTitle()){
-                                case "Event Time":
+                            String[] actionLogValuePath = column.getValuePath().toArray(new String[column.getValuePath().size()]);
+                            switch (actionLogValuePath[1]){
+                                case "actionDate":
                                     Calendar actionDate = (Calendar) actionLog.getActionDate();
                                     value = simpleDateFormat.format(actionDate.getTime());
                                     break;
-                                case "Last Event":
+                                case "entry":
                                     value = actionLog.getEntry().toString();
                                     break;
                                 default:


### PR DESCRIPTION
Resolves issues:
- https://github.com/TexasDigitalLibrary/Vireo/issues/2136
- https://github.com/TexasDigitalLibrary/Vireo/issues/1995

I tested with our instances and they showed up the same in Excel exports, but a bit more tests are always welcome.

Thanks.