### PR TITLE
replace delimeter for all repeatable field profiles

### DIFF
--- a/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
+++ b/src/main/java/org/tdl/vireo/model/packager/ExcelPackager.java
@@ -64,97 +64,21 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
 
     @Override
     public ExcelExportPackage packageExport(Submission submission, List<SubmissionListColumn> columns) {
-        Map<String, String> row = new HashMap<String, String>();
-        columns.forEach(column -> {
-            Optional<String> predicate = Optional.ofNullable(column.getPredicate());
-            if (predicate.isPresent()) {
-                List<String> fieldValues = new ArrayList<String>();
-                for (FieldValue fieldValue : submission.getFieldValues()) {
-                    if (fieldValue.getFieldPredicate().getValue().equals(predicate.get().trim())) {
-                        fieldValues.add(fieldValue.getValue());
-                        row.put(column.getTitle(), String.join(", ", fieldValues));
-                    } else {
-                        row.put(column.getTitle(), String.join(", ", fieldValues));                    }
-                }
-            } else {
-                if (column.getValuePath().size() > 0) {
-                    String[] valuePath = column.getValuePath().toArray(new String[column.getValuePath().size()]);
-                    try {
-                        if(column.getValuePath().size() > 1){
-                             valuePath = new String[] {valuePath[0]};
-                        }
-                        submission.getCommitteeContactEmail();
-                        Object valueAsObject = EntityUtility.getValueFromPath(submission, valuePath);
-
-                        String value = "";
-
-                        if (valueAsObject instanceof Calendar) {
-                            Calendar calendar = (Calendar) valueAsObject;
-                            value = simpleDateFormat.format(calendar.getTime());
-                        } else if (valueAsObject instanceof Date) {
-                            Date date = (Date) valueAsObject;
-                            value = simpleDateFormat.format(date);
-                        } else if (valueAsObject instanceof Set && ((Set<?>) valueAsObject).stream().allMatch(o -> o instanceof CustomActionValue)) {
-                            StringBuilder sb = new StringBuilder();
-                            ((Set<?>) valueAsObject).forEach(o -> {
-                                CustomActionValue customActionValue = (CustomActionValue) o;
-                                if (customActionValue.getValue()) {
-                                    sb.append("☑ ");
-                                } else {
-                                    sb.append("☐ ");
-                                }
-                                sb.append(customActionValue.getDefinition().getLabel()+"\n");
-                            });
-                            value = sb.toString();
-                        } else if (valueAsObject instanceof SubmissionStatus){
-                            SubmissionStatus submissionStatus = (SubmissionStatus) valueAsObject;
-                            value = submissionStatus.getName().toString();
-                        } else if (valueAsObject instanceof User){
-                            User user = (User) valueAsObject;
-                            value = user.getName().toString();
-                        } else if (valueAsObject instanceof ActionLog){
-                            ActionLog actionLog = (ActionLog) valueAsObject;
-                            switch (column.getTitle()){
-                                case "Event Time":
-                                    Calendar actionDate = (Calendar) actionLog.getActionDate();
-                                    value = simpleDateFormat.format(actionDate.getTime());
-                                    break;
-                                case "Last Event":
-                                    value = actionLog.getEntry().toString();
-                                    break;
-                                default:
-                                    break;
-                            }
-                        } else {
-                            value = valueAsObject.toString();
-                        }
-                        row.put(column.getTitle(), value.toString());
-                    } catch (Exception exception) {
-                        logger.warn("Unable to get value from " + String.join(",", valuePath));
-                    }
-                } else {
-                    logger.warn("Column " + column.getTitle() + " has no predicate or value path!");
-                }
-            }
-        });
-        return new ExcelExportPackage(submission, "Excel", row);
+        return new ExcelExportPackage(submission, "Excel", buildRow(submission, columns, ", "));
     }
 
     @Override
     public ExcelExportPackage packageExport(Submission submission, List<SubmissionListColumn> columns, String delimiter) {
+        return new ExcelExportPackage(submission, "Excel", buildRow(submission, columns, delimiter));
+    }
+
+    private Map<String, String> buildRow(Submission submission, List<SubmissionListColumn> columns, String fieldValueDelimiter) {
         Map<String, String> row = new HashMap<String, String>();
         columns.forEach(column -> {
             Optional<String> predicate = Optional.ofNullable(column.getPredicate());
             if (predicate.isPresent()) {
-                List<String> fieldValues = new ArrayList<String>();
-                for (FieldValue fieldValue : submission.getFieldValues()) {
-                    if (fieldValue.getFieldPredicate().getValue().equals(predicate.get().trim())) {
-                        fieldValues.add(fieldValue.getValue());
-                        row.put(column.getTitle(), String.join(", ", fieldValues));
-                    } else {
-                        row.put(column.getTitle(), String.join(delimiter+" ", fieldValues));
-                    }
-                }
+                List<String> fieldValues = getFieldValues(submission, predicate.get().trim());
+                row.put(column.getTitle(), String.join(fieldValueDelimiter, fieldValues));
             } else {
                 if (column.getValuePath().size() > 0) {
                     String[] valuePath = column.getValuePath().toArray(new String[column.getValuePath().size()]);
@@ -216,7 +140,22 @@ public class ExcelPackager extends AbstractPackager<ExcelExportPackage> {
                 }
             }
         });
-        return new ExcelExportPackage(submission, "Excel", row);
+        return row;
+    }
+
+    private List<String> getFieldValues(Submission submission, String predicate) {
+        List<String> fieldValues = new ArrayList<String>();
+        for (FieldValue fieldValue : submission.getFieldValues()) {
+            if (matchesPredicate(fieldValue, predicate)) {
+                fieldValues.add(fieldValue.getValue());
+            }
+        }
+        return fieldValues;
+    }
+
+    private boolean matchesPredicate(FieldValue fieldValue, String predicate) {
+        String fieldPredicate = fieldValue.getFieldPredicate().getValue();
+        return fieldPredicate.equals(predicate) || fieldPredicate.startsWith(predicate + ".");
     }
 
 }

