### PR TITLE
prevents error for when no controlledVocabulary defined

### DIFF
--- a/src/main/webapp/app/directives/fieldProfileDirective.js
+++ b/src/main/webapp/app/directives/fieldProfileDirective.js
@@ -412,7 +412,7 @@ vireo.directive("field", function ($controller, $filter, $q, $timeout, Controlle
             };
 
             $scope.controlledVocabularyTypeAhead = function (field, search) {
-                if (!field.fieldPredicate.id || !$scope.profile.controlledVocabulary.id) {
+                if (!field.fieldPredicate.id || !angular.isDefined($scope.profile.controlledVocabulary)) {
                     return [];
                 }
 


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes and link relevant issues -->
This fixes issue #2146 by preventing an error when no controlled vocabulary is denoted for INPUT_CONTACT

## Type of Change
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change

## AI Usage Disclosure

**AI Tool(s) Used Including Version:**
<!-- (e.g., ChatGPT 5.3, Claude Opus 4.6, etc.) -->

**Nature of Use:**
  - [ ] Code generation
  - [ ] Code suggestions/refactoring
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other (please describe)

**Additional Description:**
<!-- Briefly describe how AI was used -->

- [ x] No AI Used
