### PR TITLE
fixed order in submission and admin view

### DIFF
--- a/src/main/java/org/tdl/vireo/model/CustomActionDefinition.java
+++ b/src/main/java/org/tdl/vireo/model/CustomActionDefinition.java
@@ -37,6 +37,15 @@ public class CustomActionDefinition extends ValidatingOrderedBaseEntity {
     /**
      * @return the label
      */
+    @Override
+    @JsonView(Views.SubmissionList.class)
+    public Long getPosition() {
+        return super.getPosition();
+    }
+
+    /**
+     * @return the label
+     */
     public String getLabel() {
         return label;
     }

--- a/src/main/java/org/tdl/vireo/model/CustomActionDefinition.java
+++ b/src/main/java/org/tdl/vireo/model/CustomActionDefinition.java
@@ -35,7 +35,7 @@ public class CustomActionDefinition extends ValidatingOrderedBaseEntity {
     }
 
     /**
-     * @return the label
+     * @return the position
      */
     @Override
     @JsonView(Views.SubmissionList.class)

--- a/src/main/webapp/app/views/admin/list.html
+++ b/src/main/webapp/app/views/admin/list.html
@@ -36,7 +36,7 @@
           <span ng-class="{'glyphicon glyphicon-remove-circle' : $first}" ng-click="addRowFilter($parent.$index, row)"></span>
           <span ng-if="col.title() !== 'Custom Actions'">{{displaySubmissionProperty(row, col)}}</span>
           <span ng-if="col.title() === 'Custom Actions'">
-            <span ng-repeat="ca in row.customActionValues">
+            <span ng-repeat="ca in row.customActionValues | orderBy:'definition.position'">
               <input ng-checked="{{ca.value}}" type="checkbox" disabled> {{getCustomActionLabelById(ca.definition.id)}}</input>
               <br/>
             </span>

--- a/src/test/java/org/tdl/vireo/model/CustomActionDefinitionTest.java
+++ b/src/test/java/org/tdl/vireo/model/CustomActionDefinitionTest.java
@@ -1,8 +1,19 @@
 package org.tdl.vireo.model;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 import org.mockito.InjectMocks;
+import org.tdl.vireo.model.response.Views;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public class CustomActionDefinitionTest extends AbstractModelCustomMethodTest<CustomActionDefinition> {
 
@@ -41,6 +52,64 @@ public class CustomActionDefinitionTest extends AbstractModelCustomMethodTest<Cu
             Arguments.of("isStudentVisible", "isStudentVisible", true),
             Arguments.of("isStudentVisible", "isStudentVisible", false)
         );
+    }
+
+    /**
+     * Regression test for GitHub issue #2104.
+     *
+     * Verifies that {@code CustomActionDefinition.position} is included in the
+     * JSON output when serialized under {@link Views.SubmissionList} (and its
+     * sub-views such as {@link Views.SubmissionIndividualActionLogs}).
+     *
+     * The application sets {@code jackson.mapper.default-view-inclusion: false},
+     * so any field without a matching {@code @JsonView} annotation is silently
+     * excluded when a view is active. The fix overrides {@code getPosition()} in
+     * {@code CustomActionDefinition} with {@code @JsonView(Views.SubmissionList.class)}.
+     * Removing that annotation will cause this test to fail.
+     */
+    @Test
+    public void testPositionSerializedInSubmissionListView() throws Exception {
+        // Configure ObjectMapper to match application.yml: default-view-inclusion: false
+        ObjectMapper mapper = JsonMapper.builder()
+            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .build();
+
+        CustomActionDefinition definition = new CustomActionDefinition("Test action", true);
+        definition.setPosition(3L);
+
+        // Serialize under Views.SubmissionList — the view used by /submission/query
+        String json = mapper.writerWithView(Views.SubmissionList.class).writeValueAsString(definition);
+        ObjectNode node = (ObjectNode) mapper.readTree(json);
+
+        assertNotNull(node.get("position"),
+            "position must be present in SubmissionList view JSON; " +
+            "ensure getPosition() in CustomActionDefinition is annotated with @JsonView(Views.SubmissionList.class)");
+        assertTrue(node.get("position").isNumber(),
+            "position must be a numeric value in SubmissionList view JSON");
+    }
+
+    /**
+     * Verifies that {@code position} is also included when serialized under the
+     * {@link Views.SubmissionIndividualActionLogs} view used by the admin
+     * {@code GET /submission/get-one/{id}} endpoint, since that view extends
+     * {@link Views.SubmissionList}.
+     */
+    @Test
+    public void testPositionSerializedInSubmissionIndividualActionLogsView() throws Exception {
+        ObjectMapper mapper = JsonMapper.builder()
+            .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+            .build();
+
+        CustomActionDefinition definition = new CustomActionDefinition("Test action", true);
+        definition.setPosition(5L);
+
+        String json = mapper.writerWithView(Views.SubmissionIndividualActionLogs.class).writeValueAsString(definition);
+        ObjectNode node = (ObjectNode) mapper.readTree(json);
+
+        assertNotNull(node.get("position"),
+            "position must be present in SubmissionIndividualActionLogs view JSON");
+        assertTrue(node.get("position").isNumber(),
+            "position must be a numeric value in SubmissionIndividualActionLogs view JSON");
     }
 
 }


### PR DESCRIPTION
## Description
Prevents reordering of custom actions in submission and admin views when actions are selecte/deselected
Resolves #2104 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## AI Usage Disclosure

**AI Tool(s) Used Including Version:**
GPT-5.3-Codex

**Nature of Use:**
  - [x] Code generation
  - [x] Code suggestions/refactoring
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other (please describe)

**Additional Description:**
<!-- Briefly describe how AI was used -->

- [ ] No AI Used
