### PR TITLE
revert log4j but keep tika version 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,12 +163,12 @@
       <artifactId>commons-httpclient</artifactId>
       <version>3.1</version>
     </dependency>
-    <!-- upgrade to -->
-    <!-- <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5</artifactId>
-      <version>5.2.1</version>
-    </dependency> -->
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -209,11 +209,15 @@
     <dependency>
       <groupId>org.apache.tika</groupId>
       <artifactId>tika-core</artifactId>
-      <version>1.28.5</version>
+      <version>3.2.2</version>
       <exclusions>
         <exclusion>
           <groupId>xom</groupId>
           <artifactId>xom</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents.client5</groupId>
+          <artifactId>httpclient5</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
## Description
<!-- Briefly describe the changes and link relevant issues -->
Reverts log4j upgrade and creates workaround for error caused by Tika 3 as described in #2167 
Relates to #2168 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Breaking change

## AI Usage Disclosure

**AI Tool(s) Used Including Version:**
<!-- (e.g., ChatGPT 5.3, Claude Opus 4.6, etc.) -->

**Nature of Use:**
  - [X] Code generation
  - [X] Code suggestions/refactoring
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other (please describe)

**Additional Description:**
<!-- Briefly describe how AI was used -->

- [ ] No AI Used
