### PR TITLE
Main 2106

### DIFF
--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -94,7 +94,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
         } else {
             boolean isUserUpdated = false;
 
-            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || user.getNetid().trim().length() < 1 || !user.getNetid().equals(shibNetid))) {
+            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || (user.getNetid().trim().length() < 1) || !user.getNetid().equals(shibNetid))) {
                 user.setNetid(shibNetid);
                 isUserUpdated = true;
             }

--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -94,7 +94,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
         } else {
             boolean isUserUpdated = false;
 
-            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || user.getNetid() == '' || !user.getNetid().equals(shibNetid))) {
+            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || user.getNetid().trim().length() < 1 || !user.getNetid().equals(shibNetid))) {
                 user.setNetid(shibNetid);
                 isUserUpdated = true;
             }

--- a/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
+++ b/src/main/java/org/tdl/vireo/auth/service/VireoUserCredentialsService.java
@@ -94,7 +94,7 @@ public class VireoUserCredentialsService extends UserCredentialsService<User, Us
         } else {
             boolean isUserUpdated = false;
 
-            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || !user.getNetid().equals(shibNetid))) {
+            if (StringUtils.isNotEmpty(shibNetid) && (user.getNetid() == null || user.getNetid() == '' || !user.getNetid().equals(shibNetid))) {
                 user.setNetid(shibNetid);
                 isUserUpdated = true;
             }


### PR DESCRIPTION
This solves issue #2106 not by restricting no netid signin but by allowing updates to netid on subsequent signins when the original database netid was a blank space or spaces instead of just null.  This is a better remedy than prohibiting something that might cause problems for some non TDL hosted sites.  Netid can also normally be null when password signin is used.