### PR TITLE
match workflow steps and take out getOverrideable()

### DIFF
--- a/src/main/java/org/tdl/vireo/model/inheritance/HeritableRepoImpl.java
+++ b/src/main/java/org/tdl/vireo/model/inheritance/HeritableRepoImpl.java
@@ -38,7 +38,7 @@ public abstract class HeritableRepoImpl<M extends HeritableComponent, R extends 
         // if requesting organization originates the workflow step or the workflow step is overrideable,
         if (pendingWorkflowStep.getOriginatingOrganization().getId().equals(requestingOrganization.getId()) || pendingWorkflowStep.getOverrideable()) {
             // ... and if also that workflow step originates the heritableModel or the heritableModel is overrideable,
-            if (heritableModelToRemove.getOriginatingWorkflowStep().getId().equals(heritableModelToRemove.getId()) || heritableModelToRemove.getOverrideable()) {
+            if(heritableModelToRemove.getOriginatingWorkflowStep() != null && heritableModelToRemove.getOriginatingWorkflowStep().getId().equals(pendingWorkflowStep.getId())){
                 // ...then the update is permissible.
 
                 // if requesting organization is not the workflow step's orignating organization,


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes and link relevant issues -->

fixed issue #2092 by changing code to compare like id values.  The test of getOverrideable() did not seem relevant but please correct me if you know of a reason for it.
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## AI Usage Disclosure

**AI Tool(s) Used Including Version:**
<!-- (e.g., ChatGPT 5.3, Claude Opus 4.6, etc.) -->
ChatGPT
**Nature of Use:**
  - [ ] Code generation
  - [ x ] Code suggestions/refactoring
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other (please describe)

**Additional Description:**
<!-- Briefly describe how AI was used -->

- [ ] No AI Used
