### PR TITLE
Issue #2141: Add "signup" route for email verification when local login and register are hidden.

### DIFF
--- a/build/appConfig.js.template
+++ b/build/appConfig.js.template
@@ -38,7 +38,7 @@ var appConfig = {
       Set this to true or false booleans or set it to the literal strings (with quotes) 'alternate' or 'alternateAllowRegister'.
       When set to the boolean true, the login modal and registrations links are available.
       When set to the boolean false, a modal is not used and Shibboleth login is automatically attempted and no registration link is shown.
-      When set to the string 'alternate' to hide the local login (and registration) as if localAuthentication is false and provide an alterate (hidden) login page for local authentication.
+      When set to the string 'alternate' to hide the local login (and registration) as if localAuthentication is false and provide an alternate (hidden) login page for local authentication.
       When set to the string 'alternateAllowRegister' to hide the local login the same way as 'alternate', but allow for account registration at the /signup route.
      */
     'localAuthentication': ${LOCAL_AUTHENTICATION},

--- a/build/appConfig.js.template
+++ b/build/appConfig.js.template
@@ -35,10 +35,11 @@ var appConfig = {
 
     /*
       Designate whether or not to use the local authentication.
-      Set this to true or false booleans or set it to the the string 'alternate'.
+      Set this to true or false booleans or set it to the literal strings (with quotes) 'alternate' or 'alternateAllowRegister'.
       When set to the boolean true, the login modal and registrations links are available.
       When set to the boolean false, a modal is not used and Shibboleth login is automatically attempted and no registration link is shown.
       When set to the string 'alternate' to hide the local login (and registration) as if localAuthentication is false and provide an alterate (hidden) login page for local authentication.
+      When set to the string 'alternateAllowRegister' to hide the local login the same way as 'alternate', but allow for account registration at the /signup route.
      */
     'localAuthentication': ${LOCAL_AUTHENTICATION},
 

--- a/src/main/webapp/app/config/routes.js
+++ b/src/main/webapp/app/config/routes.js
@@ -54,6 +54,10 @@ vireo.config(function ($locationProvider, $routeProvider) {
     when('/register', {
         templateUrl: 'views/register.html'
     }).
+    when('/signup', {
+        templateUrl: 'views/signup.html',
+        controller: 'LocalAccountSignupController'
+    }).
     when('/login', {
         templateUrl: 'views/login.html',
         controller: 'LocalLoginController'

--- a/src/main/webapp/app/controllers/localAccountSignupController.js
+++ b/src/main/webapp/app/controllers/localAccountSignupController.js
@@ -1,0 +1,12 @@
+vireo.controller('LocalAccountSignupController', function ($scope, $controller, $location) {
+    angular.extend($scope, $controller('AbstractController', { $scope: $scope }));
+
+    $scope.registerEnabled =
+        appConfig.localAuthentication === true ||
+        appConfig.localAuthentication === 'alternate';
+
+    $scope.goHome = function () {
+        $location.path('/');
+    };
+});
+

--- a/src/main/webapp/app/controllers/localAccountSignupController.js
+++ b/src/main/webapp/app/controllers/localAccountSignupController.js
@@ -3,7 +3,7 @@ vireo.controller('LocalAccountSignupController', function ($scope, $controller, 
 
     $scope.registerEnabled =
         appConfig.localAuthentication === true ||
-        appConfig.localAuthentication === 'alternate';
+        appConfig.localAuthentication === 'alternateAllowRegister';
 
     $scope.goHome = function () {
         $location.path('/');

--- a/src/main/webapp/app/views/signup.html
+++ b/src/main/webapp/app/views/signup.html
@@ -1,0 +1,22 @@
+<div class="container" ng-controller="LocalAccountSignupController">
+
+    <h1>Local Account Signup</h1>
+
+    <div ng-if="registerEnabled">
+        <p>Please verify your email to continue.</p>
+
+        <button class="btn btn-primary" ng-click="openModal('#verifyEmailModal')">
+            Verify Email
+        </button>
+
+        <button class="btn btn-default" ng-click="goHome()">
+            Return Home
+        </button>
+    </div>
+
+    <div ng-if="!registerEnabled">
+        <p>Local authentication and account signup are disabled.</p>
+    </div>
+
+</div>
+


### PR DESCRIPTION
Resolves https://github.com/TexasDigitalLibrary/Vireo/issues/2141 .

I basically followed how @kaladay did with the `/login` route and the path with the least resistance seems to be just add a route/page to bring up the existing Verify Email modal that's hidden, otherwise if I choose to alter how the `/register` path behaves, it seems that I'd have to involve changing weaver stuff (`RegistrationController`?) and/or add conditional behaviors to separate it with the `/register?token=` stuff, which I'm not familiar with.

Related discussions:
- https://github.com/TexasDigitalLibrary/Vireo/issues/1699
- https://github.com/TexasDigitalLibrary/Vireo/pull/1700
- https://github.com/TexasDigitalLibrary/Vireo/pull/1697
- https://github.com/TexasDigitalLibrary/Vireo/issues/1585
- https://github.com/TexasDigitalLibrary/Vireo/issues/1593

I tested with our instance and it worked for me, but more tests on other instances are always helpful.