--- a/src/test/java/org/tdl/vireo/model/packager/ExcelPackagerTest.java
+++ b/src/test/java/org/tdl/vireo/model/packager/ExcelPackagerTest.java
@@ -1,0 +1,73 @@
+package org.tdl.vireo.model.packager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.tdl.vireo.model.FieldPredicate;
+import org.tdl.vireo.model.FieldValue;
+import org.tdl.vireo.model.Sort;
+import org.tdl.vireo.model.Submission;
+import org.tdl.vireo.model.SubmissionListColumn;
+import org.tdl.vireo.model.export.ExcelExportPackage;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class ExcelPackagerTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPackageExportUsesRequestedDelimiterForExactPredicateMatches() {
+        ExcelPackager packager = new ExcelPackager();
+        Submission submission = new Submission();
+        SubmissionListColumn column = new SubmissionListColumn("Keywords", Sort.NONE, "dc.subject");
+
+        Set<FieldValue> fieldValues = new LinkedHashSet<>();
+        fieldValues.add(createFieldValue("dc.subject", "alpha"));
+        fieldValues.add(createFieldValue("dc.subject", "beta"));
+        fieldValues.add(createFieldValue("dc.title", "ignored"));
+
+        ReflectionTestUtils.setField(submission, "fieldValues", fieldValues);
+
+        ExcelExportPackage exportPackage = packager.packageExport(submission, Arrays.asList(column), "|");
+        Map<String, String> row = (Map<String, String>) exportPackage.getPayload();
+
+        assertEquals("alpha|beta", row.get("Keywords"), "Repeatable values should be joined once with the requested delimiter.");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPackageExportMatchesSuffixedPredicates() {
+        ExcelPackager packager = new ExcelPackager();
+        Submission submission = new Submission();
+        SubmissionListColumn column = new SubmissionListColumn("Non-Chairing Committee Members", Sort.NONE, "dc.contributor.committeeMember");
+
+        Set<FieldValue> fieldValues = new LinkedHashSet<>();
+        fieldValues.add(createFieldValue("dc.contributor.committeeMember.0", "Alice Smith"));
+        fieldValues.add(createFieldValue("dc.contributor.committeeMember.1", "Bob Jones"));
+
+        ReflectionTestUtils.setField(submission, "fieldValues", fieldValues);
+
+        ExcelExportPackage exportPackage = packager.packageExport(submission, Arrays.asList(column), "|");
+        Map<String, String> row = (Map<String, String>) exportPackage.getPayload();
+
+        assertEquals("Alice Smith|Bob Jones", row.get("Non-Chairing Committee Members"), "Suffixed repeatable predicates should be included in the same exported cell.");
+    }
+
+    private FieldValue createFieldValue(String predicateValue, String value) {
+        FieldPredicate fieldPredicate = new FieldPredicate();
+        fieldPredicate.setId((long) predicateValue.hashCode());
+        fieldPredicate.setValue(predicateValue);
+
+        FieldValue fieldValue = new FieldValue();
+        fieldValue.setId((long) (predicateValue + value).hashCode());
+        fieldValue.setFieldPredicate(fieldPredicate);
+        fieldValue.setValue(value);
+
+        return fieldValue;
+    }
+
+}


### PR DESCRIPTION
This extends the use of the '|' delimiter to all repeatable field profiles.

### AI Usage Disclosure

- AI Tool(s) Used Including Version: Copilot using GPT-5.4 mini

- Nature of Use:
  - [x] Code generation
  - [x] Code suggestions/refactoring
  - [ ] Documentation
  - [x] Tests
  - [ ] Other (please describe)